### PR TITLE
fix(fc2): correct System FC 2 output for aihc-prim

### DIFF
--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -28,6 +28,7 @@ import System.Directory
     removeDirectoryRecursive,
     removeFile,
   )
+import System.Environment (lookupEnv)
 import System.FilePath (takeDirectory, takeFileName, (</>))
 import System.IO (hClose, openTempFile)
 import Test.Tasty (defaultMain, testGroup)
@@ -514,13 +515,21 @@ aihcPrimLibraryModules =
 
 findAihcPrimRoot :: IO FilePath
 findAihcPrimRoot = do
-  cwd <- getCurrentDirectory
-  findUp cwd
+  envRoot <- lookupEnv "AIHC_PRIM_SRC"
+  case envRoot of
+    Just root -> do
+      cabalExists <- doesFileExist (root </> "aihc-prim.cabal")
+      if cabalExists
+        then pure root
+        else assertFailure ("AIHC_PRIM_SRC has no aihc-prim.cabal: " <> root)
+    Nothing -> do
+      cwd <- getCurrentDirectory
+      findUp cwd
   where
     findUp dir = do
       let candidate = dir </> "core-libs" </> "aihc-prim"
-      exists <- doesDirectoryExist candidate
-      if exists
+      cabalExists <- doesFileExist (candidate </> "aihc-prim.cabal")
+      if cabalExists
         then pure candidate
         else do
           let parent = takeDirectory dir

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -7,23 +7,28 @@ import Aihc.Cli.Options (InstallV2Options (..))
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact)
 import Aihc.Fc qualified as Fc
 import Aihc.Fc2 qualified as Fc2
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc (TcInterface (..), tcTermKeyIdentifier)
 import Control.Exception (IOException, bracket, try)
 import Data.ByteString qualified as BS
 import Data.List (isInfixOf, isPrefixOf, sort)
 import Data.Maybe (mapMaybe)
+import Data.Text (Text)
+import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Hedgehog (Property, property, success)
 import System.Directory
   ( createDirectory,
     createDirectoryIfMissing,
+    doesDirectoryExist,
     doesFileExist,
+    getCurrentDirectory,
     getTemporaryDirectory,
     listDirectory,
     removeDirectoryRecursive,
     removeFile,
   )
-import System.FilePath ((</>))
+import System.FilePath (takeDirectory, takeFileName, (</>))
 import System.IO (hClose, openTempFile)
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
@@ -336,7 +341,8 @@ main =
           testCase "installs direct local dependencies" test_installV2LocalDependencies,
           testCase "rebuilds stale type artifact schemas" test_installV2StaleTypeArtifact,
           testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope,
-          testCase "writes no core files when System FC 2 desugar fails" test_installV2Fc2DesugarFailure
+          testCase "writes no core files when System FC 2 desugar fails" test_installV2Fc2DesugarFailure,
+          testCase "install-v2 writes core-v2 for aihc-prim and lints stored programs" test_installV2AihcPrim
         ],
       testProperty "Hedgehog options" prop_dummy
     ]
@@ -454,6 +460,115 @@ test_installV2Fc2DesugarFailure =
             assertBool "writes no core after Fc2 desugar failure" (not coreExists)
             assertBool "writes no core-v2 after Fc2 desugar failure" (not coreV2Exists)
           other -> assertFailure ("expected one package directory, got " <> show other)
+
+test_installV2AihcPrim :: Assertion
+test_installV2AihcPrim = do
+  aihcPrimRoot <- findAihcPrimRoot
+  withTempDir "aihc-install-v2-aihc-prim" $ \root -> do
+    let storeRoot = root </> "store"
+        options = InstallV2Options aihcPrimRoot (Just storeRoot) False
+    createDirectoryIfMissing True storeRoot
+    caught <- try (installV2 options) :: IO (Either IOException InstallV2Result)
+    result <- case caught of
+      Left err -> do
+        badFiles <- listNamedFiles storeRoot "core-v2.bad"
+        assertFailure
+          ( "install-v2 aihc-prim failed: "
+              <> show err
+              <> if null badFiles
+                then ""
+                else "\nbad core-v2 files:\n" <> unlines badFiles
+          )
+      Right value -> pure value
+    let packageDir = installV2StorePath result
+        packageId = PackageId (T.pack (takeFileName packageDir))
+        loader = Fc2.storeModuleLoader storeRoot
+    mapM_ (assertModuleCoreV2 packageDir) aihcPrimLibraryModules
+    coreV2Files <- listNamedFiles packageDir "core-v2"
+    mapM_ assertCoreV2File coreV2Files
+    types <- loadStoredFc2 loader packageId "GHC.Types"
+    prim <- loadStoredFc2 loader packageId "GHC.Prim"
+    assertBool "GHC.Types lint needs GHC.Prim" (not (null (Fc2.lintPrograms [types])))
+    assertBool "GHC.Prim lint needs GHC.Types" (not (null (Fc2.lintPrograms [prim])))
+    typesAndPrim <- Fc2.loadScopeClosure loader [types, prim]
+    assertEqual "GHC.Types and GHC.Prim closure lint errors" [] (Fc2.lintPrograms typesAndPrim)
+    mapM_ (assertModuleClosureLints loader packageId) (filter (`notElem` ["GHC.Types", "GHC.Prim"]) aihcPrimLibraryModules)
+
+aihcPrimLibraryModules :: [Text]
+aihcPrimLibraryModules =
+  [ "GHC.CString",
+    "GHC.Classes",
+    "GHC.Debug",
+    "GHC.Magic",
+    "GHC.Magic.Dict",
+    "GHC.Prim",
+    "GHC.Prim.Exception",
+    "GHC.Prim.Ext",
+    "GHC.Prim.Panic",
+    "GHC.Prim.PtrEq",
+    "GHC.Prim.Unicode",
+    "GHC.PrimopWrappers",
+    "GHC.Tuple",
+    "GHC.Types"
+  ]
+
+findAihcPrimRoot :: IO FilePath
+findAihcPrimRoot = do
+  cwd <- getCurrentDirectory
+  findUp cwd
+  where
+    findUp dir = do
+      let candidate = dir </> "core-libs" </> "aihc-prim"
+      exists <- doesDirectoryExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory dir
+          if parent == dir
+            then assertFailure ("could not find core-libs/aihc-prim from " <> dir)
+            else findUp parent
+
+moduleCoreV2Path :: FilePath -> Text -> FilePath
+moduleCoreV2Path packageDir moduleName =
+  foldl (</>) packageDir (map T.unpack (T.splitOn "." moduleName) ++ ["core-v2"])
+
+assertModuleCoreV2 :: FilePath -> Text -> Assertion
+assertModuleCoreV2 packageDir moduleName =
+  assertFileExists (moduleCoreV2Path packageDir moduleName)
+
+loadStoredFc2 :: Fc2.ModuleLoader -> PackageId -> Text -> IO Fc2.Program
+loadStoredFc2 loader packageId moduleName = do
+  loaded <- loader packageId moduleName
+  case loaded of
+    Nothing -> assertFailure ("store loader did not find " <> T.unpack moduleName)
+    Just program -> pure program
+
+assertModuleClosureLints :: Fc2.ModuleLoader -> PackageId -> Text -> Assertion
+assertModuleClosureLints loader packageId moduleName = do
+  program <- loadStoredFc2 loader packageId moduleName
+  loaded <- Fc2.loadScopeClosure loader [program]
+  assertEqual
+    (T.unpack moduleName <> " closure lint errors")
+    []
+    (Fc2.lintPrograms loaded)
+
+listNamedFiles :: FilePath -> FilePath -> IO [FilePath]
+listNamedFiles root name = do
+  exists <- doesDirectoryExist root
+  if not exists
+    then pure []
+    else do
+      entries <- listDirectory root
+      concat <$> mapM (go . (root </>)) entries
+  where
+    go path = do
+      isDir <- doesDirectoryExist path
+      if isDir
+        then listNamedFiles path name
+        else
+          if takeFileName path == name
+            then pure [path]
+            else pure []
 
 test_installV2TypeDependencies :: Assertion
 test_installV2TypeDependencies =

--- a/components/aihc-fc/src/Aihc/Fc2/Convert.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Convert.hs
@@ -19,13 +19,15 @@ module Aihc.Fc2.Convert
     lookupAxiomName,
     funType,
     liftedRepType,
+    typeRep,
+    extraKindVars,
   )
 where
 
 import Aihc.Fc2.Name
 import Aihc.Fc2.Syntax
 import Aihc.Fc2.Wired
-import Aihc.Resolve (PackageId)
+import Aihc.Resolve (PackageId (..))
 import Aihc.Tc.Types
   ( Kind (..),
     Levity (..),
@@ -34,14 +36,18 @@ import Aihc.Tc.Types
     TcType (..),
     TyCon,
     TyVarId (..),
+    TypeScheme (..),
     Unique (..),
+    kindFromTypeScheme,
     liftedRuntimeRep,
     runtimeRepOfType,
     tvKind,
     tyConKey,
+    tyConKindScheme,
     tyConModuleName,
     tyConName,
     tyConPackageId,
+    typeKind,
   )
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -126,8 +132,12 @@ convertRep env runtimeRep =
     AddrRep -> Right (repCon env "AddrRep")
     FloatRep -> Right (repCon env "FloatRep")
     DoubleRep -> Right (repCon env "DoubleRep")
-    TupleRep fields -> TyApp (repCon env "TupleRep") <$> promotedList env fields
-    SumRep fields -> TyApp (repCon env "SumRep") <$> promotedList env fields
+    TupleRep fields -> do
+      converted <- mapM (convertRep env) fields
+      Right (TyApp (repCon env "TupleRep") (promotedRuntimeRepList env converted))
+    SumRep fields -> do
+      converted <- mapM (convertRep env) fields
+      Right (TyApp (repCon env "SumRep") (promotedRuntimeRepList env converted))
     VecRep count element ->
       Right
         ( TyApp
@@ -150,13 +160,13 @@ convertRep env runtimeRep =
         Unique uniqueValue = unique
     RuntimeRepMeta {} -> Left "runtime representation still has a meta variable"
 
-promotedList :: ConvertEnv -> [RuntimeRep] -> Either String Type
-promotedList env fields = do
-  converted <- mapM (convertRep env) fields
-  pure (foldr cons nil converted)
+promotedRuntimeRepList :: ConvertEnv -> [Type] -> Type
+promotedRuntimeRepList env =
+  foldr cons nil
   where
-    cons item = TyApp (TyApp (repCon env ":") item)
-    nil = repCon env "[]"
+    runtimeRep = TyCon (runtimeRepConstructor (cePrimPackage env))
+    nil = TyApp (repCon env "[]") runtimeRep
+    cons item = TyApp (TyApp (TyApp (repCon env ":") runtimeRep) item)
 
 repCon :: ConvertEnv -> Text -> Type
 repCon env name = TyCon (wiredGhcTypes (cePrimPackage env) name SortDataConstructor)
@@ -167,8 +177,9 @@ convertType env ty =
     TcTyVar tyVar -> Right (tyVarType tyVar)
     TcMetaTv {} -> Left "type still has a meta variable"
     TcTyCon tyCon arguments -> do
+      kindArgs <- invisibleKindArgs env tyCon arguments
       converted <- mapM (convertType env) arguments
-      pure (foldl TyApp (TyCon (tyConNameFc2 env tyCon)) converted)
+      pure (foldl TyApp (TyCon (tyConNameFc2 env tyCon)) (kindArgs <> converted))
     TcFunTy argument result -> do
       convertedArgument <- convertType env argument
       convertedResult <- convertType env result
@@ -189,10 +200,7 @@ convertType env ty =
       headType <- builtinType env name
       converted <- mapM (convertType env) arguments
       case (bareBuiltin name, converted) of
-        ("[]", items) -> Right (foldr cons nil items)
-          where
-            cons item = TyApp (TyApp (repCon env ":") item)
-            nil = repCon env "[]"
+        ("[]", items) -> Right (promotedRuntimeRepList env items)
         _ -> pure (foldl TyApp headType converted)
 
 convertPred :: ConvertEnv -> Pred -> Either String Type
@@ -232,7 +240,63 @@ tyConNameFc2 :: ConvertEnv -> TyCon -> Name
 tyConNameFc2 env tyCon =
   if Set.member (tyConKey tyCon) (ceClassTyCons env)
     then classDictTypeName tyCon
-    else Name (tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+    else case wiredRewriteName env tyCon of
+      Just name -> name
+      Nothing -> Name (tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
+
+-- | Promoted runtime names from aihc-internal become GHC.Types data constructors.
+wiredRewriteName :: ConvertEnv -> TyCon -> Maybe Name
+wiredRewriteName env tyCon =
+  if shouldRewrite
+    then wiredBuiltinName env (tyConName tyCon)
+    else Nothing
+  where
+    shouldRewrite =
+      T.isPrefixOf "'" (tyConName tyCon)
+        || tyConPackageId tyCon == PackageId "aihc-internal"
+        || tyConModuleName tyCon == "Aihc.Internal"
+
+wiredBuiltinName :: ConvertEnv -> Text -> Maybe Name
+wiredBuiltinName env raw =
+  case Map.lookup (bareBuiltin raw) builtinTable of
+    Just (sort, moduleName) ->
+      Just (Name (bareBuiltin raw) sort (OriginTop (cePrimPackage env) moduleName))
+    Nothing -> Nothing
+
+-- | Invisible kind parameters that the type constructor quantifies before visible arguments.
+extraKindVars :: TyCon -> [TyVarId] -> [TyVarId]
+extraKindVars tyCon visible =
+  case tyConKindScheme tyCon of
+    ForAll vars _ _ ->
+      let seen = map tvUnique visible
+       in filter (\tyVar -> tvUnique tyVar `notElem` seen) vars
+
+invisibleKindArgs :: ConvertEnv -> TyCon -> [TcType] -> Either String [Type]
+invisibleKindArgs env tyCon arguments =
+  mapM (kindVarToType env tyCon arguments) (extraKindVars tyCon [])
+
+kindVarToType :: ConvertEnv -> TyCon -> [TcType] -> TyVarId -> Either String Type
+kindVarToType env tyCon arguments tyVar =
+  case Map.lookup (tvUnique tyVar) (ceTyVars env) of
+    Just found -> Right (tyVarType found)
+    Nothing ->
+      case Map.lookup (tvUnique tyVar) (repSubst tyCon arguments) of
+        Just runtimeRep -> convertRep env runtimeRep
+        Nothing -> convertRep env (RuntimeRepVar (tvUnique tyVar))
+
+repSubst :: TyCon -> [TcType] -> Map Unique RuntimeRep
+repSubst tyCon =
+  go (kindFromTypeScheme (tyConKindScheme tyCon))
+  where
+    go (KFun formal result) (argument : rest) =
+      matchKind formal (typeKind argument) <> go result rest
+    go _ _ = Map.empty
+
+    matchKind (KTYPE (RuntimeRepVar unique)) (KTYPE runtimeRep) =
+      Map.singleton unique runtimeRep
+    matchKind (KFun left right) (KFun left' right') =
+      matchKind left left' <> matchKind right right'
+    matchKind _ _ = Map.empty
 
 builtinType :: ConvertEnv -> Text -> Either String Type
 builtinType env name =

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -316,8 +316,9 @@ removeClassPredicate className predicates =
 convertNewtype :: ConvertEnv -> DataTypeInfo -> Either String [Decl]
 convertNewtype env info = do
   let tyCon = dtiTyCon info
-      bindersEnv = withTyVars (dtiTyVars info) env
-  binders <- mapM (tyVarBinder bindersEnv) (dtiTyVars info)
+      tyVars = extraKindVars tyCon (dtiTyVars info) <> dtiTyVars info
+      bindersEnv = withTyVars tyVars env
+  binders <- mapM (tyVarBinder bindersEnv) tyVars
   result <- convertKind bindersEnv (dtiResultKind info)
   representation <-
     case dtiConstructors info of
@@ -524,8 +525,9 @@ lookupSynonym package moduleName' name tyCons =
 convertDataType :: ConvertEnv -> DataTypeInfo -> Either String Decl
 convertDataType env info = do
   let tyCon = dtiTyCon info
-      bindersEnv = withTyVars (dtiTyVars info) env
-  binders <- mapM (tyVarBinder bindersEnv) (dtiTyVars info)
+      tyVars = extraKindVars tyCon (dtiTyVars info) <> dtiTyVars info
+      bindersEnv = withTyVars tyVars env
+  binders <- mapM (tyVarBinder bindersEnv) tyVars
   result <- convertKind bindersEnv (dtiResultKind info)
   constructors <- mapM (convertConstructor env) (dtiConstructors info)
   pure
@@ -548,8 +550,14 @@ convertConstructor env info = do
   predicates <- mapM (convertPred bindersEnv) (dciTheta info)
   fields <- mapM (convertType bindersEnv . dcfiType) (dciFields info)
   result <- convertType bindersEnv (dciResTy info)
-  let body = foldr (funType bindersEnv) result (predicates <> fields)
-      constructorType = foldr TyForAll body binders
+  body <-
+    constructorFun
+      bindersEnv
+      (replicate (length predicates) Nothing <> map (Just . dcfiType) (dciFields info))
+      (predicates <> fields)
+      (dciResTy info)
+      result
+  let constructorType = foldr TyForAll body binders
       (package, moduleName') = dciOrigin info
   pure
     ConDecl
@@ -557,6 +565,26 @@ convertConstructor env info = do
         conName = Name (dciName info) SortDataConstructor (OriginTop package moduleName'),
         conType = constructorType
       }
+
+constructorFun :: ConvertEnv -> [Maybe TcType] -> [Type] -> TcType -> Type -> Either String Type
+constructorFun env fieldTys convertedFields resultTy convertedResult =
+  go (zip fieldTys convertedFields)
+  where
+    go [] = Right convertedResult
+    go ((maybeField, converted) : rest) = do
+      restType <- go rest
+      r1 <- maybe (Right (liftedRepType env)) (typeRepOrLifted env) maybeField
+      r2 <-
+        if null rest
+          then typeRepOrLifted env resultTy
+          else Right (liftedRepType env)
+      Right (TyFun r1 r2 converted restType)
+
+typeRepOrLifted :: ConvertEnv -> TcType -> Either String Type
+typeRepOrLifted env ty =
+  case typeRep env ty of
+    Right representation -> Right representation
+    Left _ -> Right (liftedRepType env)
 
 convertSynonym :: ConvertEnv -> TyConInfo -> Either String Decl
 convertSynonym env info =

--- a/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/FromFc.hs
@@ -164,12 +164,18 @@ topVarName :: Fc.FcModuleId -> Fc.Var -> Name
 topVarName moduleId var =
   case Fc.varResolvedName var of
     Just (Fc.FcTopLevelOrigin package moduleName' name) ->
-      Name name SortValue (OriginTop (PackageId package) moduleName')
+      Name name SortValue (OriginTop (originPackage package moduleId) moduleName')
     _ ->
       Name
         (displayName var)
         SortValue
         (OriginTop (Fc.fcModulePackage moduleId) (Fc.fcModuleName moduleId))
+
+originPackage :: Text -> Fc.FcModuleId -> PackageId
+originPackage package moduleId =
+  if T.null package
+    then Fc.fcModulePackage moduleId
+    else PackageId package
 
 varNameFc2 :: TopVars -> Fc.Var -> Name
 varNameFc2 tops var =

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -341,14 +341,58 @@ lintExpr env expr =
 lintLiteral :: LintEnv -> Literal -> Either LintError Type
 lintLiteral env literal =
   case literal of
-    LitInt representation _ -> typedRep representation
-    LitChar representation _ -> typedRep representation
+    LitInt representation _ ->
+      case intLiteralPrimitiveName representation of
+        Just primitiveName -> unboxedLiteralType env primitiveName representation
+        Nothing -> typedKind representation
+    LitChar representation _ -> unboxedLiteralType env "Char#" representation
     LitString {} -> stringLiteralType env
-    LitAddr representation _ -> typedRep representation
+    LitAddr representation _ -> unboxedLiteralType env "Addr#" representation
   where
-    typedRep representation = do
+    typedKind representation = do
       _ <- lintType env representation
       Right (typeAppRep env representation)
+
+-- | An unboxed literal inhabits the primitive type for r. It does not inhabit TYPE r.
+unboxedLiteralType :: LintEnv -> Text -> Type -> Either LintError Type
+unboxedLiteralType env primitiveName representation = do
+  _ <- lintType env representation
+  case namedType env [primitiveName] of
+    Nothing -> Left (UnboundName (missingPrimitiveName env primitiveName))
+    Just name -> do
+      let expectedKind = typeAppRep env representation
+      case lookupHeaderType (leTypes env) name of
+        Nothing -> Left (UnboundName name)
+        Just actualKind -> do
+          unless (typesEqual (leTypes env) expectedKind actualKind) (Left (KindMismatch "unboxed literal type" expectedKind actualKind))
+          Right (TyCon name)
+
+intLiteralPrimitiveName :: Type -> Maybe Text
+intLiteralPrimitiveName ty =
+  case ty of
+    TyCon name ->
+      lookup
+        (nameText name)
+        [ ("IntRep", "Int#"),
+          ("WordRep", "Word#"),
+          ("Int8Rep", "Int8#"),
+          ("Int16Rep", "Int16#"),
+          ("Int32Rep", "Int32#"),
+          ("Int64Rep", "Int64#"),
+          ("Word8Rep", "Word8#"),
+          ("Word16Rep", "Word16#"),
+          ("Word32Rep", "Word32#"),
+          ("Word64Rep", "Word64#"),
+          ("FloatRep", "Float#"),
+          ("DoubleRep", "Double#")
+        ]
+    _ -> Nothing
+
+missingPrimitiveName :: LintEnv -> Text -> Name
+missingPrimitiveName env text =
+  case tePrimPackage (leTypes env) of
+    Just package -> Name text SortTypeConstructor (OriginTop package "GHC.Prim")
+    Nothing -> Name text SortTypeConstructor (OriginTop (PackageId "") "GHC.Prim")
 
 stringLiteralType :: LintEnv -> Either LintError Type
 stringLiteralType env =

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -18,13 +18,14 @@ import Control.Applicative ((<|>))
 import Control.Monad (zipWithM)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
-import Data.Char (isAlpha, isAlphaNum)
+import Data.ByteString qualified as BS
+import Data.Char (chr, digitToInt, isAlpha, isAlphaNum, isHexDigit, ord)
 import Data.Functor (($>))
 import Data.Map.Strict qualified as Map
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Encoding qualified as TE
 import Data.Void (Void)
+import Data.Word (Word8)
 import Text.Megaparsec (ParseErrorBundle, Parsec)
 import Text.Megaparsec qualified as MP
 import Text.Megaparsec.Char qualified as MPC
@@ -41,7 +42,7 @@ data OpenType
   | OpenFun OpenType OpenType
   | OpenForAll Name OpenType OpenType
   | OpenEq OpenType OpenType
-  | OpenExplicit Type
+  | OpenExplicitFun OpenType OpenType OpenType OpenType
   deriving (Eq, Show)
 
 parseProgram :: Text -> Either Fc2ParseError Program
@@ -282,20 +283,7 @@ explicitFun = do
   r1 <- symbol "@" *> typeAtom
   r2 <- symbol "@" *> typeAtom
   argument <- typeAtom
-  OpenExplicit . TyFun (demandType r1) (demandType r2) (demandType argument) . demandType <$> typeAtom
-
-demandType :: OpenType -> Type
-demandType open =
-  case open of
-    OpenVar name -> TyVar name
-    OpenCon name -> TyCon name
-    OpenApp function argument -> TyApp (demandType function) (demandType argument)
-    OpenFun argument result ->
-      TyFun (demandType argument) (demandType result) (demandType argument) (demandType result)
-    OpenForAll name kind body ->
-      TyForAll (Binder name (demandType kind)) (demandType body)
-    OpenEq left right -> TyEq (demandType left) (demandType right)
-    OpenExplicit ty -> ty
+  OpenExplicitFun r1 r2 argument <$> typeAtom
 
 typeAtom :: Parser OpenType
 typeAtom =
@@ -495,13 +483,13 @@ hashedLiteral =
         representation <- representationType
         pure (LitChar representation value),
       do
-        value <- stringLiteral
+        value <- addrLiteral
         _ <- MPC.char '#'
         representation <- representationType
         case representationName representation of
           Just name
             | nameText name == "AddrRep" ->
-                pure (LitAddr representation (TE.encodeUtf8 value))
+                pure (LitAddr representation value)
           _ -> fail "address literal representation must be AddrRep"
     ]
 
@@ -549,9 +537,27 @@ rawName :: Parser Text
 rawName =
   MP.choice
     [ "[]" <$ MPC.string "[]",
+      MP.try tupleName,
       MP.try identName,
       operatorName
     ]
+
+tupleName :: Parser Text
+tupleName = unboxedTupleName <|> boxedTupleName
+
+unboxedTupleName :: Parser Text
+unboxedTupleName = do
+  _ <- MPC.string "(#"
+  commas <- MP.many (MPC.char ',')
+  _ <- MPC.string "#)"
+  pure (T.pack ("(#" <> commas <> "#)"))
+
+boxedTupleName :: Parser Text
+boxedTupleName = do
+  _ <- MPC.char '('
+  commas <- MP.many (MPC.char ',')
+  _ <- MPC.char ')'
+  pure (T.pack ('(' : commas <> ")"))
 
 identName :: Parser Text
 identName = do
@@ -907,7 +913,8 @@ closeType env open =
       TyForAll binder <$> closeType (extend env binder) body
     OpenEq left right ->
       TyEq <$> closeType env left <*> closeType env right
-    OpenExplicit ty -> Right ty
+    OpenExplicitFun r1 r2 argument result ->
+      TyFun <$> closeType env r1 <*> closeType env r2 <*> closeType env argument <*> closeType env result
 
 -- Lexer
 
@@ -942,6 +949,13 @@ stringLiteral = lexeme $ do
   _ <- MPC.char '"'
   pure (T.pack characters)
 
+addrLiteral :: Parser BS.ByteString
+addrLiteral = lexeme $ do
+  _ <- MPC.char '"'
+  bytes <- MP.many addrByte
+  _ <- MPC.char '"'
+  pure (BS.pack bytes)
+
 charLiteral :: Parser Char
 charLiteral = lexeme $ do
   _ <- MPC.char '\''
@@ -952,12 +966,33 @@ charLiteral = lexeme $ do
 stringChar :: Parser Char
 stringChar =
   MP.choice
-    [ MP.satisfy (\character -> character /= '"' && character /= '\'' && character /= '\\'),
+    [ hexChar,
+      MP.satisfy (\character -> character /= '"' && character /= '\'' && character /= '\\'),
       MPC.string "\\\\" $> '\\',
       MPC.string "\\\"" $> '"',
       MPC.string "\\'" $> '\'',
       MPC.string "\\n" $> '\n'
     ]
+
+addrByte :: Parser Word8
+addrByte =
+  MP.choice
+    [ hexByte,
+      fromIntegral . ord <$> MP.satisfy (\character -> character /= '"' && character /= '\\'),
+      MPC.string "\\\\" $> 92,
+      MPC.string "\\\"" $> 34,
+      MPC.string "\\n" $> 10
+    ]
+
+hexChar :: Parser Char
+hexChar = chr . fromIntegral <$> hexByte
+
+hexByte :: Parser Word8
+hexByte = do
+  _ <- MPC.string "\\x"
+  high <- MP.satisfy isHexDigit
+  low <- MP.satisfy isHexDigit
+  pure (fromIntegral (digitToInt high * 16 + digitToInt low))
 
 qualifiedModuleName :: Parser Text
 qualifiedModuleName = lexeme $ do

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -14,13 +14,15 @@ import Aihc.Fc2.TypeOf
 import Aihc.Resolve (PackageId (..), packageIdText)
 import Aihc.Tc.Types (Unique (..))
 import Data.ByteString qualified as BS
-import Data.Char (chr)
+import Data.Char (chr, isAscii, isPrint, ord)
 import Data.List (intercalate)
 import Data.Map.Strict qualified as Map
 import Data.Set (Set)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Word (Word8)
+import Numeric (showHex)
 
 data Prec
   = PrecAtom
@@ -310,8 +312,26 @@ renderLiteral scopes seen literal =
   case literal of
     LitInt representation value -> show value <> "#" <> renderName scopes seen (repName representation)
     LitChar representation value -> show value <> "#" <> renderName scopes seen (repName representation)
-    LitString value -> show (T.unpack value)
-    LitAddr representation value -> show (map (chr . fromIntegral) (BS.unpack value)) <> "#" <> renderName scopes seen (repName representation)
+    LitString value -> "\"" <> concatMap encodeStringChar (T.unpack value) <> "\""
+    LitAddr representation value -> "\"" <> concatMap encodeByte (BS.unpack value) <> "\"#" <> renderName scopes seen (repName representation)
+
+encodeStringChar :: Char -> String
+encodeStringChar character
+  | character == '"' = "\\\""
+  | character == '\\' = "\\\\"
+  | character == '\n' = "\\n"
+  | isAscii character && isPrint character = [character]
+  | otherwise = encodeByte (fromIntegral (ord character))
+
+encodeByte :: Word8 -> String
+encodeByte byte
+  | isAscii character && isPrint character && character `notElem` ("\"\\'" :: String) =
+      [character]
+  | otherwise = "\\x" <> padHex (showHex (fromIntegral byte :: Int) "")
+  where
+    character = chr (fromIntegral byte)
+    padHex [digit] = ['0', digit]
+    padHex digits = digits
 
 repName :: Type -> Name
 repName ty =

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -272,7 +272,6 @@ reduceType env ty =
 typesEqual :: TypeEnv -> Type -> Type -> Bool
 typesEqual env left right =
   eq (reduceType env left) (reduceType env right)
-    || unboxedPrimitiveEqual env left right
   where
     eq (TyVar a) (TyVar b) = a == b
     eq (TyCon a) (TyCon b) = a == b
@@ -285,18 +284,3 @@ typesEqual env left right =
         && typesEqual env body1 (substType (binderName binder2) (TyVar (binderName binder1)) body2)
     eq (TyEq a1 b1) (TyEq a2 b2) = eq a1 a2 && eq b1 b2
     eq _ _ = False
-
--- | A nullary unboxed primitive T :: TYPE r is the type of literals of representation r.
-unboxedPrimitiveEqual :: TypeEnv -> Type -> Type -> Bool
-unboxedPrimitiveEqual env left right =
-  case (reduceType env left, reduceType env right) of
-    (TyCon name, kind@(TyApp (TyCon typeName) representation))
-      | isWiredName env typeName "TYPE",
-        not (isLiftedRep env representation) ->
-          case lookupHeaderType env name of
-            Just header -> typesEqual env header kind
-            Nothing -> False
-    (TyApp (TyCon typeName) _, TyCon _)
-      | isWiredName env typeName "TYPE" ->
-          unboxedPrimitiveEqual env right left
-    _ -> False

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -272,6 +272,7 @@ reduceType env ty =
 typesEqual :: TypeEnv -> Type -> Type -> Bool
 typesEqual env left right =
   eq (reduceType env left) (reduceType env right)
+    || unboxedPrimitiveEqual env left right
   where
     eq (TyVar a) (TyVar b) = a == b
     eq (TyCon a) (TyCon b) = a == b
@@ -284,3 +285,18 @@ typesEqual env left right =
         && typesEqual env body1 (substType (binderName binder2) (TyVar (binderName binder1)) body2)
     eq (TyEq a1 b1) (TyEq a2 b2) = eq a1 a2 && eq b1 b2
     eq _ _ = False
+
+-- | A nullary unboxed primitive T :: TYPE r is the type of literals of representation r.
+unboxedPrimitiveEqual :: TypeEnv -> Type -> Type -> Bool
+unboxedPrimitiveEqual env left right =
+  case (reduceType env left, reduceType env right) of
+    (TyCon name, kind@(TyApp (TyCon typeName) representation))
+      | isWiredName env typeName "TYPE",
+        not (isLiftedRep env representation) ->
+          case lookupHeaderType env name of
+            Just header -> typesEqual env header kind
+            Nothing -> False
+    (TyApp (TyCon typeName) _, TyCon _)
+      | isWiredName env typeName "TYPE" ->
+          unboxedPrimitiveEqual env right left
+    _ -> False

--- a/components/aihc-fc/test/Test/Fc2/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc2/Suite.hs
@@ -135,6 +135,7 @@ failClass name
   | "cast-source" `isInfixOf` name = Just isTypeMismatch
   | "shadowed" `isInfixOf` name = Just isShadowedBinder
   | "lit-alt" `isInfixOf` name = Just isTypeMismatch
+  | "lit-secret" `isInfixOf` name = Just isTypeMismatch
   | "string-literal" `isInfixOf` name = Just isTypeMismatch
   | "tycon-co-arity" `isInfixOf` name = Just isLintFailure
   | otherwise = Nothing

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt.fc2
@@ -10,6 +10,8 @@ pub type 1.tBool :: 2.tType {
 
 pub type 1.tIntRep :: 2.tRuntimeRep {}
 
+pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}
+
 val 1.vbad :: 1.tBool
  = case 1.vTrue as (w : 1.tBool) of {
      1#1.tIntRep →

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-secret.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-secret.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tIntRep :: 2.tRuntimeRep {}
+
+pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}
+
+pub type 1.tSecret# :: 2.tTYPE 1.tIntRep {}
+
+val 1.vbad :: 1.tSecret#
+ = 1#1.tIntRep

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/addr-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/addr-literal.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 2.tRuntimeRep :: 2.tType {
+    pub 2.vAddrRep :: 2.tRuntimeRep
+}
+
+pub type 1.tAddr# :: 2.tTYPE 2.vAddrRep {}
+
+val 1.vtable :: 1.tAddr#
+ = "\x00\x1fA"#2.vAddrRep

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/unboxed-lit.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/unboxed-lit.fc2
@@ -1,0 +1,11 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tIntRep :: 2.tRuntimeRep {}
+
+pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}
+
+val 1.vone :: 1.tInt#
+ = 1#1.tIntRep

--- a/components/aihc-fc/test/Test/Fixtures/fc2/addr-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/addr-literal.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 2.tRuntimeRep :: 2.tType {
+    pub 2.vAddrRep :: 2.tRuntimeRep
+}
+
+pub type 1.tAddr# :: 2.tTYPE 2.vAddrRep {}
+
+val 1.vtable :: 1.tAddr#
+ = "\x00\x1fA"#2.vAddrRep

--- a/components/aihc-fc/test/Test/Fixtures/fc2/fun-nested-arrow.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/fun-nested-arrow.fc2
@@ -1,0 +1,12 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tBox :: 2.tTYPE 2.tUnliftedRep {}
+
+pub type 1.tFlag :: 2.tType {
+    pub 1.vOff :: 1.tFlag
+}
+
+foreign import prim 1.vput :: FUN @2.tUnliftedRep @2.tLiftedRep 1.tBox (1.tFlag → 1.tBox)

--- a/components/aihc-fc/test/Test/Fixtures/fc2/tuple-con.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/tuple-con.fc2
@@ -1,0 +1,12 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+module 1.Test where
+
+pub type 1.tPair (a : 2.tType) (b : 2.tType) :: 2.tType {
+    pub 1.v(,) :: ∀(a : 2.tType) (b : 2.tType). a → b → 1.tPair a b
+}
+
+pub type 1.tUPair (r1 : 2.tRuntimeRep) (r2 : 2.tRuntimeRep) (a : 2.tTYPE r1) (b : 2.tTYPE r2) :: 2.tTYPE (2.vTupleRep (2.v: 2.tRuntimeRep r1 (2.v: 2.tRuntimeRep r2 (2.v[] 2.tRuntimeRep)))) {
+    pub 1.v(#,#) :: ∀(r1 : 2.tRuntimeRep) (r2 : 2.tRuntimeRep) (a : 2.tTYPE r1) (b : 2.tTYPE r2). FUN @r1 @2.tLiftedRep a (FUN @r2 @(2.vTupleRep (2.v: 2.tRuntimeRep r1 (2.v: 2.tRuntimeRep r2 (2.v[] 2.tRuntimeRep)))) b (1.tUPair r1 r2 a b))
+}

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-and-liftedrep.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-and-liftedrep.yaml
@@ -1,0 +1,51 @@
+extensions:
+  - DataKinds
+  - KindSignatures
+  - StandaloneKindSignatures
+modules:
+  - |
+    module GHC.Types where
+
+    data TYPE (rep :: RuntimeRep)
+
+    type Type :: Type
+    type Type = TYPE LiftedRep
+
+    type LiftedRep :: RuntimeRep
+    type LiftedRep = 'BoxedRep 'Lifted
+
+    type UnliftedRep :: RuntimeRep
+    type UnliftedRep = 'BoxedRep 'Unlifted
+
+    data RuntimeRep
+      = BoxedRep Levity
+      | IntRep
+
+    data Levity = Lifted | Unlifted
+expected: |-
+  scope 1 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Types where
+
+  pub type 1.tTYPE (rep{13} : 1.tRuntimeRep) :: 1.tType {}
+
+  pub type 1.tType :: 1.tType =
+   1.tTYPE 1.tLiftedRep
+
+  pub type 1.tLiftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vLifted
+
+  pub type 1.tUnliftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vUnlifted
+
+  pub type 1.tRuntimeRep :: 1.tType {
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+      pub 1.vIntRep :: 1.tRuntimeRep
+  }
+
+  pub type 1.tLevity :: 1.tType {
+      pub 1.vLifted :: 1.tLevity
+      pub 1.vUnlifted :: 1.tLevity
+  }
+status: pass
+reason: TYPE, Type, and promoted BoxedRep stay GHC.Types names.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-int.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-int.yaml
@@ -1,0 +1,65 @@
+extensions:
+  - DataKinds
+  - KindSignatures
+  - MagicHash
+  - StandaloneKindSignatures
+modules:
+  - |
+    module GHC.Types where
+
+    import GHC.Prim (Int#)
+
+    data TYPE (rep :: RuntimeRep)
+
+    type Type :: Type
+    type Type = TYPE LiftedRep
+
+    type LiftedRep :: RuntimeRep
+    type LiftedRep = 'BoxedRep 'Lifted
+
+    data RuntimeRep
+      = BoxedRep Levity
+      | IntRep
+
+    data Levity = Lifted | Unlifted
+
+    data Int = I# Int#
+  - |
+    module GHC.Prim where
+
+    data Int#
+expected: |-
+  scope 1 = "aihc-prim" GHC.Prim
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 2.GHC.Types where
+
+  pub type 2.tTYPE (rep{8} : 2.tRuntimeRep) :: 2.tType {}
+
+  pub type 2.tType :: 2.tType =
+   2.tTYPE 2.tLiftedRep
+
+  pub type 2.tLiftedRep :: 2.tRuntimeRep =
+   2.vBoxedRep 2.vLifted
+
+  pub type 2.tRuntimeRep :: 2.tType {
+      pub 2.vBoxedRep :: 2.tLevity → 2.tRuntimeRep
+      pub 2.vIntRep :: 2.tRuntimeRep
+  }
+
+  pub type 2.tLevity :: 2.tType {
+      pub 2.vLifted :: 2.tLevity
+      pub 2.vUnlifted :: 2.tLevity
+  }
+
+  pub type 2.tInt :: 2.tType {
+      pub 2.vI# :: FUN @2.vIntRep @2.tLiftedRep 1.tInt# 2.tInt
+  }
+  scope 1 = "aihc-prim" GHC.Prim
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Prim where
+
+  pub type 1.tInt# :: 2.tTYPE 2.vIntRep {}
+status: pass
+reason: The Int constructor uses FUN with IntRep on the unboxed field.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-tuple.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-tuple.yaml
@@ -1,0 +1,63 @@
+extensions:
+  - DataKinds
+  - KindSignatures
+  - MagicHash
+  - StandaloneKindSignatures
+  - UnboxedTuples
+modules:
+  - |
+    module GHC.Types where
+
+    data TYPE (rep :: RuntimeRep)
+
+    type Type :: Type
+    type Type = TYPE LiftedRep
+
+    type LiftedRep :: RuntimeRep
+    type LiftedRep = 'BoxedRep 'Lifted
+
+    data RuntimeRep
+      = BoxedRep Levity
+      | TupleRep [RuntimeRep]
+
+    data Levity = Lifted | Unlifted
+
+    data List a = [] | a : [a]
+
+    infixr 5 :
+
+    type Tuple2# :: TYPE r1 -> TYPE r2 -> TYPE ('TupleRep '[r1, r2])
+    data Tuple2# (a1 :: TYPE r1) (a2 :: TYPE r2) = (# a1, a2 #)
+expected: |-
+  scope 1 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Types where
+
+  pub type 1.tTYPE (rep{23} : 1.tRuntimeRep) :: 1.tType {}
+
+  pub type 1.tType :: 1.tType =
+   1.tTYPE 1.tLiftedRep
+
+  pub type 1.tLiftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vLifted
+
+  pub type 1.tRuntimeRep :: 1.tType {
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+      pub 1.vTupleRep :: 1.t[] 1.tRuntimeRep → 1.tRuntimeRep
+  }
+
+  pub type 1.tLevity :: 1.tType {
+      pub 1.vLifted :: 1.tLevity
+      pub 1.vUnlifted :: 1.tLevity
+  }
+
+  pub type 1.t[] (a{24} : 1.tType) :: 1.tType {
+      pub 1.v[] :: ∀(a{24} : 1.tType). 1.t[] a{24}
+      pub 1.v: :: ∀(a{24} : 1.tType). a{24} → 1.t[] a{24} → 1.t[] a{24}
+  }
+
+  pub type 1.tTuple2# (r1{1} : 1.tRuntimeRep) (r2{2} : 1.tRuntimeRep) (a1{26} : 1.tTYPE r1{1}) (a2{27} : 1.tTYPE r2{2}) :: 1.tTYPE (1.vTupleRep (1.v: 1.tRuntimeRep r1{1} (1.v: 1.tRuntimeRep r2{2} (1.v[] 1.tRuntimeRep)))) {
+      pub 1.v(#,#) :: ∀(r1{1} : 1.tRuntimeRep) (r2{2} : 1.tRuntimeRep) (a1{26} : 1.tTYPE r1{1}) (a2{27} : 1.tTYPE r2{2}). FUN @r1{1} @1.tLiftedRep a1{26} (FUN @r2{2} @(1.vTupleRep (1.v: 1.tRuntimeRep r1{1} (1.v: 1.tRuntimeRep r2{2} (1.v[] 1.tRuntimeRep)))) a2{27} (1.tTuple2# r1{1} r2{2} a1{26} a2{27}))
+  }
+status: pass
+reason: An unboxed tuple keeps kind parameters and TupleRep in the result kind.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
@@ -1,0 +1,75 @@
+extensions:
+  - DataKinds
+  - ForeignFunctionInterface
+  - GHCForeignImportPrim
+  - KindSignatures
+  - MagicHash
+  - StandaloneKindSignatures
+modules:
+  - |
+    module GHC.Types where
+
+    data TYPE (rep :: RuntimeRep)
+
+    type Type :: Type
+    type Type = TYPE LiftedRep
+
+    type LiftedRep :: RuntimeRep
+    type LiftedRep = 'BoxedRep 'Lifted
+
+    type UnliftedRep :: RuntimeRep
+    type UnliftedRep = 'BoxedRep 'Unlifted
+
+    data RuntimeRep
+      = BoxedRep Levity
+      | IntRep
+
+    data Levity = Lifted | Unlifted
+  - |
+    module GHC.Prim where
+
+    import GHC.Types (TYPE, Type, UnliftedRep)
+
+    type StableName# :: Type -> TYPE UnliftedRep
+    data StableName# a
+
+    data Int#
+
+    foreign import prim eqStableName# :: StableName# a -> StableName# b -> Int#
+expected: |-
+  scope 1 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Types where
+
+  pub type 1.tTYPE (rep{13} : 1.tRuntimeRep) :: 1.tType {}
+
+  pub type 1.tType :: 1.tType =
+   1.tTYPE 1.tLiftedRep
+
+  pub type 1.tLiftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vLifted
+
+  pub type 1.tUnliftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vUnlifted
+
+  pub type 1.tRuntimeRep :: 1.tType {
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+      pub 1.vIntRep :: 1.tRuntimeRep
+  }
+
+  pub type 1.tLevity :: 1.tType {
+      pub 1.vLifted :: 1.tLevity
+      pub 1.vUnlifted :: 1.tLevity
+  }
+  scope 1 = "aihc-prim" GHC.Prim
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Prim where
+
+  pub type 1.tStableName# (a{18} : 2.tType) :: 2.tTYPE 2.tUnliftedRep {}
+
+  pub type 1.tInt# :: 2.tTYPE 2.vIntRep {}
+
+  foreign import prim 1.veqStableName# :: ∀(a{21} : 2.tType) (b{22} : 2.tType). FUN @2.tUnliftedRep @2.tLiftedRep (1.tStableName# a{21}) (FUN @2.tUnliftedRep @2.vIntRep (1.tStableName# b{22}) 1.tInt#)
+status: pass
+reason: An unlifted foreign import prim uses UnliftedRep on FUN.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-type-kind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-type-kind.yaml
@@ -1,0 +1,73 @@
+extensions:
+  - DataKinds
+  - KindSignatures
+  - MagicHash
+  - StandaloneKindSignatures
+modules:
+  - |
+    module GHC.Types where
+
+    data TYPE (rep :: RuntimeRep)
+
+    type Type :: Type
+    type Type = TYPE LiftedRep
+
+    type LiftedType = TYPE LiftedRep
+
+    type UnliftedType = TYPE UnliftedRep
+
+    type LiftedRep :: RuntimeRep
+    type LiftedRep = 'BoxedRep 'Lifted
+
+    type UnliftedRep :: RuntimeRep
+    type UnliftedRep = 'BoxedRep 'Unlifted
+
+    data RuntimeRep
+      = BoxedRep Levity
+
+    data Levity = Lifted | Unlifted
+  - |
+    module GHC.Prim where
+
+    import GHC.Types (Type, UnliftedType)
+
+    type MutVar# :: Type -> Type -> UnliftedType
+    data MutVar# d a
+expected: |-
+  scope 1 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Types where
+
+  pub type 1.tTYPE (rep{17} : 1.tRuntimeRep) :: 1.tType {}
+
+  pub type 1.tType :: 1.tType =
+   1.tTYPE 1.tLiftedRep
+
+  pub type 1.tLiftedType :: 1.tType =
+   1.tTYPE 1.tLiftedRep
+
+  pub type 1.tUnliftedType :: 1.tType =
+   1.tTYPE 1.tUnliftedRep
+
+  pub type 1.tLiftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vLifted
+
+  pub type 1.tUnliftedRep :: 1.tRuntimeRep =
+   1.vBoxedRep 1.vUnlifted
+
+  pub type 1.tRuntimeRep :: 1.tType {
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+  }
+
+  pub type 1.tLevity :: 1.tType {
+      pub 1.vLifted :: 1.tLevity
+      pub 1.vUnlifted :: 1.tLevity
+  }
+  scope 1 = "aihc-prim" GHC.Prim
+  scope 2 = "aihc-prim" GHC.Types
+
+  module 1.GHC.Prim where
+
+  pub type 1.tMutVar# (d{23} : 2.tType) (a{25} : 2.tType) :: 2.tTYPE 2.tUnliftedRep {}
+status: pass
+reason: UnliftedType in a kind signature stays an unlifted result kind.

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -537,7 +537,8 @@ typeAsKind :: TcType -> Kind
 typeAsKind ty =
   case ty of
     TcTyCon tyCon []
-      | tyConName tyCon `elem` ["*", "Type"] -> KType
+      | tyConName tyCon `elem` ["*", "Type", "LiftedType"] -> KType
+      | tyConName tyCon == "UnliftedType" -> KTYPE (BoxedRep Unlifted)
       | tyConName tyCon == "Constraint" -> KConstraint
       | tyConName tyCon == "RuntimeRep" -> KRuntimeRep
       | tyConName tyCon == "Levity" -> KLevity
@@ -557,6 +558,8 @@ typeAsBuiltinKind name arguments =
   case (bareName name, arguments) of
     ("*", []) -> KType
     ("Type", []) -> KType
+    ("LiftedType", []) -> KType
+    ("UnliftedType", []) -> KTYPE (BoxedRep Unlifted)
     ("Constraint", []) -> KConstraint
     ("RuntimeRep", []) -> KRuntimeRep
     ("Levity", []) -> KLevity

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -251,7 +251,7 @@ It may parse imported `core-v2` files through the store loader.
 | 7 | `feat(fc2): desugar type families` | done, #1492 |
 | 8 | `feat(fc2): accept foreign import prim and reject ccall` | done, #1493 |
 | 9 | `feat(fc2): write core-v2 from install-v2` | done |
-| 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | planned |
+| 10 | `fix(fc2): correct System FC 2 output for aihc-prim` | done |
 | 11 | `feat(fc2): add System FC 2 type linter` | done |
 
 PR 4 depends on PR 3.

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -75,8 +75,14 @@
               preCheck =
                 (old.preCheck or "")
                 + ''
-                  export AIHC_BASE_SRC=${sources.baseSrc pkgs}
-                  export AIHC_PRIM_SRC=${sources.primSrc pkgs}
+                  coreLibsRoot="$TMPDIR/aihc-core-libs-root"
+                  mkdir -p "$coreLibsRoot/core-libs"
+                  ln -sfn ${sources.baseSrc pkgs} "$coreLibsRoot/core-libs/aihc-base"
+                  ln -sfn ${sources.primSrc pkgs} "$coreLibsRoot/core-libs/aihc-prim"
+                  ln -sfn ${sources.internalSrc pkgs} "$coreLibsRoot/core-libs/aihc-internal"
+                  export AIHC_CORE_LIBS_ROOT="$coreLibsRoot"
+                  export AIHC_BASE_SRC="$coreLibsRoot/core-libs/aihc-base"
+                  export AIHC_PRIM_SRC="$coreLibsRoot/core-libs/aihc-prim"
                 '';
             }
         )


### PR DESCRIPTION
Correct System FC 2 output for `aihc-prim`.

`install-v2` of `core-libs/aihc-prim` writes `core-v2` for each module.
Each file parses.
Lint of `GHC.Types` and `GHC.Prim` passes after both files load.
Lint of the other `aihc-prim` modules passes with the store loader.

The change keeps unboxed primitive types distinct from their kinds.

Depends on: System FC 2 type linter.

Progress counts: no change.