### PR TITLE
feat(fc2): desugar classes, newtypes, and families

### DIFF
--- a/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
+++ b/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
@@ -27,6 +27,7 @@ import Aihc.Tc
     TyConFlavor (..),
     TyConInfo (..),
     TyVarId (..),
+    TypeFamilyInstanceInfo (..),
     TypeScheme (..),
     Unique (..),
     VecCount (..),
@@ -92,24 +93,30 @@ getArtifact = do
 
 putInterface :: TcInterface -> Builder.Builder
 putInterface interface =
-  cborArray 6
+  cborArray 7
     <> encodeList putTerm (tcInterfaceTerms interface)
     <> encodeList putTyConInfo (tcInterfaceTyCons interface)
     <> encodeList putDataTypeInfo (tcInterfaceDataTypes interface)
     <> encodeList putClassInfo (tcInterfaceClasses interface)
     <> encodeList putInstanceInfo (tcInterfaceInstances interface)
     <> encodeList putDataFamilyInstanceInfo (tcInterfaceDataFamilyInstances interface)
+    <> encodeList putTypeFamilyInstanceInfo (tcInterfaceTypeFamilyInstances interface)
 
 getInterface :: Get.Get TcInterface
 getInterface = do
-  expectArray 6
+  length' <- getArrayLength
   tcInterfaceTerms <- getList getTerm
   tcInterfaceTyCons <- getList getTyConInfo
   tcInterfaceDataTypes <- getList getDataTypeInfo
   tcInterfaceClasses <- getList getClassInfo
   tcInterfaceInstances <- getList getInstanceInfo
   tcInterfaceDataFamilyInstances <- getList getDataFamilyInstanceInfo
-  pure TcInterface {tcInterfaceTerms, tcInterfaceTyCons, tcInterfaceDataTypes, tcInterfaceClasses, tcInterfaceInstances, tcInterfaceDataFamilyInstances}
+  tcInterfaceTypeFamilyInstances <-
+    case length' of
+      6 -> pure []
+      7 -> getList getTypeFamilyInstanceInfo
+      _ -> fail ("unsupported type interface array length: " <> show length')
+  pure TcInterface {tcInterfaceTerms, tcInterfaceTyCons, tcInterfaceDataTypes, tcInterfaceClasses, tcInterfaceInstances, tcInterfaceDataFamilyInstances, tcInterfaceTypeFamilyInstances}
 
 putTerm :: (TcTermKey, TypeScheme) -> Builder.Builder
 putTerm (key, scheme) = cborArray 2 <> putTermKey key <> putTypeScheme scheme
@@ -430,6 +437,27 @@ getDataFamilyInstanceInfo = do
   dfiiIsNewtype <- getBool
   pure DataFamilyInstanceInfo {dfiiFamilyName, dfiiFamilyType, dfiiTyVars, dfiiRepresentationTyCon, dfiiAxiomName, dfiiConstructorNames, dfiiIsNewtype}
 
+putTypeFamilyInstanceInfo :: TypeFamilyInstanceInfo -> Builder.Builder
+putTypeFamilyInstanceInfo info =
+  cborArray 6
+    <> cborText (tfiiFamilyName info)
+    <> cborText (tfiiAxiomName info)
+    <> encodeList putTyVar (tfiiTyVars info)
+    <> putType (tfiiLeft info)
+    <> putType (tfiiRight info)
+    <> putBool (tfiiClosed info)
+
+getTypeFamilyInstanceInfo :: Get.Get TypeFamilyInstanceInfo
+getTypeFamilyInstanceInfo = do
+  expectArray 6
+  tfiiFamilyName <- getText
+  tfiiAxiomName <- getText
+  tfiiTyVars <- getList getTyVar
+  tfiiLeft <- getType
+  tfiiRight <- getType
+  tfiiClosed <- getBool
+  pure TypeFamilyInstanceInfo {tfiiFamilyName, tfiiAxiomName, tfiiTyVars, tfiiLeft, tfiiRight, tfiiClosed}
+
 putOrigin :: (PackageId, Text) -> Builder.Builder
 putOrigin (packageId, moduleName) = cborArray 2 <> putPackageId packageId <> cborText moduleName
 
@@ -486,9 +514,10 @@ putTyConFlavor flavor = cborWord $ case flavor of
   DataFamilyTyCon -> 2
   NewtypeTyCon -> 3
   SynonymTyCon -> 4
+  TypeFamilyTyCon -> 5
 
 getTyConFlavor :: Get.Get TyConFlavor
-getTyConFlavor = getTagged "type constructor flavor" [(0, ClassTyCon), (1, DataTyCon), (2, DataFamilyTyCon), (3, NewtypeTyCon), (4, SynonymTyCon)]
+getTyConFlavor = getTagged "type constructor flavor" [(0, ClassTyCon), (1, DataTyCon), (2, DataFamilyTyCon), (3, NewtypeTyCon), (4, SynonymTyCon), (5, TypeFamilyTyCon)]
 
 putDataConSourceForm :: DataConSourceForm -> Builder.Builder
 putDataConSourceForm sourceForm = cborWord $ case sourceForm of

--- a/components/aihc-fc/src/Aihc/Fc2/Convert.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Convert.hs
@@ -6,12 +6,17 @@ module Aihc.Fc2.Convert
     emptyConvertEnv,
     withTyVar,
     withTyVars,
+    withClassTyCons,
+    withAxioms,
     convertKind,
     convertRep,
     convertType,
     convertPred,
     tyVarBinder,
     tyConNameFc2,
+    classDictTypeName,
+    classDictConName,
+    lookupAxiomName,
     funType,
     liftedRepType,
   )
@@ -33,26 +38,53 @@ import Aihc.Tc.Types
     liftedRuntimeRep,
     runtimeRepOfType,
     tvKind,
+    tyConKey,
     tyConModuleName,
     tyConName,
     tyConPackageId,
   )
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Set (Set)
+import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
 
 data ConvertEnv = ConvertEnv
   { cePrimPackage :: PackageId,
-    ceTyVars :: Map Unique TyVarId
+    ceTyVars :: Map Unique TyVarId,
+    ceClassTyCons :: Set (PackageId, Text, Text),
+    ceAxioms :: Map Text Name
   }
 
 emptyConvertEnv :: PackageId -> ConvertEnv
 emptyConvertEnv package =
   ConvertEnv
     { cePrimPackage = package,
-      ceTyVars = Map.empty
+      ceTyVars = Map.empty,
+      ceClassTyCons = Set.empty,
+      ceAxioms = Map.empty
     }
+
+withClassTyCons :: [(PackageId, Text, Text)] -> ConvertEnv -> ConvertEnv
+withClassTyCons keys env =
+  env {ceClassTyCons = Set.fromList keys <> ceClassTyCons env}
+
+withAxioms :: [(Text, Name)] -> ConvertEnv -> ConvertEnv
+withAxioms axioms env =
+  env {ceAxioms = Map.fromList axioms <> ceAxioms env}
+
+classDictTypeName :: TyCon -> Name
+classDictTypeName tyCon =
+  Name ("$Dict$" <> tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+
+classDictConName :: TyCon -> Name
+classDictConName tyCon =
+  Name ("$Dict$" <> tyConName tyCon) SortDataConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+
+lookupAxiomName :: ConvertEnv -> Text -> Name
+lookupAxiomName env name =
+  Map.findWithDefault (Name name SortAxiom (OriginLocal (Unique 0))) name (ceAxioms env)
 
 withTyVar :: TyVarId -> ConvertEnv -> ConvertEnv
 withTyVar tyVar env =
@@ -136,7 +168,7 @@ convertType env ty =
     TcMetaTv {} -> Left "type still has a meta variable"
     TcTyCon tyCon arguments -> do
       converted <- mapM (convertType env) arguments
-      pure (foldl TyApp (TyCon (tyConNameFc2 tyCon)) converted)
+      pure (foldl TyApp (TyCon (tyConNameFc2 env tyCon)) converted)
     TcFunTy argument result -> do
       convertedArgument <- convertType env argument
       convertedResult <- convertType env result
@@ -168,8 +200,7 @@ convertPred env predicate =
   case predicate of
     ClassPred tyCon arguments -> do
       converted <- mapM (convertType env) arguments
-      let className = Name ("$Dict$" <> tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
-      pure (foldl TyApp (TyCon className) converted)
+      pure (foldl TyApp (TyCon (classDictTypeName tyCon)) converted)
     EqPred left right ->
       TyEq <$> convertType env left <*> convertType env right
 
@@ -197,9 +228,11 @@ tyVarName tyVar =
 tyVarType :: TyVarId -> Type
 tyVarType tyVar = TyVar (tyVarName tyVar)
 
-tyConNameFc2 :: TyCon -> Name
-tyConNameFc2 tyCon =
-  Name (tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+tyConNameFc2 :: ConvertEnv -> TyCon -> Name
+tyConNameFc2 env tyCon =
+  if Set.member (tyConKey tyCon) (ceClassTyCons env)
+    then classDictTypeName tyCon
+    else Name (tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
 
 builtinType :: ConvertEnv -> Text -> Either String Type
 builtinType env name =

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
--- | Convert a checked module into System FC 2 data types and synonyms.
+-- | Convert a checked module into System FC 2 types, axioms, and values.
 module Aihc.Fc2.Desugar
   ( desugarModuleFc2,
     Fc2DesugarResult (..),
@@ -16,37 +16,51 @@ import Aihc.Fc2.Syntax
 import Aihc.Parser.Syntax
   ( DataDecl (..),
     Module (..),
+    TypeFamilyDecl (..),
     TypeSynDecl (..),
     UnqualifiedName,
     binderHeadName,
+    binderHeadParams,
     fromAnnotation,
     nameQualifier,
     peelDeclAnn,
+    tyVarBinderName,
     unqualifiedNameAnns,
     unqualifiedNameText,
   )
 import Aihc.Parser.Syntax qualified as Syn
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
 import Aihc.Tc
-  ( DataConFieldInfo (..),
+  ( ClassInfo (..),
+    DataConFieldInfo (..),
     DataConInfo (..),
+    DataFamilyInstanceInfo (..),
     DataTypeInfo (..),
     TcBindingResult (..),
     TcInterface (..),
     TyConFlavor (..),
     TyConInfo (..),
+    TypeFamilyInstanceInfo (..),
     tcModuleDiagnostics,
     tcModuleSuccess,
   )
 import Aihc.Tc.Env (TypeSynonymInfo (..))
 import Aihc.Tc.Types
   ( Kind (..),
+    Pred (..),
+    TcType (..),
     TyCon,
     TyVarId,
+    TypeScheme (..),
+    Unique (..),
+    tyConKey,
     tyConKind,
     tyConModuleName,
+    tyConName,
     tyConPackageId,
+    typeKind,
   )
+import Control.Monad (zipWithM)
 import Data.List (nub, sort)
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Text (Text)
@@ -86,14 +100,48 @@ desugarChecked :: DesugarConfig -> [TcBindingResult] -> TcInterface -> Module ->
 desugarChecked config bindings interface checked = do
   let (packageId, currentModule) = resolvedModuleOrigin checked
       moduleId = ModuleId packageId currentModule
-      env = emptyConvertEnv (primPackageId config)
       dataTypes = tcInterfaceDataTypes interface
       tyCons = tcInterfaceTyCons interface
-  typeDecls <- concat <$> mapM (dsDecl env packageId currentModule dataTypes tyCons) (Syn.moduleDecls checked)
+      classes = tcInterfaceClasses interface
+      dataFamilyInstances = tcInterfaceDataFamilyInstances interface
+      typeFamilyInstances = tcInterfaceTypeFamilyInstances interface
+      env =
+        withAxioms
+          (axiomEntries packageId currentModule dataTypes dataFamilyInstances typeFamilyInstances)
+          (withClassTyCons (map (tyConKey . ciTyCon) classes) (emptyConvertEnv (primPackageId config)))
+  typeDecls <-
+    concat
+      <$> mapM
+        (dsDecl env packageId currentModule dataTypes tyCons classes dataFamilyInstances typeFamilyInstances bindings)
+        (Syn.moduleDecls checked)
   valueDecls <- convertFcValues config bindings interface checked env
   let decls = typeDecls <> valueDecls
       scopes = buildScopes moduleId decls
   pure (Program moduleId scopes decls)
+
+axiomEntries :: PackageId -> Text -> [DataTypeInfo] -> [DataFamilyInstanceInfo] -> [TypeFamilyInstanceInfo] -> [(Text, Name)]
+axiomEntries package moduleName' dataTypes dataFamilyInstances typeFamilyInstances =
+  concatMap newtypeAxiom dataTypes
+    <> concatMap (dataFamilyAxiom package moduleName') dataFamilyInstances
+    <> map (typeFamilyAxiom package moduleName') typeFamilyInstances
+  where
+    newtypeAxiom info
+      | dtiFlavor info == NewtypeTyCon =
+          let tyCon = dtiTyCon info
+              axiomName = Name ("$ax$" <> dtiName info) SortAxiom (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+           in [(dtiName info, axiomName), ("$ax$" <> dtiName info, axiomName)]
+      | otherwise = []
+    dataFamilyAxiom currentPackage currentModule info =
+      let axiomName = Name (dfiiAxiomName info) SortAxiom (OriginTop currentPackage currentModule)
+          representationName = tyConName (dfiiRepresentationTyCon info)
+          representationAxiom =
+            Name ("$ax$" <> T.drop 1 representationName) SortAxiom (OriginTop currentPackage currentModule)
+       in [ (dfiiAxiomName info, axiomName),
+            (representationName, representationAxiom),
+            ("$ax$" <> T.drop 1 representationName, representationAxiom)
+          ]
+    typeFamilyAxiom currentPackage currentModule info =
+      (tfiiAxiomName info, Name (tfiiAxiomName info) SortAxiom (OriginTop currentPackage currentModule))
 
 convertFcValues :: DesugarConfig -> [TcBindingResult] -> TcInterface -> Module -> ConvertEnv -> Either String [Decl]
 convertFcValues config bindings interface checked env =
@@ -105,17 +153,54 @@ convertFcValues config bindings interface checked env =
             else Left (unlines (dsErrors fcResult))
         else convertValueDecls env (fcProgramModule (dsProgram fcResult)) (fcTopBinds (dsProgram fcResult))
 
-dsDecl :: ConvertEnv -> PackageId -> Text -> [DataTypeInfo] -> [TyConInfo] -> Syn.Decl -> Either String [Decl]
-dsDecl env package moduleName' dataTypes tyCons decl =
-  case peelDeclAnn decl of
-    Syn.DeclData dataDecl -> do
-      info <- lookupDataType DataTyCon package moduleName' (unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))) dataTypes
-      (: []) <$> convertDataType env info
-    Syn.DeclTypeSyn synonymDecl -> do
-      info <- lookupSynonym package moduleName' (unqualifiedNameText (binderHeadName (typeSynHead synonymDecl))) tyCons
-      (: []) <$> convertSynonym env info
-    Syn.DeclAnn _ inner -> dsDecl env package moduleName' dataTypes tyCons inner
-    _ -> Right []
+dsDecl ::
+  ConvertEnv ->
+  PackageId ->
+  Text ->
+  [DataTypeInfo] ->
+  [TyConInfo] ->
+  [ClassInfo] ->
+  [DataFamilyInstanceInfo] ->
+  [TypeFamilyInstanceInfo] ->
+  [TcBindingResult] ->
+  Syn.Decl ->
+  Either String [Decl]
+dsDecl env package moduleName' dataTypes tyCons classes dataFamilyInstances typeFamilyInstances bindings decl =
+  case decl of
+    Syn.DeclAnn ann inner
+      | Just familyInfo <- fromAnnotation ann ->
+          convertDataFamilyInst env package moduleName' bindings familyInfo
+      | Just familyEquation <- fromAnnotation ann ->
+          (: []) <$> convertTypeFamilyEquation env package moduleName' familyEquation
+      | otherwise ->
+          dsDecl env package moduleName' dataTypes tyCons classes dataFamilyInstances typeFamilyInstances bindings inner
+    _ ->
+      case peelDeclAnn decl of
+        Syn.DeclData dataDecl -> do
+          info <- lookupDataType DataTyCon package moduleName' (unqualifiedNameText (binderHeadName (dataDeclHead dataDecl))) dataTypes
+          (: []) <$> convertDataType env info
+        Syn.DeclTypeSyn synonymDecl -> do
+          info <- lookupSynonym package moduleName' (unqualifiedNameText (binderHeadName (typeSynHead synonymDecl))) tyCons
+          (: []) <$> convertSynonym env info
+        Syn.DeclClass classDecl -> do
+          info <- lookupClassInfo package moduleName' (unqualifiedNameText (binderHeadName (Syn.classDeclHead classDecl))) classes
+          (: []) <$> convertClass env info
+        Syn.DeclNewtype newtypeDecl ->
+          convertNewtype env
+            =<< lookupDataType NewtypeTyCon package moduleName' (unqualifiedNameText (binderHeadName (Syn.newtypeDeclHead newtypeDecl))) dataTypes
+        Syn.DeclDataFamilyDecl familyDecl -> do
+          info <- lookupTyConFlavor DataFamilyTyCon package moduleName' (unqualifiedNameText (binderHeadName (Syn.dataFamilyDeclHead familyDecl))) tyCons
+          (: []) <$> convertEmptyFamily env (map tyVarBinderName (binderHeadParams (Syn.dataFamilyDeclHead familyDecl))) Nominal info
+        Syn.DeclTypeFamilyDecl familyDecl -> do
+          let familyName = typeFamilyDeclName familyDecl
+          info <- lookupTyConFlavor TypeFamilyTyCon package moduleName' familyName tyCons
+          typeDecl <- convertEmptyFamily env (map tyVarBinderName (typeFamilyDeclParams familyDecl)) Nominal info
+          axioms <-
+            mapM
+              (convertTypeFamilyEquation env package moduleName')
+              [equation | equation <- typeFamilyInstances, tfiiFamilyName equation == familyName, tfiiClosed equation]
+          pure (typeDecl : axioms)
+        _ -> Right []
 
 lookupDataType :: TyConFlavor -> PackageId -> Text -> Text -> [DataTypeInfo] -> Either String DataTypeInfo
 lookupDataType flavor package moduleName' name dataTypes =
@@ -132,6 +217,289 @@ lookupDataType flavor package moduleName' name dataTypes =
         tyConPackageId (dtiTyCon info) == package,
         tyConModuleName (dtiTyCon info) == moduleName'
       ]
+
+lookupClassInfo :: PackageId -> Text -> Text -> [ClassInfo] -> Either String ClassInfo
+lookupClassInfo package moduleName' name classes =
+  case matches of
+    [info] -> Right info
+    [] -> Left ("missing checked class " <> T.unpack moduleName' <> "." <> T.unpack name)
+    _ -> Left ("duplicate checked class " <> T.unpack moduleName' <> "." <> T.unpack name)
+  where
+    matches =
+      [ info
+      | info <- classes,
+        ciName info == name,
+        tyConPackageId (ciTyCon info) == package,
+        tyConModuleName (ciTyCon info) == moduleName'
+      ]
+
+lookupTyConFlavor :: TyConFlavor -> PackageId -> Text -> Text -> [TyConInfo] -> Either String TyConInfo
+lookupTyConFlavor flavor package moduleName' name tyCons =
+  case matches of
+    [info] -> Right info
+    [] -> Left ("missing checked type constructor " <> T.unpack moduleName' <> "." <> T.unpack name)
+    _ -> Left ("duplicate checked type constructor " <> T.unpack moduleName' <> "." <> T.unpack name)
+  where
+    matches =
+      [ info
+      | info <- tyCons,
+        tciName info == name,
+        tciFlavor info == flavor,
+        tyConPackageId (tciTyCon info) == package,
+        tyConModuleName (tciTyCon info) == moduleName'
+      ]
+
+typeFamilyDeclName :: TypeFamilyDecl -> Text
+typeFamilyDeclName familyDecl =
+  fromMaybe "<type-family>" (familyHeadName (typeFamilyDeclHead familyDecl))
+
+familyHeadName :: Syn.Type -> Maybe Text
+familyHeadName ty =
+  case Syn.peelTypeHead ty of
+    Syn.TCon name _ -> Just (Syn.nameText name)
+    Syn.TInfix _ name _ _ -> Just (Syn.nameText name)
+    Syn.TApp function _ -> familyHeadName function
+    Syn.TTypeApp function _ -> familyHeadName function
+    _ -> Nothing
+
+convertClass :: ConvertEnv -> ClassInfo -> Either String Decl
+convertClass env info = do
+  let tyVars = ciTyVars info
+      bindersEnv = withTyVars tyVars env
+      dictName = classDictTypeName (ciTyCon info)
+  binders <- mapM (tyVarBinder bindersEnv) tyVars
+  result <- convertKind bindersEnv KType
+  superFields <- mapM (convertType bindersEnv) (ciSuperClassTypes info)
+  methodFields <- mapM (convertMethodField bindersEnv (ciName info) tyVars) (ciMethods info)
+  let dictApp = foldl TyApp (TyCon dictName) (map (TyVar . binderName) binders)
+      body = foldr (funType bindersEnv) dictApp (superFields <> methodFields)
+      constructorType = foldr TyForAll body binders
+  pure
+    ( DeclType
+        TypeDecl
+          { typeVis = Pub,
+            typeName = dictName,
+            typeBinders = binders,
+            typeResult = result,
+            typeRoles = replicate (length binders) Representational,
+            typeCons = [ConDecl Pub (classDictConName (ciTyCon info)) constructorType]
+          }
+    )
+
+convertMethodField :: ConvertEnv -> Text -> [TyVarId] -> (Text, TypeScheme) -> Either String Type
+convertMethodField env className classTyVars (_methodName, scheme) = do
+  fieldType <- classMethodFieldType className classTyVars scheme
+  convertType env fieldType
+
+classMethodFieldType :: Text -> [TyVarId] -> TypeScheme -> Either String TcType
+classMethodFieldType className classTyVars (ForAll methodTyVars predicates body) = do
+  remaining <- removeClassPredicate className predicates
+  let extraTyVars = filter (`notElem` classTyVars) methodTyVars
+      qualifiedBody =
+        if null remaining
+          then body
+          else TcQualTy remaining body
+  Right (foldr TcForAllTy qualifiedBody extraTyVars)
+
+removeClassPredicate :: Text -> [Pred] -> Either String [Pred]
+removeClassPredicate className predicates =
+  case predicates of
+    [] -> Left ("class method lacks its class predicate for " <> T.unpack className)
+    ClassPred tyCon _ : rest
+      | tyConName tyCon == className -> Right rest
+    predicate : rest -> (predicate :) <$> removeClassPredicate className rest
+
+convertNewtype :: ConvertEnv -> DataTypeInfo -> Either String [Decl]
+convertNewtype env info = do
+  let tyCon = dtiTyCon info
+      bindersEnv = withTyVars (dtiTyVars info) env
+  binders <- mapM (tyVarBinder bindersEnv) (dtiTyVars info)
+  result <- convertKind bindersEnv (dtiResultKind info)
+  representation <-
+    case dtiConstructors info of
+      [constructor]
+        | [field] <- dciFields constructor ->
+            convertType bindersEnv (dcfiType field)
+      _ -> Left ("newtype " <> T.unpack (dtiName info) <> " does not have exactly one checked field")
+  let typeName = tyConNameFc2 env tyCon
+      lhs = foldl TyApp (TyCon typeName) (map (TyVar . binderName) binders)
+      axiomName = Name ("$ax$" <> dtiName info) SortAxiom (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+  pure
+    [ DeclType
+        TypeDecl
+          { typeVis = Pub,
+            typeName = typeName,
+            typeBinders = binders,
+            typeResult = result,
+            typeRoles = replicate (length binders) Representational,
+            typeCons = []
+          },
+      DeclAxiom
+        AxiomDecl
+          { axiomVis = Private,
+            axiomName = axiomName,
+            axiomBinders = binders,
+            axiomRole = Representational,
+            axiomLeft = lhs,
+            axiomRight = representation
+          }
+    ]
+
+convertEmptyFamily :: ConvertEnv -> [Text] -> Role -> TyConInfo -> Either String Decl
+convertEmptyFamily env paramNames roles info = do
+  let tyCon = tciTyCon info
+      argKinds = take (tciArity info) (visibleArgKinds (tyConKind tyCon))
+      names =
+        if length paramNames == length argKinds
+          then paramNames
+          else ["a" <> T.pack (show index) | index <- [1 .. length argKinds]]
+  binders <- zipWithM (kindBinder env) names argKinds
+  result <- convertKind env (dropKindParams (length binders) (tyConKind tyCon))
+  pure
+    ( DeclType
+        TypeDecl
+          { typeVis = Pub,
+            typeName = tyConNameFc2 env tyCon,
+            typeBinders = binders,
+            typeResult = result,
+            typeRoles = replicate (length binders) roles,
+            typeCons = []
+          }
+    )
+
+kindBinder :: ConvertEnv -> Text -> Kind -> Either String Binder
+kindBinder env name kind = do
+  converted <- convertKind env kind
+  pure (Binder (Name name SortTypeVariable (OriginLocal (Unique 0))) converted)
+
+visibleArgKinds :: Kind -> [Kind]
+visibleArgKinds kind =
+  case kind of
+    KFun argument result -> argument : visibleArgKinds result
+    _ -> []
+
+dropKindParams :: Int -> Kind -> Kind
+dropKindParams remaining kind
+  | remaining <= 0 = kind
+dropKindParams remaining (KFun _ result) = dropKindParams (remaining - 1) result
+dropKindParams _ kind = kind
+
+convertDataFamilyInst :: ConvertEnv -> PackageId -> Text -> [TcBindingResult] -> DataFamilyInstanceInfo -> Either String [Decl]
+convertDataFamilyInst env package moduleName' bindings info = do
+  let tyVars = dfiiTyVars info
+      bindersEnv = withTyVars tyVars env
+      representationTyCon = dfiiRepresentationTyCon info
+      representationName = tyConNameFc2 env representationTyCon
+  binders <- mapM (tyVarBinder bindersEnv) tyVars
+  result <- convertKind bindersEnv (typeKind (TcTyCon representationTyCon (map TcTyVar tyVars)))
+  familyType <- convertType bindersEnv (dfiiFamilyType info)
+  let representationType = foldl TyApp (TyCon representationName) (map (TyVar . binderName) binders)
+      familyAxiom =
+        DeclAxiom
+          AxiomDecl
+            { axiomVis = Private,
+              axiomName = Name (dfiiAxiomName info) SortAxiom (OriginTop package moduleName'),
+              axiomBinders = binders,
+              axiomRole = Nominal,
+              axiomLeft = familyType,
+              axiomRight = representationType
+            }
+  if dfiiIsNewtype info
+    then do
+      fieldType <-
+        case dfiiConstructorNames info of
+          constructorName : _ -> do
+            constructorType <- lookupBindingType bindings constructorName
+            converted <- convertType bindersEnv constructorType
+            constructorFieldType converted
+          [] -> Left "newtype family instance has no constructor"
+      let representationAxiomName =
+            Name ("$ax$" <> T.drop 1 (tyConName representationTyCon)) SortAxiom (OriginTop package moduleName')
+      pure
+        [ DeclType
+            TypeDecl
+              { typeVis = Private,
+                typeName = representationName,
+                typeBinders = binders,
+                typeResult = result,
+                typeRoles = replicate (length binders) Representational,
+                typeCons = []
+              },
+          DeclAxiom
+            AxiomDecl
+              { axiomVis = Private,
+                axiomName = representationAxiomName,
+                axiomBinders = binders,
+                axiomRole = Representational,
+                axiomLeft = representationType,
+                axiomRight = fieldType
+              },
+          familyAxiom
+        ]
+    else do
+      constructors <- mapM (convertFamilyConstructor bindersEnv bindings package moduleName' representationType) (dfiiConstructorNames info)
+      pure
+        [ DeclType
+            TypeDecl
+              { typeVis = Private,
+                typeName = representationName,
+                typeBinders = binders,
+                typeResult = result,
+                typeRoles = replicate (length binders) Representational,
+                typeCons = constructors
+              },
+          familyAxiom
+        ]
+
+convertFamilyConstructor :: ConvertEnv -> [TcBindingResult] -> PackageId -> Text -> Type -> Text -> Either String ConDecl
+convertFamilyConstructor bindersEnv bindings package moduleName' representationType constructorName = do
+  constructorType <- lookupBindingType bindings constructorName
+  converted <- convertType bindersEnv constructorType
+  replaced <- replaceResultType converted representationType
+  pure
+    ConDecl
+      { conVis = Private,
+        conName = Name constructorName SortDataConstructor (OriginTop package moduleName'),
+        conType = replaced
+      }
+
+lookupBindingType :: [TcBindingResult] -> Text -> Either String TcType
+lookupBindingType bindings name =
+  case [tbType binding | binding <- bindings, tbName binding == name] of
+    ty : _ -> Right ty
+    [] -> Left ("missing checked constructor type " <> T.unpack name)
+
+replaceResultType :: Type -> Type -> Either String Type
+replaceResultType ty result =
+  case ty of
+    TyForAll binder body -> TyForAll binder <$> replaceResultType body result
+    TyFun r1 r2 argument body -> TyFun r1 r2 argument <$> replaceResultType body result
+    _ -> Right result
+
+constructorFieldType :: Type -> Either String Type
+constructorFieldType ty =
+  case ty of
+    TyForAll _ body -> constructorFieldType body
+    TyFun _ _ argument _ -> Right argument
+    _ -> Left "newtype family constructor is not a function"
+
+convertTypeFamilyEquation :: ConvertEnv -> PackageId -> Text -> TypeFamilyInstanceInfo -> Either String Decl
+convertTypeFamilyEquation env package moduleName' info = do
+  let bindersEnv = withTyVars (tfiiTyVars info) env
+  binders <- mapM (tyVarBinder bindersEnv) (tfiiTyVars info)
+  left <- convertType bindersEnv (tfiiLeft info)
+  right <- convertType bindersEnv (tfiiRight info)
+  pure
+    ( DeclAxiom
+        AxiomDecl
+          { axiomVis = Private,
+            axiomName = Name (tfiiAxiomName info) SortAxiom (OriginTop package moduleName'),
+            axiomBinders = binders,
+            axiomRole = Nominal,
+            axiomLeft = left,
+            axiomRight = right
+          }
+    )
 
 lookupSynonym :: PackageId -> Text -> Text -> [TyConInfo] -> Either String TyConInfo
 lookupSynonym package moduleName' name tyCons =
@@ -160,7 +528,7 @@ convertDataType env info = do
     ( DeclType
         TypeDecl
           { typeVis = Pub,
-            typeName = tyConNameFc2 tyCon,
+            typeName = tyConNameFc2 env tyCon,
             typeBinders = binders,
             typeResult = result,
             typeRoles = replicate (length binders) Representational,
@@ -347,6 +715,9 @@ definitionResolution declaration =
   case peelDeclAnn declaration of
     Syn.DeclData dataDeclaration -> nameResolution (binderHeadName (dataDeclHead dataDeclaration))
     Syn.DeclTypeSyn synonymDeclaration -> nameResolution (binderHeadName (typeSynHead synonymDeclaration))
+    Syn.DeclNewtype newtypeDeclaration -> nameResolution (binderHeadName (Syn.newtypeDeclHead newtypeDeclaration))
+    Syn.DeclClass classDeclaration -> nameResolution (binderHeadName (Syn.classDeclHead classDeclaration))
+    Syn.DeclDataFamilyDecl familyDeclaration -> nameResolution (binderHeadName (Syn.dataFamilyDeclHead familyDeclaration))
     _ -> Nothing
 
 nameResolution :: UnqualifiedName -> Maybe ResolutionAnnotation

--- a/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
@@ -139,9 +139,9 @@ convertCoercion env coercion =
     Ev.Sym inner -> CoSym <$> convertCoercion env inner
     Ev.Trans left right -> CoTrans <$> convertCoercion env left <*> convertCoercion env right
     Ev.TyConAppCo tyCon arguments ->
-      CoTyConApp (tyConNameFc2 tyCon) <$> mapM (convertCoercion env) arguments
+      CoTyConApp (tyConNameFc2 env tyCon) <$> mapM (convertCoercion env) arguments
     Ev.AxiomInstCo name arguments ->
-      CoAxiom (Name name SortAxiom (OriginLocal (Unique 0))) <$> mapM (convertType env) arguments
+      CoAxiom (lookupAxiomName env name) <$> mapM (convertType env) arguments
 
 convertTermBinder :: ConvertEnv -> TopVars -> Fc.Var -> Either String Binder
 convertTermBinder env tops var = do

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -254,8 +254,17 @@ eqType :: Parser OpenType
 eqType = do
   left <- appType
   MP.option left $ do
-    _ <- symbol "~"
+    _ <- MP.try (symbol "~" <* MP.notFollowedBy axiomRoleLetter)
     OpenEq left <$> appType
+
+axiomRoleLetter :: Parser Char
+axiomRoleLetter = do
+  letter <- MP.satisfy (`elem` ("NRP" :: String))
+  following <- MP.optional (MP.lookAhead MP.anySingle)
+  case following of
+    Just character
+      | identContinue character -> fail "role prefix"
+    _ -> pure letter
 
 appType :: Parser OpenType
 appType = do

--- a/components/aihc-fc/test/Test/Fixtures/fc2/axiom-cast.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/axiom-cast.fc2
@@ -1,0 +1,10 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tInt :: 2.tType {}
+
+pub type 1.tAge :: 2.tType {}
+
+axiom 1.$ax$Age : 1.tAge ~R 1.tInt

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-dictionary.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-dictionary.yaml
@@ -1,0 +1,31 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Flag = Off | On
+    class Parent a where
+      parent :: a -> Flag
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tFlag :: 2.tType {
+      pub 1.vOff :: 1.tFlag
+      pub 1.vOn :: 1.tFlag
+  }
+
+  pub type 1.t$Dict$Parent (a{10} : 2.tType) :: 2.tType {
+      pub 1.v$Dict$Parent :: ∀(a{10} : 2.tType). (a{10} → 1.tFlag) → 1.t$Dict$Parent a{10}
+  }
+
+  pub val 1.vparent :: ∀(a{10} : 2.tType). 1.t$Dict$Parent a{10} → a{10} → 1.tFlag
+   = Λ(a{10} : 2.tType).
+    λ($d0{1001} : 1.t$Dict$Parent a{10}).
+      case $d0{1001} as ($dict{1002} : 1.t$Dict$Parent a{10}) of {
+          1.v$Dict$Parent ($method0{1003} : a{10} → 1.tFlag) →
+              $method0{1003}
+      }
+status: pass
+reason: A class becomes a dictionary data type with a full constructor type.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-instance.yaml
@@ -1,0 +1,37 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Flag = Off | On
+    class Parent a where
+      parent :: a -> Flag
+    instance Parent Flag where
+      parent value = value
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tFlag :: 2.tType {
+      pub 1.vOff :: 1.tFlag
+      pub 1.vOn :: 1.tFlag
+  }
+
+  pub type 1.t$Dict$Parent (a{10} : 2.tType) :: 2.tType {
+      pub 1.v$Dict$Parent :: ∀(a{10} : 2.tType). (a{10} → 1.tFlag) → 1.t$Dict$Parent a{10}
+  }
+
+  pub val 1.vparent :: ∀(a{10} : 2.tType). 1.t$Dict$Parent a{10} → a{10} → 1.tFlag
+   = Λ(a{10} : 2.tType).
+    λ($d0{1001} : 1.t$Dict$Parent a{10}).
+      case $d0{1001} as ($dict{1002} : 1.t$Dict$Parent a{10}) of {
+          1.v$Dict$Parent ($method0{1003} : a{10} → 1.tFlag) →
+              $method0{1003}
+      }
+
+  pub val 1.v$fParentFlag :: 1.t$Dict$Parent 1.tFlag
+   = 1.v$Dict$Parent @1.tFlag (λ(x{1004} : 1.tFlag).
+    x{1004})
+status: pass
+reason: An instance becomes a dictionary value of the class data type.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-superclass.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-superclass.yaml
@@ -1,0 +1,45 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Flag = Off | On
+    class Parent a where
+      parent :: a -> Flag
+    class Parent a => Child a where
+      child :: a -> Flag
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tFlag :: 2.tType {
+      pub 1.vOff :: 1.tFlag
+      pub 1.vOn :: 1.tFlag
+  }
+
+  pub type 1.t$Dict$Parent (a{10} : 2.tType) :: 2.tType {
+      pub 1.v$Dict$Parent :: ∀(a{10} : 2.tType). (a{10} → 1.tFlag) → 1.t$Dict$Parent a{10}
+  }
+
+  pub type 1.t$Dict$Child (a{12} : 2.tType) :: 2.tType {
+      pub 1.v$Dict$Child :: ∀(a{12} : 2.tType). 1.t$Dict$Parent a{12} → (a{12} → 1.tFlag) → 1.t$Dict$Child a{12}
+  }
+
+  pub val 1.vparent :: ∀(a{10} : 2.tType). 1.t$Dict$Parent a{10} → a{10} → 1.tFlag
+   = Λ(a{10} : 2.tType).
+    λ($d0{1001} : 1.t$Dict$Parent a{10}).
+      case $d0{1001} as ($dict{1002} : 1.t$Dict$Parent a{10}) of {
+          1.v$Dict$Parent ($method0{1003} : a{10} → 1.tFlag) →
+              $method0{1003}
+      }
+
+  pub val 1.vchild :: ∀(a{12} : 2.tType). 1.t$Dict$Child a{12} → a{12} → 1.tFlag
+   = Λ(a{12} : 2.tType).
+    λ($d0{1005} : 1.t$Dict$Child a{12}).
+      case $d0{1005} as ($dict{1006} : 1.t$Dict$Child a{12}) of {
+          1.v$Dict$Child ($method0{1007} : 1.t$Dict$Parent a{12}) ($method1{1008} : a{12} → 1.tFlag) →
+              $method1{1008}
+      }
+status: pass
+reason: A child class stores the parent dictionary as the first field.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/data-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/data-family-instance.yaml
@@ -1,0 +1,23 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data family Payload a
+    data instance Payload a = PayloadValue a
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-internal" Aihc.Internal
+  scope 3 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tPayload (a : 3.tType) :: 3.tType @N {}
+
+  type 2.t$R$Payload$PayloadValue (a{12} : 3.tType) :: 3.tType {
+      1.vPayloadValue :: ∀(a{12} : 3.tType). a{12} → 2.t$R$Payload$PayloadValue a{12}
+  }
+
+  axiom 1.$ax$Payload$PayloadValue (a{12} : 3.tType) : 1.tPayload a{12} ~N 2.t$R$Payload$PayloadValue a{12}
+status: pass
+reason: A data family is an empty type. An instance adds a hidden representation type and a nominal axiom.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-age.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-age.yaml
@@ -1,0 +1,25 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Int = I
+    newtype Age = MkAge Int
+    one = MkAge I
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tInt :: 2.tType {
+      pub 1.vI :: 1.tInt
+  }
+
+  pub type 1.tAge :: 2.tType {}
+
+  axiom 1.$ax$Age : 1.tAge ~R 1.tInt
+
+  pub val 1.vone :: 1.tAge
+   = 1.vI ▷ sym (axiom-co 1.$ax$Age)
+status: pass
+reason: A newtype becomes an empty type, a representational axiom, and a cast.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-family-instance.yaml
@@ -1,0 +1,28 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data Unit = Unit
+    data family Wrapped a
+    newtype instance Wrapped Unit = WrappedUnit Unit
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-internal" Aihc.Internal
+  scope 3 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tUnit :: 3.tType {
+      pub 1.vUnit :: 1.tUnit
+  }
+
+  pub type 1.tWrapped (a : 3.tType) :: 3.tType @N {}
+
+  type 2.t$R$Wrapped$WrappedUnit :: 3.tType {}
+
+  axiom 1.$ax$R$Wrapped$WrappedUnit : 2.t$R$Wrapped$WrappedUnit ~R 1.tUnit
+
+  axiom 1.$ax$Wrapped$WrappedUnit : 1.tWrapped 1.tUnit ~N 2.t$R$Wrapped$WrappedUnit
+status: pass
+reason: A newtype family instance is an empty representation type plus two axioms.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-family-instance.yaml
@@ -1,0 +1,24 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data Flag = Off | On
+    type family F a
+    type instance F Flag = Flag
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  pub type 1.tFlag :: 2.tType {
+      pub 1.vOff :: 1.tFlag
+      pub 1.vOn :: 1.tFlag
+  }
+
+  pub type 1.tF (a : 2.tType) :: 2.tType @N {}
+
+  axiom 1.$ax$F$Flag : 1.tF 1.tFlag ~N 1.tFlag
+status: pass
+reason: A type family is an empty type. An instance becomes a named nominal axiom.

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -82,6 +82,10 @@ import Aihc.Parser.Syntax
     TupleFlavor (..),
     TyVarBinder (..),
     Type (..),
+    TypeFamilyDecl (..),
+    TypeFamilyEq (..),
+    TypeFamilyInst (..),
+    TypeFamilyResultSig (..),
     TypePromotion (..),
     TypeSynDecl (..),
     UnqualifiedName,
@@ -430,10 +434,12 @@ resolveDeclCore termDefinition decl =
       DeclInstance <$> resolveInstanceDecl instanceDecl
     DeclStandaloneDeriving derivingDecl ->
       DeclStandaloneDeriving <$> resolveStandaloneDerivingDecl derivingDecl
-    DeclTypeFamilyDecl {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclTypeFamilyDecl familyDecl ->
+      DeclTypeFamilyDecl <$> resolveTypeFamilyDecl familyDecl
     DeclDataFamilyDecl dataFamilyDecl ->
       DeclDataFamilyDecl <$> resolveDataFamilyDecl dataFamilyDecl
-    DeclTypeFamilyInst {} -> annotateUnhandledDecl <$> currentSpan <*> pure decl
+    DeclTypeFamilyInst familyInst ->
+      DeclTypeFamilyInst <$> resolveTypeFamilyInst familyInst
     DeclDataFamilyInst dataFamilyInst ->
       DeclDataFamilyInst <$> resolveDataFamilyInst dataFamilyInst
 
@@ -1162,6 +1168,66 @@ resolveDataDecl keyword dataDecl = do
         dataDeclKind = kind',
         dataDeclConstructors = map (resolveDataConDefinitions scope) constructors',
         dataDeclDeriving = deriving'
+      }
+
+resolveTypeFamilyDecl :: TypeFamilyDecl -> ResolveM TypeFamilyDecl
+resolveTypeFamilyDecl familyDecl = do
+  (paramScope, params') <- bindTyVarBinders (typeFamilyDeclParams familyDecl)
+  (head', resultSig', equations') <-
+    extendScope paramScope $
+      (,,)
+        <$> resolveType (typeFamilyDeclHead familyDecl)
+        <*> traverse resolveTypeFamilyResultSig (typeFamilyDeclResultSig familyDecl)
+        <*> traverse (mapM resolveTypeFamilyEq) (typeFamilyDeclEquations familyDecl)
+  pure
+    familyDecl
+      { typeFamilyDeclHead = head',
+        typeFamilyDeclParams = params',
+        typeFamilyDeclResultSig = resultSig',
+        typeFamilyDeclEquations = equations'
+      }
+
+resolveTypeFamilyResultSig :: TypeFamilyResultSig -> ResolveM TypeFamilyResultSig
+resolveTypeFamilyResultSig resultSig =
+  case resultSig of
+    TypeFamilyKindSig ty -> TypeFamilyKindSig <$> resolveType ty
+    TypeFamilyTyVarSig binder -> TypeFamilyTyVarSig <$> resolveTyVarBinderKind binder
+    TypeFamilyInjectiveSig binder injectivity ->
+      TypeFamilyInjectiveSig <$> resolveTyVarBinderKind binder <*> pure injectivity
+
+resolveTyVarBinderKind :: TyVarBinder -> ResolveM TyVarBinder
+resolveTyVarBinderKind binder = do
+  kind' <- traverse resolveType (tyVarBinderKind binder)
+  pure binder {tyVarBinderKind = kind'}
+
+resolveTypeFamilyEq :: TypeFamilyEq -> ResolveM TypeFamilyEq
+resolveTypeFamilyEq equation = do
+  (forallScope, forallBinders') <- bindTyVarBinders (typeFamilyEqForall equation)
+  (lhs', rhs') <-
+    extendScope forallScope $
+      (,)
+        <$> resolveType (typeFamilyEqLhs equation)
+        <*> resolveType (typeFamilyEqRhs equation)
+  pure
+    equation
+      { typeFamilyEqForall = forallBinders',
+        typeFamilyEqLhs = lhs',
+        typeFamilyEqRhs = rhs'
+      }
+
+resolveTypeFamilyInst :: TypeFamilyInst -> ResolveM TypeFamilyInst
+resolveTypeFamilyInst familyInst = do
+  (forallScope, forallBinders') <- bindTyVarBinders (typeFamilyInstForall familyInst)
+  (lhs', rhs') <-
+    extendScope forallScope $
+      (,)
+        <$> resolveType (typeFamilyInstLhs familyInst)
+        <*> resolveType (typeFamilyInstRhs familyInst)
+  pure
+    familyInst
+      { typeFamilyInstForall = forallBinders',
+        typeFamilyInstLhs = lhs',
+        typeFamilyInstRhs = rhs'
       }
 
 resolveDataFamilyDecl :: DataFamilyDecl -> ResolveM DataFamilyDecl

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -58,6 +58,7 @@ import Aihc.Parser.Syntax
     SourceSpan (..),
     TupleFlavor (..),
     Type (..),
+    TypeFamilyDecl (..),
     TypeSynDecl (..),
     UnqualifiedName,
     ValueDecl (..),
@@ -245,6 +246,10 @@ declExportedNames decl =
     DeclDataFamilyDecl familyDecl ->
       DeclExports [] [binderHeadName (dataFamilyDeclHead familyDecl)] Map.empty Map.empty Map.empty Map.empty
     DeclDataFamilyInst familyInst -> dataFamilyInstExports familyInst
+    DeclTypeFamilyDecl familyDecl ->
+      case typeFamilyHeadName (typeFamilyDeclHead familyDecl) of
+        Just name -> DeclExports [] [name] Map.empty Map.empty Map.empty Map.empty
+        Nothing -> DeclExports [] [] Map.empty Map.empty Map.empty Map.empty
     DeclTypeSyn typeSynDecl -> DeclExports [] [binderHeadName (typeSynHead typeSynDecl)] Map.empty Map.empty Map.empty Map.empty
     _ -> DeclExports [] [] Map.empty Map.empty Map.empty Map.empty
 
@@ -267,11 +272,15 @@ dataFamilyInstExports familyInst =
     recordFields = recordFieldMap constructors
 
 dataFamilyHeadName :: Type -> Maybe UnqualifiedName
-dataFamilyHeadName ty =
+dataFamilyHeadName = typeFamilyHeadName
+
+typeFamilyHeadName :: Type -> Maybe UnqualifiedName
+typeFamilyHeadName ty =
   case peelTypeHead ty of
     TCon name _ -> Just (mkUnqualifiedName (nameType name) (nameText name))
-    TApp function _ -> dataFamilyHeadName function
-    TTypeApp function _ -> dataFamilyHeadName function
+    TInfix _ name _ _ -> Just (mkUnqualifiedName (nameType name) (nameText name))
+    TApp function _ -> typeFamilyHeadName function
+    TTypeApp function _ -> typeFamilyHeadName function
     _ -> Nothing
 
 dataDeclExports :: BinderHead UnqualifiedName -> [DataConDecl] -> DeclExports

--- a/components/aihc-resolve/test/Test/Fixtures/golden/type-family-instance.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/type-family-instance.yaml
@@ -1,0 +1,34 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Provider (Flag(..), F) where
+    data Flag = Off | On
+    type family F a
+    type instance F Flag = Flag
+  - |
+    module Consumer where
+    import Provider (Flag, F)
+    type Alias = F Flag
+annotated:
+  - |
+    module Consumer where
+    import Provider (Flag, F)
+    type Alias = F Flag
+         │       │ └─ t Provider
+         │       └─ t Provider
+         └─ t Consumer
+  - |
+    module Provider (Flag(..), F) where
+    data Flag = Off | On
+         │      │     └─ v Provider
+         │      └─ v Provider
+         └─ t Provider
+    type family F a
+                └─ t Provider
+    type instance F Flag = Flag
+                  │ │      └─ t Provider
+                  │ └─ t Provider
+                  └─ t Provider
+status: pass
+reason: standalone type families and their instance heads participate in ordinary type resolution

--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -36,6 +36,7 @@ import Aihc.Tc
     InstanceInfo (iiDictName),
     TcInterface (..),
     TyConInfo (tciTyCon),
+    TypeFamilyInstanceInfo (tfiiAxiomName),
     dataTypeKey,
     emptyTcInterface,
     typecheckModuleSccWithInterface,
@@ -268,7 +269,8 @@ subtractInterface imported complete =
       tcInterfaceDataTypes = withoutImported dataTypeKey (tcInterfaceDataTypes imported) (tcInterfaceDataTypes complete),
       tcInterfaceClasses = withoutImported ciName (tcInterfaceClasses imported) (tcInterfaceClasses complete),
       tcInterfaceInstances = withoutImported iiDictName (tcInterfaceInstances imported) (tcInterfaceInstances complete),
-      tcInterfaceDataFamilyInstances = withoutImported dfiiAxiomName (tcInterfaceDataFamilyInstances imported) (tcInterfaceDataFamilyInstances complete)
+      tcInterfaceDataFamilyInstances = withoutImported dfiiAxiomName (tcInterfaceDataFamilyInstances imported) (tcInterfaceDataFamilyInstances complete),
+      tcInterfaceTypeFamilyInstances = withoutImported tfiiAxiomName (tcInterfaceTypeFamilyInstances imported) (tcInterfaceTypeFamilyInstances complete)
     }
 
 withoutImported :: (Ord key) => (value -> key) -> [value] -> [value] -> [value]

--- a/components/aihc-tc/src/Aihc/Tc.hs
+++ b/components/aihc-tc/src/Aihc/Tc.hs
@@ -77,6 +77,8 @@ module Aihc.Tc
     dataConArgTypes,
     dataFamilyAxiomName,
     dataFamilyRepresentationName,
+    TypeFamilyInstanceInfo (..),
+    typeFamilyAxiomName,
     ClassInfo (..),
     TyConFlavor (..),
     TyConInfo (..),
@@ -130,7 +132,7 @@ import Aihc.Parser.Syntax
   )
 import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Annotations (TcAnnotation (..), TcDerivingAnnotation (..), TcDerivingContext (..), TcDerivingPlan (..), TcDerivingStrategy (..), TcStockDerivingPlan (..), renderPred, renderTcSignature, renderTcType, renderTcTypeInModule)
-import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), dataConArgTypes, dataFamilyAxiomName, dataFamilyRepresentationName, dataTypeKey)
+import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeFamilyInstanceInfo (..), dataConArgTypes, dataFamilyAxiomName, dataFamilyRepresentationName, dataTypeKey, typeFamilyAxiomName)
 import Aihc.Tc.Error (TcDiagnostic (..), TcErrorKind (..), TcSeverity (..))
 import Aihc.Tc.Generate.Decl (TcBindingResult (..), moduleBindings, moduleClasses, moduleInstances, tcModule, tcModuleScc)
 import Aihc.Tc.Generate.Expr (inferExpr)
@@ -170,7 +172,8 @@ data TcInterface = TcInterface
     tcInterfaceDataTypes :: ![DataTypeInfo],
     tcInterfaceClasses :: ![ClassInfo],
     tcInterfaceInstances :: ![InstanceInfo],
-    tcInterfaceDataFamilyInstances :: ![DataFamilyInstanceInfo]
+    tcInterfaceDataFamilyInstances :: ![DataFamilyInstanceInfo],
+    tcInterfaceTypeFamilyInstances :: ![TypeFamilyInstanceInfo]
   }
   deriving (Eq, Show, Read)
 
@@ -182,7 +185,8 @@ emptyTcInterface =
       tcInterfaceDataTypes = [],
       tcInterfaceClasses = [],
       tcInterfaceInstances = [],
-      tcInterfaceDataFamilyInstances = []
+      tcInterfaceDataFamilyInstances = [],
+      tcInterfaceTypeFamilyInstances = []
     }
 
 instance Semigroup TcInterface where
@@ -193,7 +197,8 @@ instance Semigroup TcInterface where
         tcInterfaceDataTypes = mergeInterfaceEntries "data type interface" dataTypeKey (tcInterfaceDataTypes left <> tcInterfaceDataTypes right),
         tcInterfaceClasses = mergeInterfaceEntries "class interface" ciName (tcInterfaceClasses left <> tcInterfaceClasses right),
         tcInterfaceInstances = mergeInterfaceEntries "instance interface" iiDictName (tcInterfaceInstances left <> tcInterfaceInstances right),
-        tcInterfaceDataFamilyInstances = mergeInterfaceEntries "data family instance interface" dfiiAxiomName (tcInterfaceDataFamilyInstances left <> tcInterfaceDataFamilyInstances right)
+        tcInterfaceDataFamilyInstances = mergeInterfaceEntries "data family instance interface" dfiiAxiomName (tcInterfaceDataFamilyInstances left <> tcInterfaceDataFamilyInstances right),
+        tcInterfaceTypeFamilyInstances = mergeInterfaceEntries "type family instance interface" tfiiAxiomName (tcInterfaceTypeFamilyInstances left <> tcInterfaceTypeFamilyInstances right)
       }
 
 instance Monoid TcInterface where
@@ -389,7 +394,8 @@ typecheckModulesWithClassEnv importedTerms importedTyCons importedClasses import
               tcInterfaceDataTypes = [],
               tcInterfaceClasses = importedClasses,
               tcInterfaceInstances = importedInstances,
-              tcInterfaceDataFamilyInstances = []
+              tcInterfaceDataFamilyInstances = [],
+              tcInterfaceTypeFamilyInstances = []
             }
           modules
    in (checkedModules, exportedTermEntries interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
@@ -453,7 +459,8 @@ typecheckModuleSccWithClassEnv importedTerms importedTyCons importedClasses impo
               tcInterfaceDataTypes = [],
               tcInterfaceClasses = importedClasses,
               tcInterfaceInstances = importedInstances,
-              tcInterfaceDataFamilyInstances = []
+              tcInterfaceDataFamilyInstances = [],
+              tcInterfaceTypeFamilyInstances = []
             }
           modules
    in (checkedModules, exportedTermEntries interface, tcInterfaceTyCons interface, tcInterfaceClasses interface)
@@ -487,7 +494,8 @@ initialTcState imported =
       tcsDataTypes = mapFromListNoDuplicates "imported data type state" [(dataTypeKey dataType, dataType) | dataType <- tcInterfaceDataTypes imported],
       tcsClasses = mapFromListNoDuplicates "imported class state" [(ciName classInfo, classInfo) | classInfo <- tcInterfaceClasses imported],
       tcsInstances = mergeInterfaceEntries "imported instance state" iiDictName (tcInterfaceInstances imported),
-      tcsDataFamilyInstances = mergeInterfaceEntries "imported data family instance state" dfiiAxiomName (tcInterfaceDataFamilyInstances imported)
+      tcsDataFamilyInstances = mergeInterfaceEntries "imported data family instance state" dfiiAxiomName (tcInterfaceDataFamilyInstances imported),
+      tcsTypeFamilyInstances = mergeInterfaceEntries "imported type family instance state" tfiiAxiomName (tcInterfaceTypeFamilyInstances imported)
     }
 
 tcInterfaceFromState :: TcState -> TcInterface
@@ -498,7 +506,8 @@ tcInterfaceFromState state =
       tcInterfaceDataTypes = Map.elems (tcsDataTypes state),
       tcInterfaceClasses = Map.elems (tcsClasses state),
       tcInterfaceInstances = mergeInterfaceEntries "instance state" iiDictName (tcsInstances state),
-      tcInterfaceDataFamilyInstances = mergeInterfaceEntries "data family instance state" dfiiAxiomName (tcsDataFamilyInstances state)
+      tcInterfaceDataFamilyInstances = mergeInterfaceEntries "data family instance state" dfiiAxiomName (tcsDataFamilyInstances state),
+      tcInterfaceTypeFamilyInstances = mergeInterfaceEntries "type family instance state" tfiiAxiomName (tcsTypeFamilyInstances state)
     }
 
 exportedGlobalTerms :: TcState -> [(TcTermKey, TypeScheme)]

--- a/components/aihc-tc/src/Aihc/Tc/Env.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Env.hs
@@ -33,6 +33,10 @@ module Aihc.Tc.Env
     DataFamilyInstanceInfo (..),
     dataFamilyAxiomName,
     dataFamilyRepresentationName,
+
+    -- * Type family equations
+    TypeFamilyInstanceInfo (..),
+    typeFamilyAxiomName,
   )
 where
 
@@ -41,6 +45,7 @@ import Aihc.Tc.Types
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
+import Data.Text qualified as T
 
 -- | Global environment, built from module declarations.
 data GlobalEnv = GlobalEnv
@@ -68,6 +73,7 @@ data TyConFlavor
   | DataFamilyTyCon
   | NewtypeTyCon
   | SynonymTyCon
+  | TypeFamilyTyCon
   deriving (Eq, Show, Read)
 
 data TyConInfo = TyConInfo
@@ -214,3 +220,19 @@ dataFamilyRepresentationName familyName firstConstructor =
 dataFamilyAxiomName :: Text -> Text -> Text
 dataFamilyAxiomName familyName firstConstructor =
   "$ax$" <> familyName <> "$" <> firstConstructor
+
+-- | A checked type-family equation. Fc2 prints this as a named axiom.
+-- Do not invent equations in a later phase.
+data TypeFamilyInstanceInfo = TypeFamilyInstanceInfo
+  { tfiiFamilyName :: !Text,
+    tfiiAxiomName :: !Text,
+    tfiiTyVars :: ![TyVarId],
+    tfiiLeft :: !TcType,
+    tfiiRight :: !TcType,
+    tfiiClosed :: !Bool
+  }
+  deriving (Eq, Show, Read)
+
+typeFamilyAxiomName :: Text -> Int -> Text
+typeFamilyAxiomName familyName index =
+  "$ax$" <> familyName <> "$" <> T.pack (show index)

--- a/components/aihc-tc/src/Aihc/Tc/Finalize.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Finalize.hs
@@ -23,7 +23,7 @@ import Aihc.Tc.Annotations
     TcInstanceMethodAnnotation (..),
     TcStockDerivingPlan (..),
   )
-import Aihc.Tc.Env (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..))
+import Aihc.Tc.Env (DataConFieldInfo (..), DataConInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), TypeFamilyInstanceInfo (..))
 import Aihc.Tc.Evidence (Coercion (..), EvTerm (..), EvVar)
 import Aihc.Tc.Monad
 import Aihc.Tc.Types (Pred (..), TcType (..), TyVarId, Unique (..))
@@ -144,6 +144,7 @@ rejectMetaFinalAnnotation ann = do
   traverseReject "instance annotation" (firstMetaInstanceAnnotation <$> fromAnnotation @TcInstanceAnnotation ann)
   traverseReject "instance method annotation" (firstMetaInstanceMethodAnnotation <$> fromAnnotation @TcInstanceMethodAnnotation ann)
   traverseReject "data-family instance annotation" (firstMetaDataFamilyInstance <$> fromAnnotation @DataFamilyInstanceInfo ann)
+  traverseReject "type-family instance annotation" (firstMetaTypeFamilyInstance <$> fromAnnotation @TypeFamilyInstanceInfo ann)
   where
     traverseReject _ Nothing = pure ()
     traverseReject context (Just maybeMeta) = rejectMeta ("finalized " <> context) maybeMeta
@@ -230,6 +231,10 @@ firstMetaInstanceMethodAnnotation ann =
 firstMetaDataFamilyInstance :: DataFamilyInstanceInfo -> Maybe Unique
 firstMetaDataFamilyInstance info =
   firstMetaType (dfiiFamilyType info)
+
+firstMetaTypeFamilyInstance :: TypeFamilyInstanceInfo -> Maybe Unique
+firstMetaTypeFamilyInstance info =
+  firstMetaType (tfiiLeft info) <|> firstMetaType (tfiiRight info)
 
 firstMetaDataConInfo :: DataConInfo -> Maybe Unique
 firstMetaDataConInfo info =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -53,6 +53,10 @@ import Aihc.Parser.Syntax
     TupleFlavor (..),
     TyVarBinder,
     Type (..),
+    TypeFamilyDecl (..),
+    TypeFamilyEq (..),
+    TypeFamilyInst (..),
+    TypeFamilyResultSig (..),
     TypeSynDecl (..),
     UnqualifiedName (..),
     ValueDecl (..),
@@ -70,6 +74,7 @@ import Aihc.Parser.Syntax
     nameText,
     peelClassDeclItemAnn,
     peelDeclAnn,
+    peelTypeHead,
     unqualifiedNameAnns,
   )
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
@@ -90,7 +95,7 @@ import Aihc.Tc.Annotations
 import Aihc.Tc.Constraint
 import Aihc.Tc.Deriving (annotateAttachedDerivingTc, annotateStandaloneDerivingTc)
 import Aihc.Tc.Deriving.Context (derivingPlanInstanceInfo, finalizeDerivingModulesTc)
-import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeSynonymInfo (..), dataFamilyAxiomName, dataFamilyRepresentationName)
+import Aihc.Tc.Env (ClassInfo (..), DataConFieldInfo (..), DataConFieldUnpack (..), DataConInfo (..), DataConSourceForm (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeFamilyInstanceInfo (..), TypeSynonymInfo (..), dataFamilyAxiomName, dataFamilyRepresentationName, typeFamilyAxiomName)
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Evidence (EvTerm (..))
 import Aihc.Tc.Finalize (finalizeModuleTc)
@@ -548,6 +553,7 @@ defaultGlobalKindMetas = do
   classes <- traverse defaultClassKinds (tcsClasses state)
   instances <- mapM defaultInstanceKinds (tcsInstances state)
   dataFamilyInstances <- mapM defaultDataFamilyInstanceKinds (tcsDataFamilyInstances state)
+  typeFamilyInstances <- mapM defaultTypeFamilyInstanceKinds (tcsTypeFamilyInstances state)
   lift $
     modify' $ \current ->
       current
@@ -556,7 +562,8 @@ defaultGlobalKindMetas = do
           tcsDataTypes = dataTypes,
           tcsClasses = classes,
           tcsInstances = instances,
-          tcsDataFamilyInstances = dataFamilyInstances
+          tcsDataFamilyInstances = dataFamilyInstances,
+          tcsTypeFamilyInstances = typeFamilyInstances
         }
   where
     defaultBinderKinds binder =
@@ -638,6 +645,16 @@ defaultGlobalKindMetas = do
             dfiiTyVars = tyVars,
             dfiiRepresentationTyCon = setTyConKindScheme representationKindScheme representationTyCon
           }
+    defaultTypeFamilyInstanceKinds info = do
+      tyVars <- mapM defaultTyVarKinds (tfiiTyVars info)
+      left <- defaultTypeKinds (tfiiLeft info)
+      right <- defaultTypeKinds (tfiiRight info)
+      pure
+        info
+          { tfiiTyVars = tyVars,
+            tfiiLeft = left,
+            tfiiRight = right
+          }
 
 data TcDeclGroupResult = TcDeclGroupResult
   { tcGroupId :: !Int,
@@ -712,6 +729,8 @@ annotateDeclTc classMethods checkedValueNames decl =
     DeclTypeSyn typeSynDecl -> annotateTypeSynDeclTc typeSynDecl
     DeclDataFamilyDecl familyDecl -> annotateDataFamilyDeclTc familyDecl
     DeclDataFamilyInst familyInst -> annotateDataFamilyInstTc familyInst
+    DeclTypeFamilyDecl familyDecl -> annotateTypeFamilyDeclTc familyDecl
+    DeclTypeFamilyInst familyInst -> annotateTypeFamilyInstTc familyInst
     DeclForeign foreignDecl
       | isForeignImport foreignDecl -> annotateForeignDeclTc foreignDecl
     DeclClass classDecl -> annotateClassDeclTc classDecl
@@ -809,6 +828,41 @@ annotateDataFamilyDeclTc familyDecl = do
   ty <- tyConBindingType familyName
   let annotatedHead = annotateBinderHeadName (TcAnnotation ty [] [] [] []) (dataFamilyDeclHead familyDecl)
   pure (DeclDataFamilyDecl (familyDecl {dataFamilyDeclHead = annotatedHead}))
+
+annotateTypeFamilyDeclTc :: TypeFamilyDecl -> TcM Decl
+annotateTypeFamilyDeclTc familyDecl =
+  case typeFamilyHeadName (typeFamilyDeclHead familyDecl) of
+    Nothing -> pure (DeclTypeFamilyDecl familyDecl)
+    Just familyBinder -> do
+      ty <- tyConBindingType (unqualifiedNameText familyBinder)
+      let annotatedHead = annotateTypeFamilyHead (TcAnnotation ty [] [] [] []) (typeFamilyDeclHead familyDecl)
+      pure (DeclTypeFamilyDecl (familyDecl {typeFamilyDeclHead = annotatedHead}))
+
+annotateTypeFamilyHead :: TcAnnotation -> Type -> Type
+annotateTypeFamilyHead tcAnn ty =
+  case peelTypeHead ty of
+    TCon name promo -> TCon (annotateName tcAnn name) promo
+    TInfix left name promo right -> TInfix left (annotateName tcAnn name) promo right
+    TApp function argument -> TApp (annotateTypeFamilyHead tcAnn function) argument
+    TTypeApp function argument -> TTypeApp (annotateTypeFamilyHead tcAnn function) argument
+    other -> other
+
+annotateName :: TcAnnotation -> Name -> Name
+annotateName tcAnn name =
+  name {nameAnns = nameAnns name <> [mkAnnotation tcAnn]}
+
+annotateTypeFamilyInstTc :: TypeFamilyInst -> TcM Decl
+annotateTypeFamilyInstTc familyInst = do
+  familyInstances <- getTypeFamilyInstances
+  case find (sameTypeFamilyInstance familyInst) familyInstances of
+    Just familyInstance ->
+      pure (DeclAnn (mkAnnotation familyInstance) (DeclTypeFamilyInst familyInst))
+    Nothing -> pure (DeclTypeFamilyInst familyInst)
+
+sameTypeFamilyInstance :: TypeFamilyInst -> TypeFamilyInstanceInfo -> Bool
+sameTypeFamilyInstance familyInst info =
+  tfiiAxiomName info == sourceTypeFamilyAxiomName (typeFamilyInstLhs familyInst)
+    && not (tfiiClosed info)
 
 annotateDataFamilyInstTc :: DataFamilyInst -> TcM Decl
 annotateDataFamilyInstTc familyInst = do
@@ -1883,6 +1937,8 @@ registerTypeDeclHeader kindSchemes (DeclNewtype newtypeDecl) =
   registerNewtypeDeclHeader (resolvedTypeKey (binderHeadName (newtypeDeclHead newtypeDecl)) >>= (`Map.lookup` kindSchemes)) newtypeDecl
 registerTypeDeclHeader kindSchemes (DeclDataFamilyDecl familyDecl) =
   registerDataFamilyDeclHeader (resolvedTypeKey (binderHeadName (dataFamilyDeclHead familyDecl)) >>= (`Map.lookup` kindSchemes)) familyDecl
+registerTypeDeclHeader kindSchemes (DeclTypeFamilyDecl familyDecl) =
+  registerTypeFamilyDeclHeader (typeFamilyHeadName (typeFamilyDeclHead familyDecl) >>= resolvedTypeKey >>= (`Map.lookup` kindSchemes)) familyDecl
 registerTypeDeclHeader kindSchemes (DeclTypeSyn typeSynDecl) =
   registerTypeSynonymHeader (resolvedTypeKey (binderHeadName (typeSynHead typeSynDecl)) >>= (`Map.lookup` kindSchemes)) typeSynDecl
 registerTypeDeclHeader kindSchemes (DeclAnn _ inner) = registerTypeDeclHeader kindSchemes inner
@@ -1892,6 +1948,8 @@ registerStructuralDecl :: (Text, Text) -> Decl -> TcM [TcBindingResult]
 registerStructuralDecl _ (DeclData dataDecl) = registerDataConstructors dataDecl
 registerStructuralDecl _ (DeclNewtype newtypeDecl) = registerNewtypeConstructor newtypeDecl
 registerStructuralDecl _ (DeclDataFamilyInst familyInst) = registerDataFamilyInstance familyInst
+registerStructuralDecl _ (DeclTypeFamilyDecl familyDecl) = registerClosedTypeFamilyEquations familyDecl
+registerStructuralDecl _ (DeclTypeFamilyInst familyInst) = registerTypeFamilyInstance familyInst
 registerStructuralDecl origin (DeclClass classDecl) = registerClassDecl origin classDecl
 registerStructuralDecl origin (DeclInstance instanceDecl) = registerInstanceDecl origin instanceDecl
 registerStructuralDecl origin (DeclAnn _ inner) = registerStructuralDecl origin inner
@@ -2121,6 +2179,154 @@ dataFamilyInstanceParams familyInst = do
   explicitParams <- makeParamEnv (dataFamilyInstForall familyInst)
   let explicitNames = map paramName explicitParams
       implicitNames = freeTypeVars (dataFamilyInstHead familyInst) \\ explicitNames
+  implicitParams <- mapM makeImplicitParam implicitNames
+  pure (explicitParams <> implicitParams)
+  where
+    makeImplicitParam name = do
+      rawTyVar <- freshSkolemTv name
+      kind <- freshKindMeta
+      pure
+        ParamInfo
+          { paramName = name,
+            paramTyVar = setTyVarKind kind rawTyVar,
+            paramKind = kind
+          }
+
+typeFamilyHeadName :: Type -> Maybe UnqualifiedName
+typeFamilyHeadName ty =
+  case peelTypeHead ty of
+    TCon name _ -> Just (unqualifiedFromResolvedName name)
+    TInfix _ name _ _ -> Just (unqualifiedFromResolvedName name)
+    TApp function _ -> typeFamilyHeadName function
+    TTypeApp function _ -> typeFamilyHeadName function
+    _ -> Nothing
+
+unqualifiedFromResolvedName :: Name -> UnqualifiedName
+unqualifiedFromResolvedName name =
+  UnqualifiedName
+    { unqualifiedNameType = nameType name,
+      unqualifiedNameText = nameText name,
+      unqualifiedNameAnns = nameAnns name
+    }
+
+sourceTypeFamilyAxiomName :: Type -> Text
+sourceTypeFamilyAxiomName ty = "$ax$" <> sourceTypeKey ty
+
+sourceTypeKey :: Type -> Text
+sourceTypeKey ty =
+  case peelTypeHead ty of
+    TCon name _ -> nameText name
+    TVar name -> unqualifiedNameText name
+    TApp function argument -> sourceTypeKey function <> "$" <> sourceTypeKey argument
+    TTypeApp function argument -> sourceTypeKey function <> "$" <> sourceTypeKey argument
+    TInfix left name _ right -> sourceTypeKey left <> "$" <> nameText name <> "$" <> sourceTypeKey right
+    _ -> "T"
+
+registerTypeFamilyDeclHeader :: Maybe TypeScheme -> TypeFamilyDecl -> TcM [TcBindingResult]
+registerTypeFamilyDeclHeader maybeKindScheme familyDecl =
+  case typeFamilyHeadName (typeFamilyDeclHead familyDecl) of
+    Nothing -> do
+      emitError NoSourceSpan (OtherError "type family head does not name a type family")
+      pure []
+    Just familyBinder -> do
+      let familyName = unqualifiedNameText familyBinder
+          params = typeFamilyDeclParams familyDecl
+          arity = length params
+      (_, paramInfos) <- typeDeclParamInfos maybeKindScheme params
+      inferredKind <- tyConKindFromParams paramInfos (typeFamilyResultKindType familyDecl)
+      familyTyCon <-
+        case maybeKindScheme of
+          Just kindScheme -> declaredTyConWithKindScheme familyBinder familyName arity kindScheme
+          Nothing -> mkDeclaredTyCon familyBinder familyName arity inferredKind
+      let declaredKind = maybe inferredKind (const (tyConKind familyTyCon)) maybeKindScheme
+      extendTyConEnvPermanent
+        familyName
+        TyConInfo
+          { tciName = familyName,
+            tciArity = arity,
+            tciTyCon = familyTyCon,
+            tciFlavor = TypeFamilyTyCon,
+            tciTypeSynonym = Nothing
+          }
+      zonkedKind <- defaultKindMetas declaredKind
+      pure [TcBindingResult familyName familyName (kindToTcType zonkedKind)]
+
+typeFamilyResultKindType :: TypeFamilyDecl -> Maybe Type
+typeFamilyResultKindType familyDecl =
+  case typeFamilyDeclResultSig familyDecl of
+    Just (TypeFamilyKindSig ty) -> Just ty
+    _ -> Nothing
+
+registerClosedTypeFamilyEquations :: TypeFamilyDecl -> TcM [TcBindingResult]
+registerClosedTypeFamilyEquations familyDecl =
+  case typeFamilyDeclEquations familyDecl of
+    Nothing -> pure []
+    Just equations -> do
+      mapM_ (registerTypeFamilyEquation True (typeFamilyDeclParams familyDecl)) equations
+      pure []
+
+registerTypeFamilyInstance :: TypeFamilyInst -> TcM [TcBindingResult]
+registerTypeFamilyInstance familyInst = do
+  registerTypeFamilyEquation False (typeFamilyInstForall familyInst) $
+    TypeFamilyEq
+      { typeFamilyEqAnns = [],
+        typeFamilyEqForall = typeFamilyInstForall familyInst,
+        typeFamilyEqHeadForm = typeFamilyInstHeadForm familyInst,
+        typeFamilyEqLhs = typeFamilyInstLhs familyInst,
+        typeFamilyEqRhs = typeFamilyInstRhs familyInst
+      }
+  pure []
+
+registerTypeFamilyEquation :: Bool -> [TyVarBinder] -> TypeFamilyEq -> TcM ()
+registerTypeFamilyEquation isClosed extraBinders equation = do
+  paramInfos <- typeFamilyEquationParams extraBinders equation
+  let tvEnv =
+        Map.fromList
+          [ (paramName param, (paramTyVar param, paramKind param))
+          | param <- paramInfos
+          ]
+  lhs <- checkSurfaceType tvEnv (typeFamilyEqLhs equation) KType
+  rhs <- checkSurfaceType tvEnv (typeFamilyEqRhs equation) KType
+  case typeFamilyApplicationHead lhs of
+    Just familyTyCon -> do
+      maybeFamilyInfo <- lookupTyConByIdentity familyTyCon
+      case maybeFamilyInfo of
+        Just familyInfo
+          | tciFlavor familyInfo == TypeFamilyTyCon -> do
+              existing <- getTypeFamilyInstances
+              let familyName = tciName familyInfo
+                  axiomName =
+                    if isClosed
+                      then typeFamilyAxiomName familyName (length existing)
+                      else sourceTypeFamilyAxiomName (typeFamilyEqLhs equation)
+                  instanceInfo =
+                    TypeFamilyInstanceInfo
+                      { tfiiFamilyName = familyName,
+                        tfiiAxiomName = axiomName,
+                        tfiiTyVars = map paramTyVar paramInfos,
+                        tfiiLeft = lhs,
+                        tfiiRight = rhs,
+                        tfiiClosed = isClosed
+                      }
+              addTypeFamilyInstance instanceInfo
+        _ ->
+          emitError NoSourceSpan (OtherError ("type-family instance head does not name a type family: " <> T.unpack (tyConName familyTyCon)))
+    Nothing ->
+      emitError NoSourceSpan (OtherError ("invalid type-family instance head: " <> show lhs))
+
+typeFamilyApplicationHead :: TcType -> Maybe TyCon
+typeFamilyApplicationHead ty =
+  case ty of
+    TcTyCon tyCon _ -> Just tyCon
+    TcAppTy function _ -> typeFamilyApplicationHead function
+    _ -> Nothing
+
+typeFamilyEquationParams :: [TyVarBinder] -> TypeFamilyEq -> TcM [ParamInfo]
+typeFamilyEquationParams extraBinders equation = do
+  explicitParams <- makeParamEnv (extraBinders <> typeFamilyEqForall equation)
+  let explicitNames = map paramName explicitParams
+      implicitNames =
+        nub (freeTypeVars (typeFamilyEqLhs equation) <> freeTypeVars (typeFamilyEqRhs equation)) \\ explicitNames
   implicitParams <- mapM makeImplicitParam implicitNames
   pure (explicitParams <> implicitParams)
   where

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -77,6 +77,8 @@ module Aihc.Tc.Monad
     getInstances,
     addDataFamilyInstance,
     getDataFamilyInstances,
+    addTypeFamilyInstance,
+    getTypeFamilyInstances,
     addClass,
     getClasses,
     lookupClass,
@@ -96,7 +98,7 @@ where
 
 import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameText, unqualifiedNameText)
 import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
-import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConInfo (..), dataTypeKey)
+import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConInfo (..), TypeFamilyInstanceInfo (..), dataTypeKey)
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
 import Aihc.Tc.Types
@@ -232,6 +234,8 @@ data TcState = TcState
     tcsInstances :: ![InstanceInfo],
     -- | Standalone data-family instance equations in scope.
     tcsDataFamilyInstances :: ![DataFamilyInstanceInfo],
+    -- | Type-family equations in scope. Closed-family order stays unchanged.
+    tcsTypeFamilyInstances :: ![TypeFamilyInstanceInfo],
     -- | Names of GADT constructors (have non-trivial result types).
     tcsGadtCons :: !(Set Text)
   }
@@ -254,6 +258,7 @@ initTcState =
       tcsClasses = Map.empty,
       tcsInstances = [],
       tcsDataFamilyInstances = [],
+      tcsTypeFamilyInstances = [],
       tcsGadtCons = Set.empty
     }
 
@@ -563,6 +568,16 @@ addDataFamilyInstance instanceInfo = do
 
 getDataFamilyInstances :: TcM [DataFamilyInstanceInfo]
 getDataFamilyInstances = lift $ gets tcsDataFamilyInstances
+
+addTypeFamilyInstance :: TypeFamilyInstanceInfo -> TcM ()
+addTypeFamilyInstance instanceInfo = do
+  instances <- lift $ gets tcsTypeFamilyInstances
+  when (any ((== tfiiAxiomName instanceInfo) . tfiiAxiomName) instances) $
+    abortTc ("duplicate type family instance state key: " <> show (tfiiAxiomName instanceInfo))
+  lift $ modify' $ \state -> state {tcsTypeFamilyInstances = instances <> [instanceInfo]}
+
+getTypeFamilyInstances :: TcM [TypeFamilyInstanceInfo]
+getTypeFamilyInstances = lift $ gets tcsTypeFamilyInstances
 
 addClass :: ClassInfo -> TcM ()
 addClass classInfo = do

--- a/components/aihc-tc/test/Test/Tc/Properties.hs
+++ b/components/aihc-tc/test/Test/Tc/Properties.hs
@@ -22,6 +22,7 @@ import Aihc.Tc
     TcTermKey (..),
     TyConFlavor (..),
     TyConInfo (..),
+    TypeFamilyInstanceInfo (..),
   )
 import Aihc.Tc.Kind (convertSurfaceTypeWithKinds)
 import Aihc.Tc.Monad (emptyTcEnv, freshMetaTv, initTcState, runTcM, writeMetaTv)
@@ -66,7 +67,8 @@ genInterface = do
   tcInterfaceClasses <- optionalEntry (ClassInfo "C" classTyCon (Just ("pkg", moduleName)) [] [] [] [] [])
   tcInterfaceInstances <- optionalEntry (InstanceInfo "C" "$fC" (Just ("pkg", moduleName)) ty [] [] [])
   tcInterfaceDataFamilyInstances <- optionalEntry (DataFamilyInstanceInfo "F" ty [] tyCon "$axF" [] False)
-  pure TcInterface {tcInterfaceTerms, tcInterfaceTyCons, tcInterfaceDataTypes, tcInterfaceClasses, tcInterfaceInstances, tcInterfaceDataFamilyInstances}
+  tcInterfaceTypeFamilyInstances <- optionalEntry (TypeFamilyInstanceInfo "F" "$axF" [] ty ty False)
+  pure TcInterface {tcInterfaceTerms, tcInterfaceTyCons, tcInterfaceDataTypes, tcInterfaceClasses, tcInterfaceInstances, tcInterfaceDataFamilyInstances, tcInterfaceTypeFamilyInstances}
 
 optionalEntry :: value -> Gen [value]
 optionalEntry value = Gen.element [[], [value]]

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -242,11 +242,11 @@ Do not write `core` without `core-v2`.
 | --- | --- | --- |
 | 1 | `feat(fc2): add System FC 2 AST, pretty printer, and parser` | done, #1488 |
 | 2 | `feat(fc2): desugar data types and synonyms to System FC 2` | done, #1489 |
-| 3 | `feat(fc2): desugar values, lambda, application, and case` | open, #1490 |
-| 4 | `feat(fc2): desugar classes to dictionary data types` | this PR |
-| 5 | `feat(fc2): desugar newtypes to types, axioms, and casts` | this PR |
-| 6 | `feat(fc2): desugar data families` | this PR |
-| 7 | `feat(fc2): desugar type families` | this PR |
+| 3 | `feat(fc2): desugar values, lambda, application, and case` | done, #1490 |
+| 4 | `feat(fc2): desugar classes to dictionary data types` | done, #1492 |
+| 5 | `feat(fc2): desugar newtypes to types, axioms, and casts` | done, #1492 |
+| 6 | `feat(fc2): desugar data families` | done, #1492 |
+| 7 | `feat(fc2): desugar type families` | done, #1492 |
 | 8 | `feat(fc2): accept foreign import prim and reject ccall` | planned |
 | 9 | `feat(fc2): write core-v2 from install-v2` | planned |
 | 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -243,10 +243,10 @@ Do not write `core` without `core-v2`.
 | 1 | `feat(fc2): add System FC 2 AST, pretty printer, and parser` | done, #1488 |
 | 2 | `feat(fc2): desugar data types and synonyms to System FC 2` | done, #1489 |
 | 3 | `feat(fc2): desugar values, lambda, application, and case` | open, #1490 |
-| 4 | `feat(fc2): desugar classes to dictionary data types` | planned |
-| 5 | `feat(fc2): desugar newtypes to types, axioms, and casts` | planned |
-| 6 | `feat(fc2): desugar data families` | planned |
-| 7 | `feat(fc2): desugar type families` | planned, needs `aihc-tc` equations |
+| 4 | `feat(fc2): desugar classes to dictionary data types` | this PR |
+| 5 | `feat(fc2): desugar newtypes to types, axioms, and casts` | this PR |
+| 6 | `feat(fc2): desugar data families` | this PR |
+| 7 | `feat(fc2): desugar type families` | this PR |
 | 8 | `feat(fc2): accept foreign import prim and reject ccall` | planned |
 | 9 | `feat(fc2): write core-v2 from install-v2` | planned |
 | 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |


### PR DESCRIPTION
## Summary

Convert checked classes, newtypes, and families into System FC 2.
Keep `Aihc.Fc` and its tests.

Classes become `$Dict$Class` data types.
Method selectors and instance dictionaries stay as `val` bindings.

Newtypes become empty types.
They also become representational axioms and casts.

Data families become empty types.
Each instance adds a hidden representation type and a nominal axiom.

Type families become empty types.
Each equation becomes a named nominal axiom.
`aihc-tc` now stores those equations.
The resolver binds type-family names.

This PR covers steps 4 to 7 of the System FC 2 plan.

## Tests

Add golden-v2 fixtures:

- `class-dictionary.yaml`
- `class-superclass.yaml`
- `class-instance.yaml`
- `newtype-age.yaml`
- `data-family-instance.yaml`
- `newtype-family-instance.yaml`
- `type-family-instance.yaml`

Add an Fc2 axiom fixture:

- `axiom-cast.fc2`

Add a resolver fixture:

- `type-family-instance.yaml`

## Progress

No README progress counts change.
This PR does not switch current Fc goldens.

## Plan

This PR implements steps 4 to 7 of the System FC 2 plan.
The next PR accepts `foreign import prim` and rejects `ccall`.