### PR TITLE
fix(cli): remove Core-v1 from install-v2

### DIFF
--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -18,7 +18,7 @@ import Aihc.Cli.Options (InstallV2Options (..))
 import Aihc.Cli.ResolveArtifact (ResolveArtifact (..), decodeResolveArtifact, encodeResolveArtifact, encodeResolveScope)
 import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact, encodeTypeArtifact, encodeTypeInterface)
-import Aihc.Fc (DesugarConfig (..), DesugarResult (..), desugarModuleWithInterface, emptyLintEnv, lintProgram, renderProgram)
+import Aihc.Fc (DesugarConfig (..))
 import Aihc.Fc2 (Fc2DesugarResult (..), desugarModuleFc2)
 import Aihc.Fc2 qualified as Fc2
 import Aihc.Hackage.Cabal qualified as HackageCabal
@@ -231,7 +231,6 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       hashes = sortOn fst (sourceHashes <> Map.toList dependencyHashes)
       resolvePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "resolve.cbor"
       typePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "type.cbor"
-      corePath modu = storePath </> moduleDirectory modu </> "core"
       coreV2Path modu = storePath </> moduleDirectory modu </> "core-v2"
   cachedExports <- tryReadUnitArtifacts hashes resolvePackage resolvePath unit
   (diskExports, resolveResult, resolveChanged) <- case cachedExports of
@@ -277,16 +276,15 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       storedInterfaces <- readTypeArtifacts typeInputs typePath unit
       pure (storedInterfaces, True, Just checked)
   updatedTypeHashes <- updateTypeHashes typePath typeHashes unit
-  coreExists <- and <$> mapM (doesFileExist . corePath . sourceModuleAst) unit
   coreV2Exists <- and <$> mapM (doesFileExist . coreV2Path . sourceModuleAst) unit
   coreChanged <-
-    if typeChanged || not coreExists || not coreV2Exists
+    if typeChanged || not coreV2Exists
       then do
         (checkedModules, completeInterface) <- maybe checkUnit pure checkedResult
-        writeCoreFiles verbose primIdentity completeInterface (takeDirectory storePath) corePath checkedModules
+        writeCoreV2Files verbose primIdentity completeInterface (takeDirectory storePath) coreV2Path checkedModules
         pure True
       else do
-        mapM_ (verbose . ("Reuse Core: " <>) . T.unpack) unitNames
+        mapM_ (verbose . ("Reuse Core-v2: " <>) . T.unpack) unitNames
         pure False
   let changed = resolveChanged || typeChanged || coreChanged
       unitSet = Set.fromList unitNames
@@ -304,84 +302,40 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
   where
     sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
 
-writeCoreFiles :: (String -> IO ()) -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> [Module] -> IO ()
-writeCoreFiles verbose primIdentity interface storeRoot corePath checkedModules = do
+writeCoreV2Files :: (String -> IO ()) -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> [Module] -> IO ()
+writeCoreV2Files verbose primIdentity interface storeRoot coreV2Path checkedModules = do
   let bindings = tcInterfaceBindings interface <> concatMap tcModuleBindings checkedModules
       config = DesugarConfig primIdentity
-      results = map (desugarModuleWithInterface config bindings interface) checkedModules
       results2 = map (desugarModuleFc2 config bindings interface) checkedModules
   unless (all ds2Success results2) (ioError (userError ("Core-v2 generation failed: " <> unlines (concatMap ds2Errors results2))))
-  unless (all dsSuccess results) (ioError (userError ("Core generation failed: " <> unlines (concatMap dsErrors results))))
   loadedFc2 <- Fc2.loadScopeClosure (Fc2.storeModuleLoader storeRoot) (map ds2Program results2)
-  let lintFailures =
-        [ (modu, result, result2, errors)
-        | (modu, result, result2) <- zip3 checkedModules results results2,
-          let errors = lintProgram emptyLintEnv (dsProgram result),
-          not (null errors)
-        ]
-      fc2Errors = Fc2.lintPrograms loadedFc2
-      lintReport = concatMap renderLintFailure lintFailures
+  let fc2Errors = Fc2.lintPrograms loadedFc2
       fc2Report = map (("    " <>) . show) fc2Errors
-  unless (null lintFailures && null fc2Errors) $ do
-    if null lintFailures
-      then mapM_ writeBadFc2 (zip3 checkedModules results results2)
-      else mapM_ writeBadCore lintFailures
+  unless (null fc2Errors) $ do
+    mapM_ writeBadFc2 (zip checkedModules results2)
     ioError
       ( userError
           ( unlines
-              ( ["Core lint failed:" | not (null lintFailures)]
-                  <> lintReport
-                  <> ["Core-v2 lint failed:" | not (null fc2Errors)]
+              ( ["Core-v2 lint failed:"]
                   <> fc2Report
               )
           )
       )
-  mapM_ writeCore (zip3 checkedModules results results2)
+  mapM_ writeCoreV2 (zip checkedModules results2)
   where
-    coreV2Path modu = takeDirectory (corePath modu) </> "core-v2"
-
-    renderLintFailure (modu, _, _, errors) =
-      ("  module " <> T.unpack (fromMaybe "Main" (moduleName modu)) <> ":")
-        : ("    bad Core file: " <> corePath modu <> ".bad")
-        : ("    bad Core-v2 file: " <> coreV2Path modu <> ".bad")
-        : map (("    " <>) . show) errors
-
-    writeBadCore (modu, result, result2, _) = do
-      let path = corePath modu <> ".bad"
-          pathV2 = coreV2Path modu <> ".bad"
-          name = fromMaybe "Main" (moduleName modu)
-      removeFileIfExists (corePath modu)
-      removeFileIfExists (coreV2Path modu)
-      writeCoreFile path result
-      writeCoreV2File pathV2 result2
-      verbose ("Write bad Core: " <> T.unpack name <> " -> " <> path)
-      verbose ("Write bad Core-v2: " <> T.unpack name <> " -> " <> pathV2)
-
-    writeBadFc2 (modu, _, result2) = do
+    writeBadFc2 (modu, result2) = do
       let pathV2 = coreV2Path modu <> ".bad"
           name = fromMaybe "Main" (moduleName modu)
-      removeFileIfExists (corePath modu)
-      removeFileIfExists (corePath modu <> ".bad")
       removeFileIfExists (coreV2Path modu)
       writeCoreV2File pathV2 result2
       verbose ("Write bad Core-v2: " <> T.unpack name <> " -> " <> pathV2)
 
-    writeCore (modu, result, result2) = do
-      let path = corePath modu
-          pathV2 = coreV2Path modu
+    writeCoreV2 (modu, result2) = do
+      let pathV2 = coreV2Path modu
           name = fromMaybe "Main" (moduleName modu)
-      removeFileIfExists (path <> ".bad")
       removeFileIfExists (pathV2 <> ".bad")
-      writeCoreFile path result
       writeCoreV2File pathV2 result2
-      verbose ("Write Core: " <> T.unpack name)
       verbose ("Write Core-v2: " <> T.unpack name)
-
-    writeCoreFile path result = do
-      let rendered = renderProgram (dsProgram result)
-          output = if "\n" `isSuffixOf` rendered then rendered else rendered <> "\n"
-      createDirectoryIfMissing True (takeDirectory path)
-      writeFile path output
 
     writeCoreV2File path result = do
       let rendered = Fc2.renderProgram (ds2Program result)

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -5,7 +5,6 @@ module Main (main) where
 import Aihc.Cli.InstallV2 (InstallV2Result (..), installV2)
 import Aihc.Cli.Options (InstallV2Options (..))
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact)
-import Aihc.Fc qualified as Fc
 import Aihc.Fc2 qualified as Fc2
 import Aihc.Resolve (PackageId (..))
 import Aihc.Tc (TcInterface (..), tcTermKeyIdentifier)
@@ -335,7 +334,7 @@ main =
       --   ],
       testGroup
         "install-v2"
-        [ testCase "writes one resolve artifact for each module and reuses equal SCC inputs" test_installV2ResolveArtifacts,
+        [ testCase "writes no legacy Core files and reuses equal SCC inputs" test_installV2ResolveArtifacts,
           testCase "rebuilds a module when a predecessor resolve artifact changes" test_installV2ResolveDependencies,
           testCase "rebuilds a module when a predecessor type interface changes" test_installV2TypeDependencies,
           testCase "duplicates re-exported term signatures in type interfaces" test_installV2TypeReexports,
@@ -379,8 +378,8 @@ test_installV2ResolveArtifacts =
     assertFileExists (installV2StorePath first </> "Demo" </> "B" </> "resolve.cbor")
     assertFileExists (installV2StorePath first </> "Demo" </> "A" </> "type.cbor")
     assertFileExists (installV2StorePath first </> "Demo" </> "B" </> "type.cbor")
-    assertCoreFile (installV2StorePath first </> "Demo" </> "A" </> "core")
-    assertCoreFile (installV2StorePath first </> "Demo" </> "B" </> "core")
+    assertFileDoesNotExist (installV2StorePath first </> "Demo" </> "A" </> "core")
+    assertFileDoesNotExist (installV2StorePath first </> "Demo" </> "B" </> "core")
     assertCoreV2File (installV2StorePath first </> "Demo" </> "A" </> "core-v2")
     assertCoreV2File (installV2StorePath first </> "Demo" </> "B" </> "core-v2")
     second <- installV2 options
@@ -388,9 +387,6 @@ test_installV2ResolveArtifacts =
     assertEqual "stable package directory" (installV2StorePath first) (installV2StorePath second)
     assertCoreV2File (installV2StorePath second </> "Demo" </> "A" </> "core-v2")
     assertCoreV2File (installV2StorePath second </> "Demo" </> "B" </> "core-v2")
-    removeFile (installV2StorePath first </> "Demo" </> "A" </> "core")
-    coreRepaired <- installV2 options
-    assertEqual "repairs the complete SCC with cached types" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules coreRepaired))
     removeFile (installV2StorePath first </> "Demo" </> "A" </> "core-v2")
     coreV2Repaired <- installV2 options
     assertEqual "repairs the complete SCC when core-v2 is absent" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules coreV2Repaired))
@@ -404,14 +400,6 @@ test_installV2ResolveArtifacts =
     repaired <- installV2 options
     assertEqual "repairs the complete corrupt SCC" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules repaired))
     assertEqual "does not reuse a corrupt SCC" [] (installV2ReusedModules repaired)
-
-assertCoreFile :: FilePath -> Assertion
-assertCoreFile path = do
-  assertFileExists path
-  core <- TIO.readFile path
-  case Fc.parseProgram core of
-    Left parseError -> assertFailure ("invalid Core file " <> path <> ": " <> Fc.renderParseError parseError)
-    Right program -> assertEqual ("Core lint errors in " <> path) [] (Fc.lintProgram Fc.emptyLintEnv program)
 
 assertCoreV2File :: FilePath -> Assertion
 assertCoreV2File path = do
@@ -1632,6 +1620,11 @@ assertFileExists :: FilePath -> Assertion
 assertFileExists path = do
   exists <- doesFileExist path
   assertBool ("expected file to exist: " <> path) exists
+
+assertFileDoesNotExist :: FilePath -> Assertion
+assertFileDoesNotExist path = do
+  exists <- doesFileExist path
+  assertBool ("expected file not to exist: " <> path) (not exists)
 
 {- Disabled with the related test groups in main.
 assertFileDoesNotExist :: FilePath -> Assertion


### PR DESCRIPTION
## Summary

- Remove Core-v1 generation and lint checks from `install-v2`.
- Keep Core-v2 generation, lint checks, and cache repair.
- Verify that `install-v2` does not write legacy Core files.

## Progress counts

- Keep the `install-v2` test count at 9.
- Keep all repository progress counts unchanged.

## Tests

- `just check`