### PR TITLE
fix(tc): use module origin for family representation types

### DIFF
--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/data-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/data-family-instance.yaml
@@ -7,17 +7,16 @@ modules:
     data instance Payload a = PayloadValue a
 expected: |-
   scope 1 = "" Test
-  scope 2 = "aihc-internal" Aihc.Internal
-  scope 3 = "aihc-prim" GHC.Types
+  scope 2 = "aihc-prim" GHC.Types
 
   module 1.Test where
 
-  pub type 1.tPayload (a : 3.tType) :: 3.tType @N {}
+  pub type 1.tPayload (a : 2.tType) :: 2.tType @N {}
 
-  type 2.t$R$Payload$PayloadValue (a{12} : 3.tType) :: 3.tType {
-      1.vPayloadValue :: ∀(a{12} : 3.tType). a{12} → 2.t$R$Payload$PayloadValue a{12}
+  type 1.t$R$Payload$PayloadValue (a{12} : 2.tType) :: 2.tType {
+      1.vPayloadValue :: ∀(a{12} : 2.tType). a{12} → 1.t$R$Payload$PayloadValue a{12}
   }
 
-  axiom 1.$ax$Payload$PayloadValue (a{12} : 3.tType) : 1.tPayload a{12} ~N 2.t$R$Payload$PayloadValue a{12}
+  axiom 1.$ax$Payload$PayloadValue (a{12} : 2.tType) : 1.tPayload a{12} ~N 1.t$R$Payload$PayloadValue a{12}
 status: pass
 reason: A data family is an empty type. An instance adds a hidden representation type and a nominal axiom.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-family-instance.yaml
@@ -8,21 +8,20 @@ modules:
     newtype instance Wrapped Unit = WrappedUnit Unit
 expected: |-
   scope 1 = "" Test
-  scope 2 = "aihc-internal" Aihc.Internal
-  scope 3 = "aihc-prim" GHC.Types
+  scope 2 = "aihc-prim" GHC.Types
 
   module 1.Test where
 
-  pub type 1.tUnit :: 3.tType {
+  pub type 1.tUnit :: 2.tType {
       pub 1.vUnit :: 1.tUnit
   }
 
-  pub type 1.tWrapped (a : 3.tType) :: 3.tType @N {}
+  pub type 1.tWrapped (a : 2.tType) :: 2.tType @N {}
 
-  type 2.t$R$Wrapped$WrappedUnit :: 3.tType {}
+  type 1.t$R$Wrapped$WrappedUnit :: 2.tType {}
 
-  axiom 1.$ax$R$Wrapped$WrappedUnit : 2.t$R$Wrapped$WrappedUnit ~R 1.tUnit
+  axiom 1.$ax$R$Wrapped$WrappedUnit : 1.t$R$Wrapped$WrappedUnit ~R 1.tUnit
 
-  axiom 1.$ax$Wrapped$WrappedUnit : 1.tWrapped 1.tUnit ~N 2.t$R$Wrapped$WrappedUnit
+  axiom 1.$ax$Wrapped$WrappedUnit : 1.tWrapped 1.tUnit ~N 1.t$R$Wrapped$WrappedUnit
 status: pass
 reason: A newtype family instance is an empty representation type plus two axioms.

--- a/components/aihc-fc/test/Test/Fixtures/golden/data-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/data-family-instance.yaml
@@ -7,13 +7,12 @@ modules:
     data instance Payload a = PayloadValue a
 expected: |-
   scope 1 = "" Test
-  scope 2 = "aihc-internal" Aihc.Internal
 
   module 1.Test where
 
   data 1.$R$Payload$PayloadValue (a{unique 22} : Type) : Type
    = 1.PayloadValue ((a{unique 22} : Type))
 
-  axiom $ax$Payload$PayloadValue (a{unique 22} : Type) : tycon 1.Payload/1 { :: Type → Type }[(a{unique 22} : Type)] ~N tycon 2.$R$Payload$PayloadValue/1 { :: Type → Type }[(a{unique 22} : Type)]
+  axiom $ax$Payload$PayloadValue (a{unique 22} : Type) : tycon 1.Payload/1 { :: Type → Type }[(a{unique 22} : Type)] ~N tycon 1.$R$Payload$PayloadValue/1 { :: Type → Type }[(a{unique 22} : Type)]
 status: pass
 reason: data-family instances retain an explicit representation type and nominal equality axiom in System FC

--- a/components/aihc-fc/test/Test/Fixtures/golden/newtype-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden/newtype-family-instance.yaml
@@ -8,15 +8,14 @@ modules:
     newtype instance Wrapped Unit = WrappedUnit Unit
 expected: |-
   scope 1 = "" Test
-  scope 2 = "aihc-internal" Aihc.Internal
 
   module 1.Test where
 
   data 1.Unit : Type
    = 1.Unit
 
-  newtype 1.$R$Wrapped$WrappedUnit : tycon 2.$R$Wrapped$WrappedUnit/0 { :: Type } = 1.WrappedUnit tycon 1.Unit/0 { :: Type }
+  newtype 1.$R$Wrapped$WrappedUnit : tycon 1.$R$Wrapped$WrappedUnit/0 { :: Type } = 1.WrappedUnit tycon 1.Unit/0 { :: Type }
 
-  axiom $ax$Wrapped$WrappedUnit : tycon 1.Wrapped/1 { :: Type → Type }[tycon 1.Unit/0 { :: Type }] ~N tycon 2.$R$Wrapped$WrappedUnit/0 { :: Type }
+  axiom $ax$Wrapped$WrappedUnit : tycon 1.Wrapped/1 { :: Type → Type }[tycon 1.Unit/0 { :: Type }] ~N tycon 1.$R$Wrapped$WrappedUnit/0 { :: Type }
 status: pass
 reason: newtype-family instances retain a representation newtype and their nominal family equation

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -1947,7 +1947,7 @@ registerTypeDeclHeader _ _ = pure []
 registerStructuralDecl :: (Text, Text) -> Decl -> TcM [TcBindingResult]
 registerStructuralDecl _ (DeclData dataDecl) = registerDataConstructors dataDecl
 registerStructuralDecl _ (DeclNewtype newtypeDecl) = registerNewtypeConstructor newtypeDecl
-registerStructuralDecl _ (DeclDataFamilyInst familyInst) = registerDataFamilyInstance familyInst
+registerStructuralDecl origin (DeclDataFamilyInst familyInst) = registerDataFamilyInstance origin familyInst
 registerStructuralDecl _ (DeclTypeFamilyDecl familyDecl) = registerClosedTypeFamilyEquations familyDecl
 registerStructuralDecl _ (DeclTypeFamilyInst familyInst) = registerTypeFamilyInstance familyInst
 registerStructuralDecl origin (DeclClass classDecl) = registerClassDecl origin classDecl
@@ -2131,8 +2131,8 @@ registerDataFamilyDeclHeader maybeKindScheme familyDecl = do
   zonkedKind <- defaultKindMetas declaredKind
   pure [TcBindingResult familyName familyName (kindToTcType zonkedKind)]
 
-registerDataFamilyInstance :: DataFamilyInst -> TcM [TcBindingResult]
-registerDataFamilyInstance familyInst = do
+registerDataFamilyInstance :: (Text, Text) -> DataFamilyInst -> TcM [TcBindingResult]
+registerDataFamilyInstance (packageName, moduleName') familyInst = do
   paramInfos <- dataFamilyInstanceParams familyInst
   let tvEnv =
         Map.fromList
@@ -2153,7 +2153,13 @@ registerDataFamilyInstance familyInst = do
               representationKind <- tyConKindFromParams paramInfos (dataFamilyInstKind familyInst)
               let familyName = tciName familyInfo
                   representationName = dataFamilyRepresentationName familyName firstConstructor
-                  representationTyCon = mkTyCon representationName (length paramInfos) representationKind
+                  representationTyCon =
+                    mkTyConWithOrigin
+                      (PackageId packageName)
+                      moduleName'
+                      representationName
+                      (length paramInfos)
+                      representationKind
                   axiomName = dataFamilyAxiomName familyName firstConstructor
                   instanceInfo =
                     DataFamilyInstanceInfo


### PR DESCRIPTION
## Summary

- Use the source module identity for generated data-family representation types.
- Remove incorrect internal scopes from Core v1 and Core v2 output.

## Tests

- `just fmt`
- `just check`

## Progress counts

- Pass counts do not change.