### PR TITLE
feat(fc2): accept foreign import prim and reject ccall

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -200,6 +200,10 @@ dsDecl env package moduleName' dataTypes tyCons classes dataFamilyInstances type
               (convertTypeFamilyEquation env package moduleName')
               [equation | equation <- typeFamilyInstances, tfiiFamilyName equation == familyName, tfiiClosed equation]
           pure (typeDecl : axioms)
+        Syn.DeclForeign foreignDecl ->
+          case Syn.foreignCallConv foreignDecl of
+            Syn.CPrim -> Right []
+            _ -> Left "System FC 2 accepts only foreign import prim"
         _ -> Right []
 
 lookupDataType :: TyConFlavor -> PackageId -> Text -> Text -> [DataTypeInfo] -> Either String DataTypeInfo
@@ -718,6 +722,7 @@ definitionResolution declaration =
     Syn.DeclNewtype newtypeDeclaration -> nameResolution (binderHeadName (Syn.newtypeDeclHead newtypeDeclaration))
     Syn.DeclClass classDeclaration -> nameResolution (binderHeadName (Syn.classDeclHead classDeclaration))
     Syn.DeclDataFamilyDecl familyDeclaration -> nameResolution (binderHeadName (Syn.dataFamilyDeclHead familyDeclaration))
+    Syn.DeclForeign foreignDecl -> nameResolution (Syn.foreignName foreignDecl)
     _ -> Nothing
 
 nameResolution :: UnqualifiedName -> Maybe ResolutionAnnotation

--- a/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
@@ -43,6 +43,8 @@ convertTopBind :: ConvertEnv -> Fc.FcModuleId -> TopVars -> Fc.FcTopBind -> Eith
 convertTopBind env moduleId tops topBind =
   case topBind of
     Fc.FcTopBind bind -> convertBindDecls env moduleId tops bind
+    Fc.FcPrimitive var _ -> (: []) . DeclPrim <$> convertPrim env moduleId var
+    Fc.FcForeignImport {} -> Left "System FC 2 accepts only foreign import prim"
     _ -> Right []
 
 convertBindDecls :: ConvertEnv -> Fc.FcModuleId -> TopVars -> Fc.FcBind -> Either String [Decl]
@@ -61,6 +63,16 @@ convertVal env moduleId tops var expr = do
         valName = topVarName moduleId var,
         valType = ty,
         valBody = body
+      }
+
+convertPrim :: ConvertEnv -> Fc.FcModuleId -> Fc.Var -> Either String PrimDecl
+convertPrim env moduleId var = do
+  ty <- convertType env (Fc.varType var)
+  pure
+    PrimDecl
+      { primVis = Pub,
+        primName = topVarName moduleId var,
+        primType = ty
       }
 
 convertExpr :: ConvertEnv -> TopVars -> Fc.FcExpr -> Either String Expr
@@ -93,7 +105,7 @@ convertExpr env tops expression =
     Fc.FcCast inner coercion ->
       ExCast <$> convertExpr env tops inner <*> convertCoercion env coercion
     Fc.FcCallForeign {} ->
-      Left "foreign-call terms are not in System FC 2 yet"
+      Left "System FC 2 accepts only foreign import prim"
 
 convertRecBind :: ConvertEnv -> TopVars -> (Fc.Var, Fc.FcExpr) -> Either String Bind
 convertRecBind env tops (var, expr) = do

--- a/components/aihc-fc/test/Test/Fixtures/fc2/foreign-prim.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/foreign-prim.fc2
@@ -1,0 +1,6 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-ccall.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-ccall.yaml
@@ -1,0 +1,9 @@
+extensions:
+  - ForeignFunctionInterface
+modules:
+  - |
+    module Test where
+    data Int = I
+    foreign import ccall unsafe "identity" identityInt :: Int -> Int
+status: fail
+reason: System FC 2 accepts only foreign import prim.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim-use.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim-use.yaml
@@ -1,0 +1,24 @@
+extensions:
+  - ForeignFunctionInterface
+  - GHCForeignImportPrim
+  - MagicHash
+modules:
+  - |
+    module Test where
+    foreign import prim raise# :: a -> b
+    boom x = raise# x
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  foreign import prim 1.vraise# :: ∀(a{10} : 2.tType) (b{11} : 2.tType). a{10} → b{11}
+
+  pub val 1.vboom :: ∀(a{22} : 2.tType) (b{23} : 2.tType). a{22} → b{23}
+   = Λ(a{22} : 2.tType).
+    Λ(b{23} : 2.tType).
+      λ(x{1002} : a{22}).
+        1.vraise# @a{22} @b{23} x{1002}
+status: pass
+reason: A use of a foreign import prim stays an ordinary application.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim.yaml
@@ -1,0 +1,17 @@
+extensions:
+  - ForeignFunctionInterface
+  - GHCForeignImportPrim
+  - MagicHash
+modules:
+  - |
+    module Test where
+    foreign import prim raise# :: a -> b
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.Test where
+
+  foreign import prim 1.vraise# :: ∀(a{10} : 2.tType) (b{11} : 2.tType). a{10} → b{11}
+status: pass
+reason: A foreign import prim keeps its checked type.

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -247,7 +247,7 @@ Do not write `core` without `core-v2`.
 | 5 | `feat(fc2): desugar newtypes to types, axioms, and casts` | done, #1492 |
 | 6 | `feat(fc2): desugar data families` | done, #1492 |
 | 7 | `feat(fc2): desugar type families` | done, #1492 |
-| 8 | `feat(fc2): accept foreign import prim and reject ccall` | in progress |
+| 8 | `feat(fc2): accept foreign import prim and reject ccall` | done, #1493 |
 | 9 | `feat(fc2): write core-v2 from install-v2` | planned |
 | 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |
 

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -206,7 +206,7 @@ Do not rebuild Haskell types in Fc2.
 | `foreign import prim` | `foreign import prim` |
 | `foreign import ccall` | fail the module |
 
-`desugarModuleFc2` already emits data types, synonyms, and values.
+`desugarModuleFc2` already emits data types, synonyms, values, and `foreign import prim`.
 
 ## Tests
 
@@ -247,7 +247,7 @@ Do not write `core` without `core-v2`.
 | 5 | `feat(fc2): desugar newtypes to types, axioms, and casts` | done, #1492 |
 | 6 | `feat(fc2): desugar data families` | done, #1492 |
 | 7 | `feat(fc2): desugar type families` | done, #1492 |
-| 8 | `feat(fc2): accept foreign import prim and reject ccall` | planned |
+| 8 | `feat(fc2): accept foreign import prim and reject ccall` | in progress |
 | 9 | `feat(fc2): write core-v2 from install-v2` | planned |
 | 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |
 


### PR DESCRIPTION
## Summary

Convert a checked `foreign import prim` into a System FC 2 prim declaration.
If desugar sees `ccall`, it fails the module.
Keep `Aihc.Fc` and its tests.

This PR covers step 8 of the System FC 2 plan.

## Tests

Add golden-v2 fixtures:

- `foreign-prim.yaml`
- `foreign-prim-use.yaml`
- `foreign-ccall.yaml`

Add an Fc2 fixture:

- `foreign-prim.fc2`

## Progress

No README progress counts change.
This PR does not switch current Fc goldens.

## Plan

This PR implements step 8 of the System FC 2 plan.
The next PR writes `core-v2` from `install-v2`.