### PR TITLE
fix(cli): format install-v2 resolve errors

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -8,6 +8,10 @@ author: David Himmelstrup
 maintainer: lemmih@gmail.com
 category: Development
 synopsis: Production command-line interface for the aihc compiler
+extra-source-files:
+  test/Test/Fixtures/install-v2/resolve-error/demo.cabal
+  test/Test/Fixtures/install-v2/resolve-error/expected.txt
+  test/Test/Fixtures/install-v2/resolve-error/src/Demo.hs
 
 library
   exposed-modules:

--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -25,13 +25,15 @@ import Aihc.Hackage.Cabal qualified as HackageCabal
 import Aihc.Hackage.Download qualified as HackageDownload
 import Aihc.Hackage.Util qualified as HackageUtil
 import Aihc.Hackage.VersionResolver (getLatestVersion)
-import Aihc.Parser.Syntax (ImportDecl (..), Module, Name (..), moduleName)
+import Aihc.Parser.Syntax (ImportDecl (..), Module, Name (..), SourceSpan (..), moduleName)
 import Aihc.Parser.Syntax qualified as Syntax
 import Aihc.Resolve
   ( ModuleExports,
     ModuleKey (..),
     Package (..),
     PackageId (..),
+    ResolutionNamespace (..),
+    ResolveError (..),
     ResolveResult (..),
     ResolvedName (..),
     Scope (..),
@@ -66,7 +68,7 @@ import Data.Bits (xor)
 import Data.ByteString qualified as BS
 import Data.ByteString.Lazy qualified as BL
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (isSuffixOf, nub, sortOn)
+import Data.List (intercalate, isSuffixOf, nub, sortOn)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe, mapMaybe)
 import Data.Set qualified as Set
@@ -92,7 +94,8 @@ data InstallV2Result = InstallV2Result
 data SourceModule = SourceModule
   { sourceModulePath :: !FilePath,
     sourceModuleHash :: !Text,
-    sourceModuleAst :: !Module
+    sourceModuleAst :: !Module,
+    sourceModuleSourceLines :: !(Map.Map FilePath (Map.Map Int Text))
   }
 
 data InstalledV2Package = InstalledV2Package
@@ -209,7 +212,7 @@ parseSource root fileInfo = do
   bytes <- BS.readFile (HackageCabal.fileInfoPath fileInfo)
   parsed <- parseInterfaceFile root fileInfo
   case parsed of
-    ParsedFileOk path modu _ _ -> pure (SourceModule path (T.pack (stableHash [bytes])) modu)
+    ParsedFileOk path modu sourceLines _ -> pure (SourceModule path (T.pack (stableHash [bytes])) modu sourceLines)
     ParsedFileFailed path _ _ _ -> ioError (userError ("Failed to parse " <> path))
 
 sourceModuleSccs :: [SourceModule] -> [[SourceModule]]
@@ -220,6 +223,67 @@ sourceModuleSccs = map flatten . stronglyConnComp . map node
     moduleImportsOf = Syntax.moduleImports . sourceModuleAst
     flatten (AcyclicSCC value) = [value]
     flatten (CyclicSCC values) = values
+
+renderResolveErrors :: [SourceModule] -> [ResolveError] -> String
+renderResolveErrors sources errors =
+  "Name resolution failed:\n"
+    <> intercalate "\n\n" (map (renderResolveError sourceLines) errors)
+    <> "\n"
+  where
+    sourceLines = Map.unions (map sourceModuleSourceLines sources)
+
+renderResolveError :: Map.Map FilePath (Map.Map Int Text) -> ResolveError -> String
+renderResolveError sourceLines resolveError =
+  case resolveError of
+    ResolveResolutionError sourceSpan name namespace message ->
+      renderResolveLocation sourceSpan
+        <> ": error: "
+        <> renderResolveMessage message name namespace
+        <> renderResolveExcerpt sourceLines sourceSpan
+    ResolveNotImplemented message -> "error: not implemented: " <> message
+
+renderResolveLocation :: SourceSpan -> String
+renderResolveLocation sourceSpan =
+  case sourceSpan of
+    NoSourceSpan -> "<unknown location>"
+    SourceSpan sourceName startLine startColumn _ _ _ _ ->
+      sourceName <> ":" <> show startLine <> ":" <> show startColumn
+
+renderResolveMessage :: String -> Text -> ResolutionNamespace -> String
+renderResolveMessage message name namespace
+  | message == "unbound" = "unbound " <> renderedNamespace <> " name ‘" <> T.unpack name <> "’"
+  | message == "not found" = renderedNamespace <> " ‘" <> T.unpack name <> "’ not found"
+  | otherwise = message <> ": " <> renderedNamespace <> " name ‘" <> T.unpack name <> "’"
+  where
+    renderedNamespace =
+      case namespace of
+        ResolutionNamespaceTerm -> "term"
+        ResolutionNamespaceType -> "type"
+        ResolutionNamespaceModule -> "module"
+
+renderResolveExcerpt :: Map.Map FilePath (Map.Map Int Text) -> SourceSpan -> String
+renderResolveExcerpt sourceLines sourceSpan =
+  case sourceSpan of
+    NoSourceSpan -> ""
+    SourceSpan sourceName startLine startColumn endLine endColumn _ _ ->
+      case Map.lookup sourceName sourceLines >>= Map.lookup startLine of
+        Nothing -> ""
+        Just sourceLine ->
+          let lineNumber = show startLine
+              gutterWidth = length lineNumber
+              caretStart = max 0 (startColumn - 1)
+              caretWidth
+                | startLine == endLine = max 1 (endColumn - startColumn)
+                | otherwise = max 1 (T.length sourceLine - caretStart)
+           in "\n  "
+                <> lineNumber
+                <> " | "
+                <> T.unpack sourceLine
+                <> "\n  "
+                <> replicate gutterWidth ' '
+                <> " | "
+                <> replicate caretStart ' '
+                <> replicate caretWidth '^'
 
 installUnit :: (String -> IO ()) -> FilePath -> Package -> PackageId -> FilePath -> (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text) -> [SourceModule] -> IO (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text)
 installUnit verbose storePath resolvePackage primIdentity root (dependencyExports, scopeHashes, dependencyTypes, typeHashes, written, reused) unit = do
@@ -239,7 +303,7 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       pure (exports, Nothing, False)
     Nothing -> do
       let result = resolveWithDeps dependencyExports packageModules
-      unless (null (resolveErrors result)) (ioError (userError ("Name resolution failed: " <> show (resolveErrors result))))
+      unless (null (resolveErrors result)) (ioError (userError (renderResolveErrors unit (resolveErrors result))))
       let exports = extractInterfaceWithDeps dependencyExports result
       mapM_ (\source -> writeArtifact verbose hashes exports resolvePackage (resolvePath source) source) unit
       storedExports <- readUnitArtifacts hashes resolvePackage resolvePath unit
@@ -255,7 +319,7 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
           Just result -> pure result
           Nothing -> do
             let result = resolveWithDeps dependencyExports packageModules
-            unless (null (resolveErrors result)) (ioError (userError ("Name resolution failed: " <> show (resolveErrors result))))
+            unless (null (resolveErrors result)) (ioError (userError (renderResolveErrors unit (resolveErrors result))))
             pure result
         let checked@(checkedModules, _) =
               typecheckModuleSccWithInterfaceConfig

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -30,6 +30,7 @@ import System.Directory
 import System.Environment (lookupEnv)
 import System.FilePath (takeDirectory, takeFileName, (</>))
 import System.IO (hClose, openTempFile)
+import System.IO.Error (ioeGetErrorString)
 import Test.Tasty (defaultMain, testGroup)
 import Test.Tasty.HUnit (Assertion, assertBool, assertEqual, assertFailure, testCase)
 import Test.Tasty.Hedgehog (testProperty)
@@ -341,6 +342,7 @@ main =
           testCase "installs direct local dependencies" test_installV2LocalDependencies,
           testCase "rebuilds stale type artifact schemas" test_installV2StaleTypeArtifact,
           testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope,
+          testCase "reports resolve errors with source locations" test_installV2ResolveError,
           testCase "writes no core files when System FC 2 desugar fails" test_installV2Fc2DesugarFailure,
           testCase "install-v2 writes core-v2 for aihc-prim and lints stored programs" test_installV2AihcPrim
         ],
@@ -400,6 +402,37 @@ test_installV2ResolveArtifacts =
     repaired <- installV2 options
     assertEqual "repairs the complete corrupt SCC" ["Demo.A", "Demo.B"] (sort (installV2WrittenModules repaired))
     assertEqual "does not reuse a corrupt SCC" [] (installV2ReusedModules repaired)
+
+test_installV2ResolveError :: Assertion
+test_installV2ResolveError = do
+  fixtureRoot <- findFixtureRoot "bin/aihc/test/Test/Fixtures/install-v2/resolve-error"
+  expected <- readFile (fixtureRoot </> "expected.txt")
+  withTempDir "aihc-install-v2-resolve-error" $ \root -> do
+    let options = InstallV2Options fixtureRoot (Just (root </> "store")) False
+    result <- try (installV2 options) :: IO (Either IOException InstallV2Result)
+    case result of
+      Right _ -> assertFailure "expected name resolution to fail"
+      Left err ->
+        assertEqual
+          "formatted name resolution error"
+          expected
+          (T.unpack (T.replace (T.pack fixtureRoot) "<PACKAGE>" (T.pack (ioeGetErrorString err))))
+
+findFixtureRoot :: FilePath -> IO FilePath
+findFixtureRoot fixture = do
+  cwd <- getCurrentDirectory
+  findUp cwd
+  where
+    findUp directory = do
+      let candidate = directory </> fixture
+      exists <- doesDirectoryExist candidate
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory directory
+          if parent == directory
+            then assertFailure ("could not find fixture " <> fixture)
+            else findUp parent
 
 assertCoreV2File :: FilePath -> Assertion
 assertCoreV2File path = do

--- a/bin/aihc/test/Test/Fixtures/install-v2/resolve-error/demo.cabal
+++ b/bin/aihc/test/Test/Fixtures/install-v2/resolve-error/demo.cabal
@@ -1,0 +1,8 @@
+cabal-version: 3.0
+name: demo
+version: 0.1.0.0
+
+library
+  exposed-modules: Demo
+  hs-source-dirs: src
+  default-language: Haskell2010

--- a/bin/aihc/test/Test/Fixtures/install-v2/resolve-error/expected.txt
+++ b/bin/aihc/test/Test/Fixtures/install-v2/resolve-error/expected.txt
@@ -1,0 +1,4 @@
+Name resolution failed:
+<PACKAGE>/src/Demo.hs:3:16: error: unbound type name ‘MissingType’
+  3 | data Box = Box MissingType
+    |                ^^^^^^^^^^^

--- a/bin/aihc/test/Test/Fixtures/install-v2/resolve-error/src/Demo.hs
+++ b/bin/aihc/test/Test/Fixtures/install-v2/resolve-error/src/Demo.hs
@@ -1,0 +1,3 @@
+module Demo where
+
+data Box = Box MissingType

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -171,6 +171,7 @@ in rec {
   aihcSrc = mkRootSubsetSrc ["bin/aihc/"] [
     ".hs"
     ".cabal"
+    "expected.txt"
   ];
 
   examplesSrc = mkRootSubsetSrc ["examples/"] exampleSourceSuffixes;


### PR DESCRIPTION
## Summary

- Format each `install-v2` name resolution error as a diagnostic.
- Show the source file, line, column, source line, and caret range.
- Keep preprocessed source lines with each parsed module for diagnostic output.

## Progress counts

- Increase the `aihc` test count from 34 to 35.
- Add one `install-v2` diagnostic fixture.

## Tests

- `just check`
- `cabal run -v0 aihc -- install-v2 core-libs/aihc-base`