### PR TITLE
feat(fc2): add System FC 2 type linter

### DIFF
--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -283,7 +283,7 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
     if typeChanged || not coreExists || not coreV2Exists
       then do
         (checkedModules, completeInterface) <- maybe checkUnit pure checkedResult
-        writeCoreFiles verbose primIdentity completeInterface corePath checkedModules
+        writeCoreFiles verbose primIdentity completeInterface (takeDirectory storePath) corePath checkedModules
         pure True
       else do
         mapM_ (verbose . ("Reuse Core: " <>) . T.unpack) unitNames
@@ -304,24 +304,38 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
   where
     sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
 
-writeCoreFiles :: (String -> IO ()) -> PackageId -> TcInterface -> (Module -> FilePath) -> [Module] -> IO ()
-writeCoreFiles verbose primIdentity interface corePath checkedModules = do
+writeCoreFiles :: (String -> IO ()) -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> [Module] -> IO ()
+writeCoreFiles verbose primIdentity interface storeRoot corePath checkedModules = do
   let bindings = tcInterfaceBindings interface <> concatMap tcModuleBindings checkedModules
       config = DesugarConfig primIdentity
       results = map (desugarModuleWithInterface config bindings interface) checkedModules
       results2 = map (desugarModuleFc2 config bindings interface) checkedModules
   unless (all ds2Success results2) (ioError (userError ("Core-v2 generation failed: " <> unlines (concatMap ds2Errors results2))))
   unless (all dsSuccess results) (ioError (userError ("Core generation failed: " <> unlines (concatMap dsErrors results))))
+  loadedFc2 <- Fc2.loadScopeClosure (Fc2.storeModuleLoader storeRoot) (map ds2Program results2)
   let lintFailures =
         [ (modu, result, result2, errors)
         | (modu, result, result2) <- zip3 checkedModules results results2,
           let errors = lintProgram emptyLintEnv (dsProgram result),
           not (null errors)
         ]
+      fc2Errors = Fc2.lintPrograms loadedFc2
       lintReport = concatMap renderLintFailure lintFailures
-  unless (null lintFailures) $ do
-    mapM_ writeBadCore lintFailures
-    ioError (userError (unlines ("Core lint failed:" : lintReport)))
+      fc2Report = map (("    " <>) . show) fc2Errors
+  unless (null lintFailures && null fc2Errors) $ do
+    if null lintFailures
+      then mapM_ writeBadFc2 (zip3 checkedModules results results2)
+      else mapM_ writeBadCore lintFailures
+    ioError
+      ( userError
+          ( unlines
+              ( ["Core lint failed:" | not (null lintFailures)]
+                  <> lintReport
+                  <> ["Core-v2 lint failed:" | not (null fc2Errors)]
+                  <> fc2Report
+              )
+          )
+      )
   mapM_ writeCore (zip3 checkedModules results results2)
   where
     coreV2Path modu = takeDirectory (corePath modu) </> "core-v2"
@@ -341,6 +355,14 @@ writeCoreFiles verbose primIdentity interface corePath checkedModules = do
       writeCoreFile path result
       writeCoreV2File pathV2 result2
       verbose ("Write bad Core: " <> T.unpack name <> " -> " <> path)
+      verbose ("Write bad Core-v2: " <> T.unpack name <> " -> " <> pathV2)
+
+    writeBadFc2 (modu, _, result2) = do
+      let pathV2 = coreV2Path modu <> ".bad"
+          name = fromMaybe "Main" (moduleName modu)
+      removeFileIfExists (corePath modu)
+      removeFileIfExists (coreV2Path modu)
+      writeCoreV2File pathV2 result2
       verbose ("Write bad Core-v2: " <> T.unpack name <> " -> " <> pathV2)
 
     writeCore (modu, result, result2) = do

--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -361,6 +361,7 @@ writeCoreFiles verbose primIdentity interface storeRoot corePath checkedModules 
       let pathV2 = coreV2Path modu <> ".bad"
           name = fromMaybe "Main" (moduleName modu)
       removeFileIfExists (corePath modu)
+      removeFileIfExists (corePath modu <> ".bad")
       removeFileIfExists (coreV2Path modu)
       writeCoreV2File pathV2 result2
       verbose ("Write bad Core-v2: " <> T.unpack name <> " -> " <> pathV2)

--- a/components/aihc-fc/aihc-fc.cabal
+++ b/components/aihc-fc/aihc-fc.cabal
@@ -32,6 +32,7 @@ library
     Aihc.Fc2.Convert
     Aihc.Fc2.Desugar
     Aihc.Fc2.FromFc
+    Aihc.Fc2.Lint
     Aihc.Fc2.Name
     Aihc.Fc2.Parser
     Aihc.Fc2.Pretty
@@ -54,6 +55,8 @@ library
     base >=4.16 && <5,
     bytestring,
     containers,
+    directory,
+    filepath,
     libffi >=0.2 && <0.3,
     megaparsec >=9.0 && <10,
     text >=1.2,

--- a/components/aihc-fc/common/Fc2Golden.hs
+++ b/components/aihc-fc/common/Fc2Golden.hs
@@ -12,7 +12,7 @@ module Fc2Golden
 where
 
 import Aihc.Fc.Desugar (DesugarConfig (..))
-import Aihc.Fc2 (Fc2DesugarResult (..), desugarModuleFc2, parseProgram, renderParseError, renderProgram)
+import Aihc.Fc2 (Fc2DesugarResult (..), desugarModuleFc2, lintPrograms, parseProgram, renderParseError, renderProgram)
 import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
 import Aihc.Parser.Syntax (Extension, moduleName, parseExtensionName)
 import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), resolveWithDeps)
@@ -158,7 +158,7 @@ renderFc2Case tc =
                               tcResults
                           fixtureResults = drop supportModuleCount results
                        in if all ds2Success results
-                            then renderResults fixtureResults
+                            then lintAndRenderResults results fixtureResults
                             else Left (unlines (concatMap ds2Errors results))
                     else Left ("typecheck error: " <> unlines [show d | r <- tcResults, d <- tcModuleDiagnostics r])
             ResolveResult {resolveErrors} ->
@@ -180,6 +180,18 @@ renderFc2Case tc =
        in if null errs
             then Right ast
             else Left (show errs)
+    lintAndRenderResults results fixtureResults =
+      case renderResults fixtureResults of
+        Left renderError -> Left renderError
+        Right rendered ->
+          case lintPrograms (map ds2Program results) of
+            [] -> Right rendered
+            lintErrors ->
+              Left
+                ( unlines ["System FC 2 lint error: " <> show lintError | lintError <- lintErrors]
+                    <> "\nSystem FC 2 output:\n"
+                    <> rendered
+                )
     renderResults results =
       unlines <$> traverse renderResult results
     renderResult result =

--- a/components/aihc-fc/src/Aihc/Fc2.hs
+++ b/components/aihc-fc/src/Aihc/Fc2.hs
@@ -10,10 +10,16 @@ module Aihc.Fc2
     Fc2ParseError,
     desugarModuleFc2,
     Fc2DesugarResult (..),
+    lintPrograms,
+    loadScopeClosure,
+    ModuleLoader,
+    storeModuleLoader,
+    LintError (..),
   )
 where
 
 import Aihc.Fc2.Desugar (Fc2DesugarResult (..), desugarModuleFc2)
+import Aihc.Fc2.Lint (LintError (..), ModuleLoader, lintPrograms, loadScopeClosure, storeModuleLoader)
 import Aihc.Fc2.Name
 import Aihc.Fc2.Parser (Fc2ParseError, parseProgram, renderParseError)
 import Aihc.Fc2.Pretty (renderExpr, renderProgram, renderType)

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -17,6 +17,7 @@ import Aihc.Fc2.TypeOf
 import Aihc.Fc2.Wired
 import Aihc.Resolve (PackageId (..), packageIdText)
 import Control.Monad (foldM, unless, when)
+import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (listToMaybe)
@@ -93,7 +94,7 @@ storeModuleLoader storeRoot package moduleName = do
 
 moduleDirectoryText :: Text -> FilePath
 moduleDirectoryText name =
-  foldl' (</>) "" (map T.unpack (T.splitOn "." name))
+  List.foldl' (</>) "" (map T.unpack (T.splitOn "." name))
 
 moduleKey :: Program -> (PackageId, Text)
 moduleKey program =
@@ -110,7 +111,7 @@ registerPrograms :: [Program] -> LintEnv
 registerPrograms programs =
   LintEnv
     { leTypes = typeEnvFromPrograms programs,
-      leAxioms = foldl' addAxiom Map.empty (allDecls programs)
+      leAxioms = List.foldl' addAxiom Map.empty (allDecls programs)
     }
   where
     addAxiom axioms decl =
@@ -537,7 +538,7 @@ coercionEndpoints env coercion =
         Just ty -> Right ty
       pairs <- mapM (coercionEndpoints env) arguments
       checkTyConCoercion env header pairs
-      Right (foldl' TyApp (TyCon name) (map fst pairs), foldl' TyApp (TyCon name) (map snd pairs))
+      Right (List.foldl' TyApp (TyCon name) (map fst pairs), List.foldl' TyApp (TyCon name) (map snd pairs))
     CoAxiom name arguments ->
       case Map.lookup name (leAxioms env) of
         Nothing -> Left (UnboundName name)

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -1,0 +1,517 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Type-check System FC 2 terms and types. Kinds are types.
+module Aihc.Fc2.Lint
+  ( lintPrograms,
+    loadScopeClosure,
+    ModuleLoader,
+    storeModuleLoader,
+    LintError (..),
+  )
+where
+
+import Aihc.Fc2.Name
+import Aihc.Fc2.Parser (parseProgram, renderParseError)
+import Aihc.Fc2.Syntax
+import Aihc.Fc2.TypeOf
+import Aihc.Fc2.Wired
+import Aihc.Resolve (PackageId (..), packageIdText)
+import Control.Monad (foldM, unless, when)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
+import System.Directory (doesFileExist)
+import System.FilePath ((</>))
+
+data LintError
+  = UnboundName !Name
+  | TypeMismatch !String !Type !Type
+  | KindMismatch !String !Type !Type
+  | ShadowedBinder !Name
+  | InconsistentAlts !Type !Type
+  | LintFailure !String
+  deriving (Eq, Show)
+
+data LintEnv = LintEnv
+  { leTypes :: TypeEnv,
+    leAxioms :: Map Name AxiomDecl
+  }
+
+type ModuleLoader = PackageId -> Text -> IO (Maybe Program)
+
+lintPrograms :: [Program] -> [LintError]
+lintPrograms programs =
+  let env = registerPrograms programs
+   in concatMap (lintDeclHeaders env) (allDecls programs)
+        <> concatMap (lintDeclBodies env) (allDecls programs)
+
+loadScopeClosure :: ModuleLoader -> [Program] -> IO [Program]
+loadScopeClosure loader seeds = Map.elems <$> go (Map.fromList [(moduleKey program, program) | program <- seeds]) (concatMap scopeKeys seeds)
+  where
+    go seen [] = pure seen
+    go seen (key : rest)
+      | alreadyLoaded seen key = go seen rest
+      | otherwise = do
+          loaded <- uncurry loader key
+          case loaded of
+            Nothing -> go seen rest
+            Just program ->
+              go (Map.insert key program seen) (rest <> filter (not . alreadyLoaded seen) (scopeKeys program))
+
+    -- Skip a loaded module name. A seed can list a second package identity.
+    alreadyLoaded seen (package, name) =
+      Map.member (package, name) seen
+        || any (\program -> moduleName (programModule program) == name) (Map.elems seen)
+
+storeModuleLoader :: FilePath -> ModuleLoader
+storeModuleLoader storeRoot package moduleName = do
+  let path = storeRoot </> T.unpack (packageIdText package) </> moduleDirectoryText moduleName </> "core-v2"
+  exists <- doesFileExist path
+  if not exists
+    then pure Nothing
+    else do
+      source <- TIO.readFile path
+      case parseProgram source of
+        Left parseError -> fail ("Invalid core-v2 file " <> path <> ": " <> renderParseError parseError)
+        Right program -> pure (Just program)
+
+moduleDirectoryText :: Text -> FilePath
+moduleDirectoryText name =
+  foldl' (</>) "" (map T.unpack (T.splitOn "." name))
+
+moduleKey :: Program -> (PackageId, Text)
+moduleKey program =
+  (modulePackage (programModule program), moduleName (programModule program))
+
+scopeKeys :: Program -> [(PackageId, Text)]
+scopeKeys program =
+  [(package, name) | (_, package, name) <- scopeEntries (programScopes program)]
+
+allDecls :: [Program] -> [Decl]
+allDecls = concatMap programDecls
+
+registerPrograms :: [Program] -> LintEnv
+registerPrograms programs =
+  LintEnv
+    { leTypes = typeEnvFromPrograms programs,
+      leAxioms = foldl' addAxiom Map.empty (allDecls programs)
+    }
+  where
+    addAxiom axioms decl =
+      case decl of
+        DeclAxiom declaration -> Map.insert (axiomName declaration) declaration axioms
+        _ -> axioms
+
+lintDeclHeaders :: LintEnv -> Decl -> [LintError]
+lintDeclHeaders env decl =
+  case decl of
+    DeclType declaration -> lintTypeDecl env declaration
+    DeclSynonym declaration -> lintSynonymDecl env declaration
+    DeclAxiom declaration -> lintAxiomDecl env declaration
+    DeclVal declaration -> eitherToList (lintType env (valType declaration))
+    DeclPrim declaration -> eitherToList (lintType env (primType declaration))
+
+lintDeclBodies :: LintEnv -> Decl -> [LintError]
+lintDeclBodies env decl =
+  case decl of
+    DeclVal declaration ->
+      case lintExpr env (valBody declaration) of
+        Left err -> [err]
+        Right actual ->
+          [TypeMismatch "val body" (valType declaration) actual | not (typesEqual (leTypes env) (valType declaration) actual)]
+    _ -> []
+
+lintTypeDecl :: LintEnv -> TypeDecl -> [LintError]
+lintTypeDecl env declaration =
+  case foldM bindLocal env (typeBinders declaration) of
+    Left err -> [err]
+    Right binderEnv ->
+      eitherToList (lintType binderEnv (typeResult declaration))
+        <> concatMap (eitherToList . lintType env . conType) (typeCons declaration)
+
+lintSynonymDecl :: LintEnv -> SynonymDecl -> [LintError]
+lintSynonymDecl env declaration =
+  case foldM bindLocal env (synBinders declaration) of
+    Left err -> [err]
+    Right binderEnv ->
+      case (lintType binderEnv (synResult declaration), lintType binderEnv (synBody declaration)) of
+        (Left err, _) -> [err]
+        (_, Left err) -> [err]
+        (Right {}, Right bodyKind) ->
+          [KindMismatch "synonym body" (synResult declaration) bodyKind | not (typesEqual (leTypes binderEnv) (synResult declaration) bodyKind)]
+
+lintAxiomDecl :: LintEnv -> AxiomDecl -> [LintError]
+lintAxiomDecl env declaration =
+  case foldM bindLocal env (axiomBinders declaration) of
+    Left err -> [err]
+    Right binderEnv ->
+      case (lintType binderEnv (axiomLeft declaration), lintType binderEnv (axiomRight declaration)) of
+        (Left err, _) -> [err]
+        (_, Left err) -> [err]
+        (Right leftKind, Right rightKind) ->
+          [KindMismatch "axiom sides" leftKind rightKind | not (typesEqual (leTypes binderEnv) leftKind rightKind)]
+
+bindLocal :: LintEnv -> Binder -> Either LintError LintEnv
+bindLocal env binder = do
+  _ <- lintType env (binderType binder)
+  let name = binderName binder
+      types = leTypes env
+  when (Map.member name (teBinders types) || Map.member name (teHeaders types)) (Left (ShadowedBinder name))
+  pure env {leTypes = extendBinder types binder}
+
+lintType :: LintEnv -> Type -> Either LintError Type
+lintType env ty =
+  case ty of
+    TyVar name ->
+      case lookupBinderType (leTypes env) name of
+        Nothing -> Left (UnboundName name)
+        Just kind -> Right kind
+    TyCon name ->
+      case lookupHeaderType (leTypes env) name of
+        Nothing -> Left (UnboundName name)
+        Just kind -> Right kind
+    TyApp function argument -> do
+      functionKind <- lintType env function
+      argumentKind <- lintType env argument
+      applyKind env function functionKind argument argumentKind
+    TyFun r1 r2 argument result -> lintFun env r1 r2 argument result
+    TyForAll binder body -> do
+      binderEnv <- bindLocal env binder
+      lintType binderEnv body
+    TyEq left right -> do
+      leftKind <- lintType env left
+      rightKind <- lintType env right
+      unless (typesEqual (leTypes env) leftKind rightKind) (Left (KindMismatch "equality" leftKind rightKind))
+      case constraintKind env of
+        Nothing -> Left (LintFailure "equality needs GHC.Types.Constraint")
+        Just kind -> Right kind
+
+lintFun :: LintEnv -> Type -> Type -> Type -> Type -> Either LintError Type
+lintFun env r1 r2 argument result = do
+  r1Kind <- lintType env r1
+  r2Kind <- lintType env r2
+  argumentKind <- lintType env argument
+  resultKind <- lintType env result
+  runtimeRep <- runtimeRepKind env
+  typeKind <- typeKindType env
+  unless (typesEqual (leTypes env) r1Kind runtimeRep) (Left (KindMismatch "FUN r1" runtimeRep r1Kind))
+  unless (typesEqual (leTypes env) r2Kind runtimeRep) (Left (KindMismatch "FUN r2" runtimeRep r2Kind))
+  unless (typesEqual (leTypes env) argumentKind (typeAppRep env r1)) (Left (KindMismatch "FUN argument" (typeAppRep env r1) argumentKind))
+  unless (typesEqual (leTypes env) resultKind (typeAppRep env r2)) (Left (KindMismatch "FUN result" (typeAppRep env r2) resultKind))
+  Right typeKind
+
+applyKind :: LintEnv -> Type -> Type -> Type -> Type -> Either LintError Type
+applyKind env function functionKind argument argumentKind =
+  case viewForAll env functionKind of
+    Just (binder, body) -> do
+      unless (kindsCompatible env function (binderType binder) argumentKind) (Left (KindMismatch "type application argument" (binderType binder) argumentKind))
+      Right (substType (binderName binder) argument body)
+    Nothing ->
+      case viewFun env functionKind of
+        Just (_, _, expected, result) -> do
+          unless (kindsCompatible env function expected argumentKind) (Left (KindMismatch "type application argument" expected argumentKind))
+          Right result
+        Nothing -> Left (LintFailure ("type application to a type that is not a pi-type or FUN: " <> show functionKind))
+
+-- TYPE in a stub GHC.Types uses a Type parameter. Accept a RuntimeRep argument.
+kindsCompatible :: LintEnv -> Type -> Type -> Type -> Bool
+kindsCompatible env function expected actual =
+  typesEqual (leTypes env) expected actual
+    || (isTYPEName env function && isTypeKind env expected && isRuntimeRepKind env actual)
+
+isTYPEName :: LintEnv -> Type -> Bool
+isTYPEName env ty =
+  case ty of
+    TyCon name -> isWiredText env name "TYPE"
+    _ -> False
+
+isTypeKind :: LintEnv -> Type -> Bool
+isTypeKind env ty =
+  case typeKindType env of
+    Right expected -> typesEqual (leTypes env) expected ty
+    Left _ -> False
+
+isRuntimeRepKind :: LintEnv -> Type -> Bool
+isRuntimeRepKind env ty =
+  case runtimeRepKind env of
+    Right expected -> typesEqual (leTypes env) expected ty
+    Left _ -> False
+
+isWiredText :: LintEnv -> Name -> Text -> Bool
+isWiredText env name expected =
+  case tePrimPackage (leTypes env) of
+    Nothing -> False
+    Just package -> isGhcTypesOrigin package name && nameText name == expected
+
+viewForAll :: LintEnv -> Type -> Maybe (Binder, Type)
+viewForAll env ty =
+  case reduceType (leTypes env) ty of
+    TyForAll binder body -> Just (binder, body)
+    _ -> Nothing
+
+viewFun :: LintEnv -> Type -> Maybe (Type, Type, Type, Type)
+viewFun env ty =
+  case reduceType (leTypes env) ty of
+    TyFun r1 r2 argument result -> Just (r1, r2, argument, result)
+    _ -> Nothing
+
+typeKindType :: LintEnv -> Either LintError Type
+typeKindType env =
+  case tePrimPackage (leTypes env) of
+    Nothing -> Left (LintFailure "FUN needs a GHC.Types scope")
+    Just package -> Right (typeSynonym package)
+
+runtimeRepKind :: LintEnv -> Either LintError Type
+runtimeRepKind env =
+  case tePrimPackage (leTypes env) of
+    Nothing -> Left (LintFailure "RuntimeRep needs a GHC.Types scope")
+    Just package -> Right (TyCon (runtimeRepConstructor package))
+
+constraintKind :: LintEnv -> Maybe Type
+constraintKind env =
+  TyCon . constraintName <$> tePrimPackage (leTypes env)
+
+typeAppRep :: LintEnv -> Type -> Type
+typeAppRep env representation =
+  case tePrimPackage (leTypes env) of
+    Nothing -> representation
+    Just package -> TyApp (TyCon (typeConstructor package)) representation
+
+lintExpr :: LintEnv -> Expr -> Either LintError Type
+lintExpr env expr =
+  case expr of
+    ExVar name -> lookupTerm env name
+    ExLit literal -> lintLiteral env literal
+    ExApp function argument -> do
+      functionType <- lintExpr env function
+      argumentType <- lintExpr env argument
+      case viewFun env functionType of
+        Just (_, _, expected, result) -> do
+          unless (typesEqual (leTypes env) expected argumentType) (Left (TypeMismatch "application argument" expected argumentType))
+          Right result
+        Nothing -> Left (LintFailure ("application to a non-FUN type: " <> show functionType))
+    ExTyApp function argument -> do
+      functionType <- lintExpr env function
+      argumentKind <- lintType env argument
+      case viewForAll env functionType of
+        Just (binder, body) -> do
+          unless (typesEqual (leTypes env) (binderType binder) argumentKind) (Left (KindMismatch "type application argument" (binderType binder) argumentKind))
+          Right (substType (binderName binder) argument body)
+        Nothing -> Left (LintFailure ("type application to a non-pi type: " <> show functionType))
+    ExLam binder body -> do
+      binderEnv <- bindLocal env binder
+      bodyType <- lintExpr binderEnv body
+      r1 <- representationOf binderEnv (binderType binder)
+      r2 <- representationOf binderEnv bodyType
+      Right (TyFun r1 r2 (binderType binder) bodyType)
+    ExTyLam binder body -> do
+      binderEnv <- bindLocal env binder
+      bodyType <- lintExpr binderEnv body
+      Right (TyForAll binder bodyType)
+    ExLet bind body -> do
+      bindEnv <- lintNonRecBind env bind
+      lintExpr bindEnv body
+    ExRec binds body -> do
+      recEnv <- foldM bindLocal env (map bindBinder binds)
+      mapM_ (lintRecRhs recEnv) binds
+      lintExpr recEnv body
+    ExCase scrutinee binder alts -> lintCase env scrutinee binder alts
+    ExCast body coercion -> do
+      bodyType <- lintExpr env body
+      (source, target) <- coercionEndpoints env coercion
+      unless (typesEqual (leTypes env) bodyType source) (Left (TypeMismatch "cast source" source bodyType))
+      Right target
+
+lintLiteral :: LintEnv -> Literal -> Either LintError Type
+lintLiteral env literal =
+  case literal of
+    LitInt representation _ -> typedRep representation
+    LitChar representation _ -> typedRep representation
+    LitString {} -> typeKindType env
+    LitAddr representation _ -> typedRep representation
+  where
+    typedRep representation = do
+      _ <- lintType env representation
+      Right (typeAppRep env representation)
+
+lookupTerm :: LintEnv -> Name -> Either LintError Type
+lookupTerm env name =
+  case lookupBinderType (leTypes env) name of
+    Just ty -> Right ty
+    Nothing ->
+      case lookupHeaderType (leTypes env) name of
+        Just ty -> Right ty
+        Nothing -> Left (UnboundName name)
+
+lintNonRecBind :: LintEnv -> Bind -> Either LintError LintEnv
+lintNonRecBind env bind = do
+  _ <- lintType env (binderType (bindBinder bind))
+  rhsType <- lintExpr env (bindRhs bind)
+  unless (typesEqual (leTypes env) (binderType (bindBinder bind)) rhsType) (Left (TypeMismatch "let binding" (binderType (bindBinder bind)) rhsType))
+  bindLocal env (bindBinder bind)
+
+lintRecRhs :: LintEnv -> Bind -> Either LintError ()
+lintRecRhs env bind = do
+  rhsType <- lintExpr env (bindRhs bind)
+  unless (typesEqual (leTypes env) (binderType (bindBinder bind)) rhsType) (Left (TypeMismatch "rec binding" (binderType (bindBinder bind)) rhsType))
+
+lintCase :: LintEnv -> Expr -> Binder -> [Alt] -> Either LintError Type
+lintCase env scrutinee binder alts = do
+  scrutType <- lintExpr env scrutinee
+  unless (typesEqual (leTypes env) scrutType (binderType binder)) (Left (TypeMismatch "case binder" scrutType (binderType binder)))
+  caseEnv <- bindLocal env binder
+  case alts of
+    [] -> Left (LintFailure "case expression has no alternatives")
+    first : rest -> do
+      resultType <- lintAlt caseEnv scrutType first
+      mapM_ (lintAltExpected caseEnv scrutType resultType) rest
+      Right resultType
+
+lintAltExpected :: LintEnv -> Type -> Type -> Alt -> Either LintError ()
+lintAltExpected env scrutType expected alt = do
+  actual <- lintAlt env scrutType alt
+  unless (typesEqual (leTypes env) expected actual) (Left (InconsistentAlts expected actual))
+
+lintAlt :: LintEnv -> Type -> Alt -> Either LintError Type
+lintAlt env scrutType alt =
+  case altCon alt of
+    AltDefault -> do
+      unless (null (altBinders alt)) (Left (LintFailure "default alternative has field binders"))
+      lintExpr env (altRhs alt)
+    AltLit literal -> do
+      unless (null (altBinders alt)) (Left (LintFailure "literal alternative has field binders"))
+      _ <- lintLiteral env literal
+      lintExpr env (altRhs alt)
+    AltData name ->
+      case lookupHeaderType (leTypes env) name of
+        Nothing -> Left (UnboundName name)
+        Just constructorType -> do
+          (existentials, fields) <- matchConstructor env constructorType scrutType
+          unless (length fields == length (altBinders alt)) (Left (LintFailure ("case alternative binder count does not match constructor: " <> show name)))
+          envEx <- foldM bindLocal env existentials
+          envFields <- foldM bindField envEx (zip fields (altBinders alt))
+          lintExpr envFields (altRhs alt)
+
+bindField :: LintEnv -> (Type, Binder) -> Either LintError LintEnv
+bindField env (expected, binder) = do
+  env' <- bindLocal env binder
+  unless (typesEqual (leTypes env) expected (binderType binder)) (Left (TypeMismatch "case alternative binder" expected (binderType binder)))
+  Right env'
+
+matchConstructor :: LintEnv -> Type -> Type -> Either LintError ([Binder], [Type])
+matchConstructor env constructorType scrutType = do
+  let (foralls, fields, result) = splitConType env constructorType
+  subst <- matchExpected env (map binderName foralls) Map.empty result scrutType
+  let existentials = [binder | binder <- foralls, binderName binder `Map.notMember` subst]
+      substituted = map (applySubst subst) fields
+  Right (existentials, substituted)
+
+splitConType :: LintEnv -> Type -> ([Binder], [Type], Type)
+splitConType env ty =
+  case ty of
+    TyForAll binder body ->
+      let (binders, fields, result) = splitConType env body
+       in (binder : binders, fields, result)
+    TyFun _ _ argument body ->
+      let (binders, fields, result) = splitConType env body
+       in (binders, argument : fields, result)
+    other ->
+      let reduced = reduceType (leTypes env) other
+       in if reduced == other
+            then ([], [], other)
+            else splitConType env reduced
+
+matchExpected :: LintEnv -> [Name] -> Map Name Type -> Type -> Type -> Either LintError (Map Name Type)
+matchExpected env foralls subst expected actual =
+  case (expected, actual) of
+    (TyVar name, _)
+      | name `elem` foralls ->
+          case Map.lookup name subst of
+            Nothing -> Right (Map.insert name actual subst)
+            Just previous -> do
+              unless (typesEqual (leTypes env) previous actual) (Left (TypeMismatch "constructor result" previous actual))
+              Right subst
+    _ -> matchReduced env foralls subst (reduceType (leTypes env) expected) (reduceType (leTypes env) actual)
+
+matchReduced :: LintEnv -> [Name] -> Map Name Type -> Type -> Type -> Either LintError (Map Name Type)
+matchReduced env foralls subst expected actual =
+  case (expected, actual) of
+    (TyVar name, _)
+      | name `elem` foralls -> matchExpected env foralls subst expected actual
+      | TyVar other <- actual,
+        name == other ->
+          Right subst
+      | otherwise -> Left (TypeMismatch "constructor result" expected actual)
+    (TyCon left, TyCon right)
+      | left == right -> Right subst
+    (TyApp function1 argument1, TyApp function2 argument2) -> do
+      subst' <- matchExpected env foralls subst function1 function2
+      matchExpected env foralls subst' argument1 argument2
+    (TyFun r1a r2a a1 b1, TyFun r1b r2b a2 b2) -> do
+      subst1 <- matchExpected env foralls subst r1a r1b
+      subst2 <- matchExpected env foralls subst1 r2a r2b
+      subst3 <- matchExpected env foralls subst2 a1 a2
+      matchExpected env foralls subst3 b1 b2
+    (TyEq a1 b1, TyEq a2 b2) -> do
+      subst' <- matchExpected env foralls subst a1 a2
+      matchExpected env foralls subst' b1 b2
+    _
+      | typesEqual (leTypes env) expected actual -> Right subst
+      | otherwise -> Left (TypeMismatch "constructor result" expected actual)
+
+applySubst :: Map Name Type -> Type -> Type
+applySubst subst ty = Map.foldrWithKey substType ty subst
+
+coercionEndpoints :: LintEnv -> Coercion -> Either LintError (Type, Type)
+coercionEndpoints env coercion =
+  case coercion of
+    CoVar name -> do
+      ty <- lookupTerm env name
+      case reduceType (leTypes env) ty of
+        TyEq left right -> Right (left, right)
+        _ -> Left (LintFailure ("coercion variable does not have an equality type: " <> show name))
+    CoRefl ty -> do
+      _ <- lintType env ty
+      Right (ty, ty)
+    CoSym inner -> do
+      (left, right) <- coercionEndpoints env inner
+      Right (right, left)
+    CoTrans left right -> do
+      (from, middleLeft) <- coercionEndpoints env left
+      (middleRight, to) <- coercionEndpoints env right
+      unless (typesEqual (leTypes env) middleLeft middleRight) (Left (TypeMismatch "coercion transitivity" middleLeft middleRight))
+      Right (from, to)
+    CoTyConApp name arguments -> do
+      _ <- case lookupHeaderType (leTypes env) name of
+        Nothing -> Left (UnboundName name)
+        Just header -> Right header
+      pairs <- mapM (coercionEndpoints env) arguments
+      Right (foldl TyApp (TyCon name) (map fst pairs), foldl TyApp (TyCon name) (map snd pairs))
+    CoAxiom name arguments ->
+      case Map.lookup name (leAxioms env) of
+        Nothing -> Left (UnboundName name)
+        Just declaration -> do
+          unless (length arguments == length (axiomBinders declaration)) (Left (LintFailure ("coercion axiom arity mismatch: " <> show name)))
+          envBinders <- foldM bindLocal env (axiomBinders declaration)
+          mapM_ (lintType env) arguments
+          let subst = Map.fromList (zip (map binderName (axiomBinders declaration)) arguments)
+          mapM_
+            ( \(binder, argument) -> do
+                argumentKind <- lintType env argument
+                unless (typesEqual (leTypes envBinders) (applySubst subst (binderType binder)) argumentKind) (Left (KindMismatch "coercion axiom argument" (binderType binder) argumentKind))
+            )
+            (zip (axiomBinders declaration) arguments)
+          Right (applySubst subst (axiomLeft declaration), applySubst subst (axiomRight declaration))
+
+representationOf :: LintEnv -> Type -> Either LintError Type
+representationOf env ty = do
+  kind <- lintType env ty
+  case reduceType (leTypes env) kind of
+    TyApp (TyCon name) representation
+      | isWiredText env name "TYPE" -> Right representation
+    other -> Left (LintFailure ("term type does not have a TYPE representation: " <> show other))
+
+eitherToList :: Either LintError a -> [LintError]
+eitherToList = either pure (const [])

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -358,12 +358,20 @@ stringLiteralType env =
 
 namedType :: LintEnv -> [Text] -> Maybe Name
 namedType env candidates =
-  listToMaybe
-    [ name
-    | name <- Map.keys (teHeaders (leTypes env)),
-      nameText name `elem` candidates,
-      nameClass (nameSort name) == NameClassType
-    ]
+  listToMaybe (ghcTypesNames <> otherNames)
+  where
+    matches =
+      [ name
+      | name <- Map.keys (teHeaders (leTypes env)),
+        nameText name `elem` candidates,
+        nameClass (nameSort name) == NameClassType
+      ]
+    fromGhcTypes name =
+      case tePrimPackage (leTypes env) of
+        Just package -> isGhcTypesOrigin package name
+        Nothing -> False
+    ghcTypesNames = filter fromGhcTypes matches
+    otherNames = filter (not . fromGhcTypes) matches
 
 missingTypeName :: LintEnv -> Text -> Name
 missingTypeName env text =
@@ -430,20 +438,9 @@ lintAlt env scrutType alt =
           lintExpr envFields (altRhs alt)
 
 matchLiteralAlternative :: LintEnv -> Type -> Literal -> Either LintError ()
-matchLiteralAlternative env scrutType literal =
-  case literal of
-    LitInt representation _ -> matchLiteralRep env scrutType representation
-    LitChar representation _ -> matchLiteralRep env scrutType representation
-    LitAddr representation _ -> matchLiteralRep env scrutType representation
-    LitString {} -> do
-      stringType <- stringLiteralType env
-      unless (typesEqual (leTypes env) stringType scrutType) (Left (TypeMismatch "literal alternative" scrutType stringType))
-
-matchLiteralRep :: LintEnv -> Type -> Type -> Either LintError ()
-matchLiteralRep env scrutType representation = do
-  _ <- lintType env representation
-  scrutRep <- representationOf env scrutType
-  unless (typesEqual (leTypes env) scrutRep representation) (Left (TypeMismatch "literal alternative" scrutType representation))
+matchLiteralAlternative env scrutType literal = do
+  literalType <- lintLiteral env literal
+  unless (typesEqual (leTypes env) scrutType literalType) (Left (TypeMismatch "literal alternative" scrutType literalType))
 
 bindField :: LintEnv -> (Type, Binder) -> Either LintError LintEnv
 bindField env (expected, binder) = do

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -19,6 +19,7 @@ import Aihc.Resolve (PackageId (..), packageIdText)
 import Control.Monad (foldM, unless, when)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (listToMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -60,10 +61,23 @@ loadScopeClosure loader seeds = Map.elems <$> go (Map.fromList [(moduleKey progr
             Just program ->
               go (Map.insert key program seen) (rest <> filter (not . alreadyLoaded seen) (scopeKeys program))
 
-    -- Skip a loaded module name. A seed can list a second package identity.
     alreadyLoaded seen (package, name) =
       Map.member (package, name) seen
-        || any (\program -> moduleName (programModule program) == name) (Map.elems seen)
+        || (isEmptyPackage package && hasModuleName seen name)
+        || hasEmptyPackageModule seen name
+
+    isEmptyPackage package = packageIdText package == ""
+
+    hasModuleName seen name =
+      any (\program -> moduleName (programModule program) == name) (Map.elems seen)
+
+    hasEmptyPackageModule seen name =
+      any
+        ( \program ->
+            moduleName (programModule program) == name
+              && isEmptyPackage (modulePackage (programModule program))
+        )
+        (Map.elems seen)
 
 storeModuleLoader :: FilePath -> ModuleLoader
 storeModuleLoader storeRoot package moduleName = do
@@ -215,7 +229,6 @@ applyKind env function functionKind argument argumentKind =
           Right result
         Nothing -> Left (LintFailure ("type application to a type that is not a pi-type or FUN: " <> show functionKind))
 
--- TYPE in a stub GHC.Types uses a Type parameter. Accept a RuntimeRep argument.
 kindsCompatible :: LintEnv -> Type -> Type -> Type -> Bool
 kindsCompatible env function expected actual =
   typesEqual (leTypes env) expected actual
@@ -329,12 +342,34 @@ lintLiteral env literal =
   case literal of
     LitInt representation _ -> typedRep representation
     LitChar representation _ -> typedRep representation
-    LitString {} -> typeKindType env
+    LitString {} -> stringLiteralType env
     LitAddr representation _ -> typedRep representation
   where
     typedRep representation = do
       _ <- lintType env representation
       Right (typeAppRep env representation)
+
+stringLiteralType :: LintEnv -> Either LintError Type
+stringLiteralType env =
+  case (namedType env ["[]", "List"], namedType env ["Char"]) of
+    (Just listName, Just charName) -> Right (TyApp (TyCon listName) (TyCon charName))
+    (Nothing, _) -> Left (UnboundName (missingTypeName env "[]"))
+    (_, Nothing) -> Left (UnboundName (missingTypeName env "Char"))
+
+namedType :: LintEnv -> [Text] -> Maybe Name
+namedType env candidates =
+  listToMaybe
+    [ name
+    | name <- Map.keys (teHeaders (leTypes env)),
+      nameText name `elem` candidates,
+      nameClass (nameSort name) == NameClassType
+    ]
+
+missingTypeName :: LintEnv -> Text -> Name
+missingTypeName env text =
+  case tePrimPackage (leTypes env) of
+    Just package -> Name text SortTypeConstructor (OriginTop package ghcTypesModule)
+    Nothing -> Name text SortTypeConstructor (OriginTop (PackageId "") "")
 
 lookupTerm :: LintEnv -> Name -> Either LintError Type
 lookupTerm env name =
@@ -382,7 +417,7 @@ lintAlt env scrutType alt =
       lintExpr env (altRhs alt)
     AltLit literal -> do
       unless (null (altBinders alt)) (Left (LintFailure "literal alternative has field binders"))
-      _ <- lintLiteral env literal
+      matchLiteralAlternative env scrutType literal
       lintExpr env (altRhs alt)
     AltData name ->
       case lookupHeaderType (leTypes env) name of
@@ -393,6 +428,22 @@ lintAlt env scrutType alt =
           envEx <- foldM bindLocal env existentials
           envFields <- foldM bindField envEx (zip fields (altBinders alt))
           lintExpr envFields (altRhs alt)
+
+matchLiteralAlternative :: LintEnv -> Type -> Literal -> Either LintError ()
+matchLiteralAlternative env scrutType literal =
+  case literal of
+    LitInt representation _ -> matchLiteralRep env scrutType representation
+    LitChar representation _ -> matchLiteralRep env scrutType representation
+    LitAddr representation _ -> matchLiteralRep env scrutType representation
+    LitString {} -> do
+      stringType <- stringLiteralType env
+      unless (typesEqual (leTypes env) stringType scrutType) (Left (TypeMismatch "literal alternative" scrutType stringType))
+
+matchLiteralRep :: LintEnv -> Type -> Type -> Either LintError ()
+matchLiteralRep env scrutType representation = do
+  _ <- lintType env representation
+  scrutRep <- representationOf env scrutType
+  unless (typesEqual (leTypes env) scrutRep representation) (Left (TypeMismatch "literal alternative" scrutType representation))
 
 bindField :: LintEnv -> (Type, Binder) -> Either LintError LintEnv
 bindField env (expected, binder) = do
@@ -484,11 +535,12 @@ coercionEndpoints env coercion =
       unless (typesEqual (leTypes env) middleLeft middleRight) (Left (TypeMismatch "coercion transitivity" middleLeft middleRight))
       Right (from, to)
     CoTyConApp name arguments -> do
-      _ <- case lookupHeaderType (leTypes env) name of
+      header <- case lookupHeaderType (leTypes env) name of
         Nothing -> Left (UnboundName name)
-        Just header -> Right header
+        Just ty -> Right ty
       pairs <- mapM (coercionEndpoints env) arguments
-      Right (foldl TyApp (TyCon name) (map fst pairs), foldl TyApp (TyCon name) (map snd pairs))
+      checkTyConCoercion env header pairs
+      Right (foldl' TyApp (TyCon name) (map fst pairs), foldl' TyApp (TyCon name) (map snd pairs))
     CoAxiom name arguments ->
       case Map.lookup name (leAxioms env) of
         Nothing -> Left (UnboundName name)
@@ -504,6 +556,35 @@ coercionEndpoints env coercion =
             )
             (zip (axiomBinders declaration) arguments)
           Right (applySubst subst (axiomLeft declaration), applySubst subst (axiomRight declaration))
+
+checkTyConCoercion :: LintEnv -> Type -> [(Type, Type)] -> Either LintError ()
+checkTyConCoercion env = go
+  where
+    go ty [] =
+      case viewForAll env ty of
+        Just {} -> Left (LintFailure "type constructor coercion arity mismatch")
+        Nothing ->
+          case viewFun env ty of
+            Just {} -> Left (LintFailure "type constructor coercion arity mismatch")
+            Nothing -> Right ()
+    go ty ((left, right) : rest) =
+      case viewForAll env ty of
+        Just (binder, body) -> do
+          checkCoercionArgumentKind env (binderType binder) left right
+          go (substType (binderName binder) left body) rest
+        Nothing ->
+          case viewFun env ty of
+            Just (_, _, expected, result) -> do
+              checkCoercionArgumentKind env expected left right
+              go result rest
+            Nothing -> Left (LintFailure "type constructor coercion arity mismatch")
+
+checkCoercionArgumentKind :: LintEnv -> Type -> Type -> Type -> Either LintError ()
+checkCoercionArgumentKind env expected left right = do
+  leftKind <- lintType env left
+  rightKind <- lintType env right
+  unless (typesEqual (leTypes env) expected leftKind) (Left (KindMismatch "type constructor coercion argument" expected leftKind))
+  unless (typesEqual (leTypes env) expected rightKind) (Left (KindMismatch "type constructor coercion argument" expected rightKind))
 
 representationOf :: LintEnv -> Type -> Either LintError Type
 representationOf env ty = do

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -5,6 +5,7 @@ module Aihc.Fc2.TypeOf
   ( TypeEnv (..),
     emptyTypeEnv,
     typeEnvFromProgram,
+    typeEnvFromPrograms,
     typeOf,
     unfoldType,
     unfoldRep,
@@ -14,6 +15,11 @@ module Aihc.Fc2.TypeOf
     headerType,
     applyType,
     lookupBinderType,
+    lookupHeaderType,
+    extendBinder,
+    substType,
+    reduceType,
+    typesEqual,
   )
 where
 
@@ -23,6 +29,7 @@ import Aihc.Fc2.Wired
 import Aihc.Resolve (PackageId)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
+import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
 
 -- | Local headers, synonym bodies, and binder types used by typeOf.
@@ -45,30 +52,48 @@ emptyTypeEnv =
 
 typeEnvFromProgram :: Program -> TypeEnv
 typeEnvFromProgram program =
-  foldl addDecl baseEnv (programDecls program)
+  typeEnvFromPrograms [program]
+
+-- | Register every header from every program. Later programs replace equal names.
+typeEnvFromPrograms :: [Program] -> TypeEnv
+typeEnvFromPrograms programs =
+  foldl' addProgram baseEnv programs
   where
     baseEnv =
       emptyTypeEnv
-        { tePrimPackage = primPackageFromScopes (programScopes program)
+        { tePrimPackage = listToMaybe (mapMaybe (primPackageFromScopes . programScopes) programs)
         }
-    addDecl env decl =
-      case decl of
-        DeclType declaration ->
-          env {teHeaders = Map.insert (typeName declaration) (headerType (typeBinders declaration) (typeResult declaration)) (teHeaders env)}
-        DeclSynonym declaration ->
-          env
-            { teHeaders = Map.insert (synName declaration) (headerType (synBinders declaration) (synResult declaration)) (teHeaders env),
-              teSynonyms = Map.insert (synName declaration) (foldr TyForAll (synBody declaration) (synBinders declaration)) (teSynonyms env)
-            }
-        DeclAxiom {} -> env
-        DeclVal {} -> env
-        DeclPrim {} -> env
+    addProgram env program = foldl' addDecl env (programDecls program)
+
+addDecl :: TypeEnv -> Decl -> TypeEnv
+addDecl env decl =
+  case decl of
+    DeclType declaration ->
+      env {teHeaders = foldl' addConstructor (Map.insert (typeName declaration) (headerType (typeBinders declaration) (typeResult declaration)) (teHeaders env)) (typeCons declaration)}
+      where
+        addConstructor headers constructor = Map.insert (conName constructor) (conType constructor) headers
+    DeclSynonym declaration ->
+      env
+        { teHeaders = Map.insert (synName declaration) (headerType (synBinders declaration) (synResult declaration)) (teHeaders env),
+          teSynonyms = Map.insert (synName declaration) (foldr TyForAll (synBody declaration) (synBinders declaration)) (teSynonyms env)
+        }
+    DeclAxiom {} -> env
+    DeclVal declaration ->
+      env {teHeaders = Map.insert (valName declaration) (valType declaration) (teHeaders env)}
+    DeclPrim declaration ->
+      env {teHeaders = Map.insert (primName declaration) (primType declaration) (teHeaders env)}
 
 headerType :: [Binder] -> Type -> Type
 headerType binders result = foldr TyForAll result binders
 
 lookupBinderType :: TypeEnv -> Name -> Maybe Type
 lookupBinderType env name = Map.lookup name (teBinders env)
+
+lookupHeaderType :: TypeEnv -> Name -> Maybe Type
+lookupHeaderType env name =
+  case Map.lookup name (teHeaders env) of
+    Just header -> Just header
+    Nothing -> wiredTypeOf env name
 
 typeOf :: TypeEnv -> Type -> Maybe Type
 typeOf env ty =
@@ -205,6 +230,12 @@ wiredTypeOf env name =
       | nameText name == "Levity" -> Just (typeSynonym package)
       | nameText name == "LiftedRep" -> Just (TyCon (runtimeRepConstructor package))
       | nameText name == "UnliftedRep" -> Just (TyCon (runtimeRepConstructor package))
+      | nameText name == "BoxedRep" ->
+          do
+            lifted <- liftedRepType env
+            Just (TyFun lifted lifted (TyCon (levityConstructor package)) (TyCon (runtimeRepConstructor package)))
+      | nameText name == "Lifted" -> Just (TyCon (levityConstructor package))
+      | nameText name == "Unlifted" -> Just (TyCon (levityConstructor package))
       | otherwise -> Nothing
 
 typeAppTYPE :: TypeEnv -> Type -> Type
@@ -216,3 +247,39 @@ typeAppTYPE env representation =
 liftedRepType :: TypeEnv -> Maybe Type
 liftedRepType env =
   TyCon . liftedRepName <$> tePrimPackage env
+
+-- | Unfold synonyms and wired Type, then compare structure.
+reduceType :: TypeEnv -> Type -> Type
+reduceType env ty =
+  case ty of
+    TyVar {} -> ty
+    TyCon {} ->
+      let unfolded = unfoldRep env (unfoldType env ty)
+       in if unfolded == ty then ty else reduceType env unfolded
+    TyApp function argument ->
+      case reduceType env function of
+        TyForAll binder body ->
+          reduceType env (substType (binderName binder) argument body)
+        function' -> TyApp function' (reduceType env argument)
+    TyFun r1 r2 argument result ->
+      TyFun (reduceType env r1) (reduceType env r2) (reduceType env argument) (reduceType env result)
+    TyForAll binder body ->
+      TyForAll binder {binderType = reduceType env (binderType binder)} (reduceType env body)
+    TyEq left right ->
+      TyEq (reduceType env left) (reduceType env right)
+
+typesEqual :: TypeEnv -> Type -> Type -> Bool
+typesEqual env left right =
+  eq (reduceType env left) (reduceType env right)
+  where
+    eq (TyVar a) (TyVar b) = a == b
+    eq (TyCon a) (TyCon b) = a == b
+    eq (TyApp function1 argument1) (TyApp function2 argument2) =
+      eq function1 function2 && eq argument1 argument2
+    eq (TyFun r1a r2a a1 b1) (TyFun r1b r2b a2 b2) =
+      eq r1a r1b && eq r2a r2b && eq a1 a2 && eq b1 b2
+    eq (TyForAll binder1 body1) (TyForAll binder2 body2) =
+      eq (binderType binder1) (binderType binder2)
+        && typesEqual env body1 (substType (binderName binder2) (TyVar (binderName binder1)) body2)
+    eq (TyEq a1 b1) (TyEq a2 b2) = eq a1 a2 && eq b1 b2
+    eq _ _ = False

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -101,9 +101,7 @@ typeOf env ty =
     TyVar name ->
       Map.lookup name (teBinders env)
     TyCon name ->
-      case Map.lookup name (teHeaders env) of
-        Just header -> Just header
-        Nothing -> wiredTypeOf env name
+      lookupHeaderType env name
     TyApp function argument ->
       do
         functionType <- typeOf env function
@@ -129,14 +127,14 @@ unfoldType :: TypeEnv -> Type -> Type
 unfoldType env ty =
   case ty of
     TyCon name
+      | Just body <- Map.lookup name (teSynonyms env) ->
+          unfoldType env (stripForAlls body)
       | isWiredName env name "Type",
         Just representation <- liftedRepType env ->
           typeAppTYPE env representation
       | isWiredName env name "Constraint",
         Just representation <- liftedRepType env ->
           typeAppTYPE env representation
-      | Just body <- Map.lookup name (teSynonyms env) ->
-          unfoldType env (stripForAlls body)
       | isWiredName env name "TYPE" -> ty
       | isWiredName env name "RuntimeRep" -> ty
       | isWiredName env name "Levity" -> ty
@@ -150,6 +148,8 @@ unfoldRep :: TypeEnv -> Type -> Type
 unfoldRep env ty =
   case ty of
     TyCon name
+      | Just body <- Map.lookup name (teSynonyms env) ->
+          unfoldRep env (stripForAlls body)
       | isWiredName env name "LiftedRep",
         Just package <- tePrimPackage env ->
           TyApp (TyCon (boxedRepName package)) (TyCon (liftedName package))

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -27,6 +27,7 @@ import Aihc.Fc2.Name
 import Aihc.Fc2.Syntax
 import Aihc.Fc2.Wired
 import Aihc.Resolve (PackageId)
+import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (listToMaybe, mapMaybe)
@@ -57,19 +58,19 @@ typeEnvFromProgram program =
 -- | Register every header from every program. Later programs replace equal names.
 typeEnvFromPrograms :: [Program] -> TypeEnv
 typeEnvFromPrograms programs =
-  foldl' addProgram baseEnv programs
+  List.foldl' addProgram baseEnv programs
   where
     baseEnv =
       emptyTypeEnv
         { tePrimPackage = listToMaybe (mapMaybe (primPackageFromScopes . programScopes) programs)
         }
-    addProgram env program = foldl' addDecl env (programDecls program)
+    addProgram env program = List.foldl' addDecl env (programDecls program)
 
 addDecl :: TypeEnv -> Decl -> TypeEnv
 addDecl env decl =
   case decl of
     DeclType declaration ->
-      env {teHeaders = foldl' addConstructor (Map.insert (typeName declaration) (headerType (typeBinders declaration) (typeResult declaration)) (teHeaders env)) (typeCons declaration)}
+      env {teHeaders = List.foldl' addConstructor (Map.insert (typeName declaration) (headerType (typeBinders declaration) (typeResult declaration)) (teHeaders env)) (typeCons declaration)}
       where
         addConstructor headers constructor = Map.insert (conName constructor) (conType constructor) headers
     DeclSynonym declaration ->

--- a/components/aihc-fc/test/Spec.hs
+++ b/components/aihc-fc/test/Spec.hs
@@ -5,7 +5,7 @@ import System.Environment (lookupEnv)
 import Test.Fc.Properties (fcPropertyTests)
 import Test.Fc.Suite (fcGoldenTests, fcLintTests)
 import Test.Fc2.Properties (fc2PropertyTests)
-import Test.Fc2.Suite (fc2FixtureTests, fc2GoldenTests)
+import Test.Fc2.Suite (fc2FixtureTests, fc2GoldenTests, fc2LintTests)
 import Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
@@ -16,5 +16,6 @@ main = do
     _ -> do
       golden <- fcGoldenTests
       fc2 <- fc2FixtureTests
+      fc2Lint <- fc2LintTests
       fc2Golden <- fc2GoldenTests
-      defaultMain (testGroup "aihc-fc" [fcLintTests, golden, fcPropertyTests, fc2, fc2Golden, fc2PropertyTests])
+      defaultMain (testGroup "aihc-fc" [fcLintTests, golden, fcPropertyTests, fc2, fc2Lint, fc2Golden, fc2PropertyTests])

--- a/components/aihc-fc/test/Test/Fc2/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc2/Suite.hs
@@ -8,15 +8,16 @@ module Test.Fc2.Suite
   )
 where
 
-import Aihc.Fc2 (Program, lintPrograms, parseProgram, renderParseError, renderProgram)
+import Aihc.Fc2 (LintError (..), Program, lintPrograms, loadScopeClosure, parseProgram, renderParseError, renderProgram, storeModuleLoader)
+import Control.Exception (IOException, try)
 import Data.Char (isSpace)
-import Data.List (dropWhileEnd, sort)
+import Data.List (dropWhileEnd, isInfixOf, sort)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Fc2Golden (Fc2Case (..), Outcome (..), evaluateFc2Case, loadFc2Cases)
-import System.Directory (doesDirectoryExist, listDirectory)
-import System.FilePath (takeExtension, (</>))
+import System.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive)
+import System.FilePath (takeExtension, takeFileName, (</>))
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
 
@@ -72,7 +73,7 @@ lintFileTest expectPass path = testCase path $ do
   let errors = lintPrograms [program]
   if expectPass
     then assertEqual (path <> " lint errors") [] errors
-    else assertBool (path <> " expected lint errors") (not (null errors))
+    else assertBool (path <> " expected lint errors") (matchesFail path errors)
 
 mutualLintTests :: FilePath -> IO TestTree
 mutualLintTests dir = do
@@ -91,9 +92,72 @@ mutualLintTests dir = do
                     "a single mutual file must fail lint"
                     (not (null (lintPrograms [program])))
               )
-              programs
+              programs,
+          scopeLoaderTest
         ]
     )
+
+scopeLoaderTest :: TestTree
+scopeLoaderTest = testCase "loadScopeClosure loads a scoped module from the store" $ do
+  tmp <- getTemporaryDirectory
+  let store = tmp </> "aihc-fc2-lint-scope"
+      typesDir = store </> "aihc-prim" </> "GHC" </> "Types"
+      primDir = store </> "aihc-prim" </> "GHC" </> "Prim"
+  ignoreMissing (removeDirectoryRecursive store)
+  createDirectoryIfMissing True typesDir
+  createDirectoryIfMissing True primDir
+  copyFile (lintRoot </> "mutual" </> "GHC.Types.fc2") (typesDir </> "core-v2")
+  copyFile (lintRoot </> "mutual" </> "GHC.Prim.fc2") (primDir </> "core-v2")
+  seed <- loadFc2Program (lintRoot </> "mutual" </> "GHC.Types.fc2")
+  loaded <- loadScopeClosure (storeModuleLoader store) [seed]
+  ignoreMissing (removeDirectoryRecursive store)
+  assertEqual "loaded module count" 2 (length loaded)
+  assertEqual "closure lint errors" [] (lintPrograms loaded)
+
+ignoreMissing :: IO () -> IO ()
+ignoreMissing action = do
+  result <- try action :: IO (Either IOException ())
+  case result of
+    Left _ -> pure ()
+    Right () -> pure ()
+
+matchesFail :: FilePath -> [LintError] -> Bool
+matchesFail path errors =
+  case failClass (takeFileName path) of
+    Just check -> any check errors
+    Nothing -> not (null errors)
+
+failClass :: FilePath -> Maybe (LintError -> Bool)
+failClass name
+  | "unbound" `isInfixOf` name = Just isUnboundName
+  | "app-mismatch" `isInfixOf` name = Just isTypeMismatch
+  | "tyapp-kind" `isInfixOf` name = Just isKindMismatch
+  | "cast-source" `isInfixOf` name = Just isTypeMismatch
+  | "shadowed" `isInfixOf` name = Just isShadowedBinder
+  | "lit-alt" `isInfixOf` name = Just isTypeMismatch
+  | "string-literal-type" `isInfixOf` name = Just isTypeMismatch
+  | "tycon-co-arity" `isInfixOf` name = Just isLintFailure
+  | otherwise = Nothing
+
+isUnboundName :: LintError -> Bool
+isUnboundName UnboundName {} = True
+isUnboundName _ = False
+
+isTypeMismatch :: LintError -> Bool
+isTypeMismatch TypeMismatch {} = True
+isTypeMismatch _ = False
+
+isKindMismatch :: LintError -> Bool
+isKindMismatch KindMismatch {} = True
+isKindMismatch _ = False
+
+isShadowedBinder :: LintError -> Bool
+isShadowedBinder ShadowedBinder {} = True
+isShadowedBinder _ = False
+
+isLintFailure :: LintError -> Bool
+isLintFailure LintFailure {} = True
+isLintFailure _ = False
 
 listFc2Files :: FilePath -> IO [FilePath]
 listFc2Files dir = do

--- a/components/aihc-fc/test/Test/Fc2/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc2/Suite.hs
@@ -4,12 +4,13 @@
 module Test.Fc2.Suite
   ( fc2FixtureTests,
     fc2GoldenTests,
+    fc2LintTests,
   )
 where
 
-import Aihc.Fc2 (parseProgram, renderParseError, renderProgram)
+import Aihc.Fc2 (Program, lintPrograms, parseProgram, renderParseError, renderProgram)
 import Data.Char (isSpace)
-import Data.List (dropWhileEnd)
+import Data.List (dropWhileEnd, sort)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -17,7 +18,7 @@ import Fc2Golden (Fc2Case (..), Outcome (..), evaluateFc2Case, loadFc2Cases)
 import System.Directory (doesDirectoryExist, listDirectory)
 import System.FilePath (takeExtension, (</>))
 import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.HUnit (assertEqual, assertFailure, testCase)
+import Test.Tasty.HUnit (assertBool, assertEqual, assertFailure, testCase)
 
 fixtureRoot :: FilePath
 fixtureRoot = "test/Test/Fixtures/fc2"
@@ -49,6 +50,66 @@ normalize :: Text -> Text
 normalize = T.pack . trim . T.unpack
   where
     trim = dropWhileEnd isSpace . dropWhile isSpace
+
+lintRoot :: FilePath
+lintRoot = "test/Test/Fixtures/fc2-lint"
+
+fc2LintTests :: IO TestTree
+fc2LintTests = do
+  pass <- lintFileTests "pass" True (lintRoot </> "pass")
+  failCases <- lintFileTests "fail" False (lintRoot </> "fail")
+  mutual <- mutualLintTests (lintRoot </> "mutual")
+  pure (testGroup "SystemFC2 lint" [pass, failCases, mutual])
+
+lintFileTests :: String -> Bool -> FilePath -> IO TestTree
+lintFileTests label expectPass dir = do
+  files <- listFc2Files dir
+  pure (testGroup label (map (lintFileTest expectPass) files))
+
+lintFileTest :: Bool -> FilePath -> TestTree
+lintFileTest expectPass path = testCase path $ do
+  program <- loadFc2Program path
+  let errors = lintPrograms [program]
+  if expectPass
+    then assertEqual (path <> " lint errors") [] errors
+    else assertBool (path <> " expected lint errors") (not (null errors))
+
+mutualLintTests :: FilePath -> IO TestTree
+mutualLintTests dir = do
+  files <- listFc2Files dir
+  pure
+    ( testGroup
+        "mutual"
+        [ testCase "lint of all files together passes" $ do
+            programs <- mapM loadFc2Program files
+            assertEqual "mutual lint errors" [] (lintPrograms programs),
+          testCase "lint of one file without the other fails" $ do
+            programs <- mapM loadFc2Program files
+            mapM_
+              ( \program ->
+                  assertBool
+                    "a single mutual file must fail lint"
+                    (not (null (lintPrograms [program])))
+              )
+              programs
+        ]
+    )
+
+listFc2Files :: FilePath -> IO [FilePath]
+listFc2Files dir = do
+  exists <- doesDirectoryExist dir
+  if not exists
+    then pure []
+    else do
+      names <- sort <$> listDirectory dir
+      pure [dir </> name | name <- names, takeExtension name == ".fc2"]
+
+loadFc2Program :: FilePath -> IO Program
+loadFc2Program path = do
+  source <- TIO.readFile path
+  case parseProgram source of
+    Left parseError -> assertFailure (path <> ": " <> renderParseError parseError)
+    Right program -> pure program
 
 fc2GoldenTests :: IO TestTree
 fc2GoldenTests = testGroup "SystemFC2 goldens" . map mkGolden <$> loadFc2Cases

--- a/components/aihc-fc/test/Test/Fc2/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc2/Suite.hs
@@ -135,7 +135,7 @@ failClass name
   | "cast-source" `isInfixOf` name = Just isTypeMismatch
   | "shadowed" `isInfixOf` name = Just isShadowedBinder
   | "lit-alt" `isInfixOf` name = Just isTypeMismatch
-  | "string-literal-type" `isInfixOf` name = Just isTypeMismatch
+  | "string-literal" `isInfixOf` name = Just isTypeMismatch
   | "tycon-co-arity" `isInfixOf` name = Just isLintFailure
   | otherwise = Nothing
 

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/app-mismatch.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/app-mismatch.fc2
@@ -1,0 +1,16 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vnot :: 1.tBool → 1.tBool
+ = λ(x : 1.tBool).
+  1.vFalse
+
+val 1.vbad :: 1.tBool
+ = 1.vnot 1.vnot

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/cast-source.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/cast-source.fc2
@@ -1,0 +1,20 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+pub type 1.tInt :: 2.tType {
+    pub 1.vI :: 1.tInt
+}
+
+pub type 1.tAge :: 2.tType {}
+
+axiom 1.$ax$Age : 1.tAge ~R 1.tInt
+
+val 1.vbad :: 1.tAge
+ = 1.vTrue ▷ sym (axiom-co 1.$ax$Age)

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt-lifted.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt-lifted.fc2
@@ -1,0 +1,17 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vbad :: 1.tBool
+ = case 1.vTrue as (w : 1.tBool) of {
+     1#2.tLiftedRep →
+       1.vFalse;
+     _ →
+       1.vTrue
+   }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt.fc2
@@ -1,0 +1,19 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+pub type 1.tIntRep :: 2.tRuntimeRep {}
+
+val 1.vbad :: 1.tBool
+ = case 1.vTrue as (w : 1.tBool) of {
+     1#1.tIntRep →
+       1.vFalse;
+     _ →
+       1.vTrue
+   }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/shadowed.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/shadowed.fc2
@@ -1,0 +1,14 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vbad :: 1.tBool → 1.tBool → 1.tBool
+ = λ(x : 1.tBool).
+  λ(x : 1.tBool).
+    x

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-origin.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-origin.fc2
@@ -1,0 +1,15 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 2.tChar :: 2.tType {}
+
+pub type 2.t[] (a : 2.tType) :: 2.tType {}
+
+pub type 1.tChar :: 2.tType {}
+
+pub type 1.t[] (a : 2.tType) :: 2.tType {}
+
+val 1.vbad :: 1.t[] 1.tChar
+ = "x"

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-type.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-type.fc2
@@ -1,0 +1,16 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+pub type 1.tChar :: 2.tType {}
+
+pub type 1.t[] (a : 2.tType) :: 2.tType {}
+
+val 1.vbad :: 1.tBool
+ = "x"

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tyapp-kind.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tyapp-kind.fc2
@@ -1,0 +1,17 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vid :: ∀(a : 2.tType). a → a
+ = Λ(a : 2.tType).
+  λ(x : a).
+    x
+
+val 1.vbad :: 1.tBool
+ = 1.vid @2.tLiftedRep 1.vTrue

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tycon-co-arity.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tycon-co-arity.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tMaybe (a : 2.tType) :: 2.tType {
+    pub 1.vNothing :: ∀(a : 2.tType). 1.tMaybe a
+}
+
+val 1.vbad :: ∀(a : 2.tType). 1.tMaybe a → 1.tMaybe a
+ = Λ(a : 2.tType).
+  λ(x : 1.tMaybe a).
+    x ▷ tycon-co 1.tMaybe (refl a) (refl a)

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/unbound.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/unbound.fc2
@@ -1,0 +1,12 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vbad :: 1.tBool
+ = 1.vunknown

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Prim.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Prim.fc2
@@ -1,0 +1,6 @@
+scope 1 = "aihc-prim" GHC.Prim
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.GHC.Prim where
+
+pub type 1.tInt# :: 2.tTYPE 2.vIntRep {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Types.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Types.fc2
@@ -1,0 +1,15 @@
+scope 1 = "aihc-prim" GHC.Types
+scope 2 = "aihc-prim" GHC.Prim
+
+module 1.GHC.Types where
+
+pub type 1.tType :: 1.tType {}
+
+pub type 1.tRuntimeRep :: 1.tType {
+    pub 1.vIntRep :: 1.tRuntimeRep
+}
+
+pub type 1.tTYPE (r : 1.tRuntimeRep) :: 1.tType {}
+
+pub type 1.tInt :: 1.tTYPE 1.vIntRep =
+  2.tInt#

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/foreign-prim.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/foreign-prim.fc2
@@ -1,0 +1,12 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b
+
+val 1.vboom :: ∀(a : 2.tType) (b : 2.tType). a → b
+ = Λ(a : 2.tType).
+  Λ(b : 2.tType).
+    λ(x : a).
+      1.vraise# @a @b x

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/fun-explicit.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/fun-explicit.fc2
@@ -1,0 +1,12 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tIntRep :: 2.tRuntimeRep {}
+
+pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}
+
+val 1.vid# :: FUN @1.tIntRep @1.tIntRep 1.tInt# 1.tInt#
+ = λ(x : 1.tInt#).
+  x

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/identity.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/identity.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vid :: 1.tBool → 1.tBool
+ = λ(x : 1.tBool).
+  x

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/lambda-app-case.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/lambda-app-case.fc2
@@ -1,0 +1,29 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBool :: 2.tType {
+    pub 1.vFalse :: 1.tBool
+    pub 1.vTrue :: 1.tBool
+}
+
+val 1.vid :: ∀(a : 2.tType). a → a
+ = Λ(a : 2.tType).
+  λ(x : a).
+    x
+
+val 1.vnot :: 1.tBool → 1.tBool
+ = λ(x : 1.tBool).
+  case x as (w : 1.tBool) of {
+    1.vTrue →
+      1.vFalse;
+    1.vFalse →
+      1.vTrue
+  }
+
+val 1.vtrue :: 1.tBool
+ = 1.vid @1.tBool 1.vTrue
+
+val 1.vapply :: 1.tBool
+ = 1.vnot 1.vtrue

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/newtype-cast.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/newtype-cast.fc2
@@ -1,0 +1,15 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tInt :: 2.tType {
+    pub 1.vI :: 1.tInt
+}
+
+pub type 1.tAge :: 2.tType {}
+
+axiom 1.$ax$Age : 1.tAge ~R 1.tInt
+
+val 1.vone :: 1.tAge
+ = 1.vI ▷ sym (axiom-co 1.$ax$Age)

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal-ghc.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal-ghc.fc2
@@ -1,0 +1,18 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 2.tChar :: 2.tType {}
+
+pub type 2.t[] (a : 2.tType) :: 2.tType {
+    pub 2.v[] :: ∀(a : 2.tType). 2.t[] a
+    pub 2.v: :: ∀(a : 2.tType). a → 2.t[] a → 2.t[] a
+}
+
+pub type 1.tChar :: 2.tType {}
+
+pub type 1.t[] (a : 2.tType) :: 2.tType {}
+
+val 1.vmsg :: 2.t[] 2.tChar
+ = "x"

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal.fc2
@@ -1,0 +1,14 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tChar :: 2.tType {}
+
+pub type 1.t[] (a : 2.tType) :: 2.tType {
+    pub 1.v[] :: ∀(a : 2.tType). 1.t[] a
+    pub 1.v: :: ∀(a : 2.tType). a → 1.t[] a → 1.t[] a
+}
+
+val 1.vmsg :: 1.t[] 1.tChar
+ = "x"

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/tycon-co.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/tycon-co.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tMaybe (a : 2.tType) :: 2.tType {
+    pub 1.vNothing :: ∀(a : 2.tType). 1.tMaybe a
+}
+
+val 1.vidMaybe :: ∀(a : 2.tType). 1.tMaybe a → 1.tMaybe a
+ = Λ(a : 2.tType).
+  λ(x : 1.tMaybe a).
+    x ▷ tycon-co 1.tMaybe (refl a)

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -28,7 +28,6 @@ It has no ambiguity.
 - Do not add source spans in the first version.
 - Do not add an evaluator in the first version.
 - Do not add a CBOR schema in the first version.
-- Do not add Fc2 lint in the first version.
 - Do not point GRIN at Fc2 in this plan.
 
 ## Place in the compiler
@@ -233,8 +232,11 @@ It must also write `core-v2` next to it:
 Example: `Demo/A/core-v2`.
 
 If Fc2 desugar fails, the install fails.
+If Fc2 lint fails, the install fails.
+Write `core-v2.bad` when Fc2 lint fails.
 Do not write `core` without `core-v2`.
-`install-v2` does not parse `core-v2`.
+`install-v2` does not parse the `core-v2` file that it writes.
+It may parse imported `core-v2` files through the store loader.
 
 ## PR plan
 
@@ -250,6 +252,7 @@ Do not write `core` without `core-v2`.
 | 8 | `feat(fc2): accept foreign import prim and reject ccall` | done, #1493 |
 | 9 | `feat(fc2): write core-v2 from install-v2` | done |
 | 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |
+| 11 | `feat(fc2): add System FC 2 type linter` | done |
 
 PR 4 depends on PR 3.
 PR 5 depends on PR 3.

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -45,6 +45,7 @@ in rec {
     ".cabal"
     ".yaml"
     ".yml"
+    ".fc2"
   ];
 
   arm64Src = mkRootSubsetSrc ["components/aihc-arm64/" "test/support/" "test/Test/Fixtures/grin-snapshot/"] [


### PR DESCRIPTION
Add a System FC 2 linter in `Aihc.Fc2.Lint`.

The linter type-checks every term and every type.
Kind checks are type checks.

It loads the scope closure first.
It registers every header from every loaded program.
Then it checks kinds and terms.

`GHC.Types` and `GHC.Prim` can depend on each other.
Both files load before identifier lookup.

`install-v2` runs this linter before it writes `core` and `core-v2`.
A lint error fails the install.

Depends on: write core-v2 from install-v2.

Progress counts: no change.