### PR TITLE
feat(fc2): write core-v2 from install-v2

### DIFF
--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -19,6 +19,8 @@ import Aihc.Cli.ResolveArtifact (ResolveArtifact (..), decodeResolveArtifact, en
 import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact, encodeTypeArtifact, encodeTypeInterface)
 import Aihc.Fc (DesugarConfig (..), DesugarResult (..), desugarModuleWithInterface, emptyLintEnv, lintProgram, renderProgram)
+import Aihc.Fc2 (Fc2DesugarResult (..), desugarModuleFc2)
+import Aihc.Fc2 qualified as Fc2
 import Aihc.Hackage.Cabal qualified as HackageCabal
 import Aihc.Hackage.Download qualified as HackageDownload
 import Aihc.Hackage.Util qualified as HackageUtil
@@ -230,6 +232,7 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       resolvePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "resolve.cbor"
       typePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "type.cbor"
       corePath modu = storePath </> moduleDirectory modu </> "core"
+      coreV2Path modu = storePath </> moduleDirectory modu </> "core-v2"
   cachedExports <- tryReadUnitArtifacts hashes resolvePackage resolvePath unit
   (diskExports, resolveResult, resolveChanged) <- case cachedExports of
     Just exports -> do
@@ -275,8 +278,9 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       pure (storedInterfaces, True, Just checked)
   updatedTypeHashes <- updateTypeHashes typePath typeHashes unit
   coreExists <- and <$> mapM (doesFileExist . corePath . sourceModuleAst) unit
+  coreV2Exists <- and <$> mapM (doesFileExist . coreV2Path . sourceModuleAst) unit
   coreChanged <-
-    if typeChanged || not coreExists
+    if typeChanged || not coreExists || not coreV2Exists
       then do
         (checkedModules, completeInterface) <- maybe checkUnit pure checkedResult
         writeCoreFiles verbose primIdentity completeInterface corePath checkedModules
@@ -303,11 +307,14 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
 writeCoreFiles :: (String -> IO ()) -> PackageId -> TcInterface -> (Module -> FilePath) -> [Module] -> IO ()
 writeCoreFiles verbose primIdentity interface corePath checkedModules = do
   let bindings = tcInterfaceBindings interface <> concatMap tcModuleBindings checkedModules
-      results = map (desugarModuleWithInterface (DesugarConfig primIdentity) bindings interface) checkedModules
+      config = DesugarConfig primIdentity
+      results = map (desugarModuleWithInterface config bindings interface) checkedModules
+      results2 = map (desugarModuleFc2 config bindings interface) checkedModules
+  unless (all ds2Success results2) (ioError (userError ("Core-v2 generation failed: " <> unlines (concatMap ds2Errors results2))))
   unless (all dsSuccess results) (ioError (userError ("Core generation failed: " <> unlines (concatMap dsErrors results))))
   let lintFailures =
-        [ (modu, result, errors)
-        | (modu, result) <- zip checkedModules results,
+        [ (modu, result, result2, errors)
+        | (modu, result, result2) <- zip3 checkedModules results results2,
           let errors = lintProgram emptyLintEnv (dsProgram result),
           not (null errors)
         ]
@@ -315,29 +322,46 @@ writeCoreFiles verbose primIdentity interface corePath checkedModules = do
   unless (null lintFailures) $ do
     mapM_ writeBadCore lintFailures
     ioError (userError (unlines ("Core lint failed:" : lintReport)))
-  mapM_ writeCore (zip checkedModules results)
+  mapM_ writeCore (zip3 checkedModules results results2)
   where
-    renderLintFailure (modu, _, errors) =
+    coreV2Path modu = takeDirectory (corePath modu) </> "core-v2"
+
+    renderLintFailure (modu, _, _, errors) =
       ("  module " <> T.unpack (fromMaybe "Main" (moduleName modu)) <> ":")
         : ("    bad Core file: " <> corePath modu <> ".bad")
+        : ("    bad Core-v2 file: " <> coreV2Path modu <> ".bad")
         : map (("    " <>) . show) errors
 
-    writeBadCore (modu, result, _) = do
+    writeBadCore (modu, result, result2, _) = do
       let path = corePath modu <> ".bad"
+          pathV2 = coreV2Path modu <> ".bad"
           name = fromMaybe "Main" (moduleName modu)
       removeFileIfExists (corePath modu)
+      removeFileIfExists (coreV2Path modu)
       writeCoreFile path result
+      writeCoreV2File pathV2 result2
       verbose ("Write bad Core: " <> T.unpack name <> " -> " <> path)
+      verbose ("Write bad Core-v2: " <> T.unpack name <> " -> " <> pathV2)
 
-    writeCore (modu, result) = do
+    writeCore (modu, result, result2) = do
       let path = corePath modu
+          pathV2 = coreV2Path modu
           name = fromMaybe "Main" (moduleName modu)
       removeFileIfExists (path <> ".bad")
+      removeFileIfExists (pathV2 <> ".bad")
       writeCoreFile path result
+      writeCoreV2File pathV2 result2
       verbose ("Write Core: " <> T.unpack name)
+      verbose ("Write Core-v2: " <> T.unpack name)
 
     writeCoreFile path result = do
       let rendered = renderProgram (dsProgram result)
+          output = if "\n" `isSuffixOf` rendered then rendered else rendered <> "\n"
+      createDirectoryIfMissing True (takeDirectory path)
+      writeFile path output
+
+    writeCoreV2File path result = do
+      let rendered = Fc2.renderProgram (ds2Program result)
           output = if "\n" `isSuffixOf` rendered then rendered else rendered <> "\n"
       createDirectoryIfMissing True (takeDirectory path)
       writeFile path output

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -6,10 +6,11 @@ import Aihc.Cli.InstallV2 (InstallV2Result (..), installV2)
 import Aihc.Cli.Options (InstallV2Options (..))
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact)
 import Aihc.Fc qualified as Fc
+import Aihc.Fc2 qualified as Fc2
 import Aihc.Tc (TcInterface (..), tcTermKeyIdentifier)
-import Control.Exception (bracket)
+import Control.Exception (IOException, bracket, try)
 import Data.ByteString qualified as BS
-import Data.List (isPrefixOf, sort)
+import Data.List (isInfixOf, isPrefixOf, sort)
 import Data.Maybe (mapMaybe)
 import Data.Text.IO qualified as TIO
 import Hedgehog (Property, property, success)
@@ -334,7 +335,8 @@ main =
           testCase "duplicates re-exported term signatures in type interfaces" test_installV2TypeReexports,
           testCase "installs direct local dependencies" test_installV2LocalDependencies,
           testCase "rebuilds stale type artifact schemas" test_installV2StaleTypeArtifact,
-          testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope
+          testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope,
+          testCase "writes no core files when System FC 2 desugar fails" test_installV2Fc2DesugarFailure
         ],
       testProperty "Hedgehog options" prop_dummy
     ]
@@ -372,12 +374,19 @@ test_installV2ResolveArtifacts =
     assertFileExists (installV2StorePath first </> "Demo" </> "B" </> "type.cbor")
     assertCoreFile (installV2StorePath first </> "Demo" </> "A" </> "core")
     assertCoreFile (installV2StorePath first </> "Demo" </> "B" </> "core")
+    assertCoreV2File (installV2StorePath first </> "Demo" </> "A" </> "core-v2")
+    assertCoreV2File (installV2StorePath first </> "Demo" </> "B" </> "core-v2")
     second <- installV2 options
     assertEqual "reused modules" ["Demo.A", "Demo.B"] (sort (installV2ReusedModules second))
     assertEqual "stable package directory" (installV2StorePath first) (installV2StorePath second)
+    assertCoreV2File (installV2StorePath second </> "Demo" </> "A" </> "core-v2")
+    assertCoreV2File (installV2StorePath second </> "Demo" </> "B" </> "core-v2")
     removeFile (installV2StorePath first </> "Demo" </> "A" </> "core")
     coreRepaired <- installV2 options
     assertEqual "repairs the complete SCC with cached types" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules coreRepaired))
+    removeFile (installV2StorePath first </> "Demo" </> "A" </> "core-v2")
+    coreV2Repaired <- installV2 options
+    assertEqual "repairs the complete SCC when core-v2 is absent" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules coreV2Repaired))
     writeFile (sourceDir </> "B.hs") "module Demo.B where\nimport Demo.A\nb x = (x)\n"
     changed <- installV2 options
     assertEqual "source changes keep the package directory" (installV2StorePath first) (installV2StorePath changed)
@@ -396,6 +405,55 @@ assertCoreFile path = do
   case Fc.parseProgram core of
     Left parseError -> assertFailure ("invalid Core file " <> path <> ": " <> Fc.renderParseError parseError)
     Right program -> assertEqual ("Core lint errors in " <> path) [] (Fc.lintProgram Fc.emptyLintEnv program)
+
+assertCoreV2File :: FilePath -> Assertion
+assertCoreV2File path = do
+  assertFileExists path
+  core <- TIO.readFile path
+  case Fc2.parseProgram core of
+    Left parseError -> assertFailure ("invalid Core-v2 file " <> path <> ": " <> Fc2.renderParseError parseError)
+    Right _ -> pure ()
+
+test_installV2Fc2DesugarFailure :: Assertion
+test_installV2Fc2DesugarFailure =
+  withTempDir "aihc-install-v2-fc2-ccall" $ \root -> do
+    let sourceRoot = root </> "source"
+        storeRoot = root </> "store"
+        sourceDir = sourceRoot </> "src"
+        options = InstallV2Options sourceRoot (Just storeRoot) False
+    createDirectoryIfMissing True sourceDir
+    writeFile
+      (sourceRoot </> "demo.cabal")
+      ( unlines
+          [ "cabal-version: 3.0",
+            "name: demo",
+            "version: 0.1.0.0",
+            "library",
+            "  exposed-modules: Demo",
+            "  hs-source-dirs: src",
+            "  default-language: Haskell2010",
+            "  default-extensions: ForeignFunctionInterface"
+          ]
+      )
+    writeFile
+      (sourceDir </> "Demo.hs")
+      "module Demo where\ndata Int = I\nforeign import ccall unsafe \"foo\" foo :: Int -> Int\n"
+    caught <- try (installV2 options) :: IO (Either IOException InstallV2Result)
+    case caught of
+      Right _ -> assertFailure "expected install-v2 to fail on foreign import ccall"
+      Left err -> do
+        assertBool
+          ("expected System FC 2 ccall error, got: " <> show err)
+          ("System FC 2 accepts only foreign import prim" `isInfixOf` show err)
+        storeEntries <- listDirectory storeRoot
+        case storeEntries of
+          [packageDir] -> do
+            let moduleDir = storeRoot </> packageDir </> "Demo"
+            coreExists <- doesFileExist (moduleDir </> "core")
+            coreV2Exists <- doesFileExist (moduleDir </> "core-v2")
+            assertBool "writes no core after Fc2 desugar failure" (not coreExists)
+            assertBool "writes no core-v2 after Fc2 desugar failure" (not coreV2Exists)
+          other -> assertFailure ("expected one package directory, got " <> show other)
 
 test_installV2TypeDependencies :: Assertion
 test_installV2TypeDependencies =

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -248,7 +248,7 @@ Do not write `core` without `core-v2`.
 | 6 | `feat(fc2): desugar data families` | done, #1492 |
 | 7 | `feat(fc2): desugar type families` | done, #1492 |
 | 8 | `feat(fc2): accept foreign import prim and reject ccall` | done, #1493 |
-| 9 | `feat(fc2): write core-v2 from install-v2` | planned |
+| 9 | `feat(fc2): write core-v2 from install-v2` | done |
 | 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |
 
 PR 4 depends on PR 3.


### PR DESCRIPTION
`install-v2` still writes `core`.
It also writes `core-v2` next to `core`.

Path:

```text
{store}/{pkg}-{version}-{dephash}/{Module/Path}/core-v2
```

If Fc2 desugar fails, the install fails.
The writer does not write `core` without `core-v2`.
Reuse of a unit needs both files.

Progress counts: no change.