### PR TITLE
fix(base): import primitive types

### DIFF
--- a/core-libs/aihc-base/src/GHC/Internal/Integer.hs
+++ b/core-libs/aihc-base/src/GHC/Internal/Integer.hs
@@ -28,9 +28,11 @@ where
 
 import GHC.Prim
   ( ByteArray#,
+    Int#,
     MutableByteArray#,
     RealWorld,
     State#,
+    Word#,
     addIntC#,
     addWordC#,
     and#,

--- a/core-libs/aihc-base/src/GHC/Ptr.hs
+++ b/core-libs/aihc-base/src/GHC/Ptr.hs
@@ -2,4 +2,6 @@
 
 module GHC.Ptr (Ptr (..)) where
 
+import GHC.Prim (Addr#)
+
 data Ptr a = Ptr Addr#

--- a/core-libs/aihc-base/src/GHC/Word.hs
+++ b/core-libs/aihc-base/src/GHC/Word.hs
@@ -9,6 +9,8 @@ module GHC.Word
   )
 where
 
+import GHC.Prim (Word#, Word16#, Word32#, Word64#, Word8#)
+
 data Word = W# Word#
 
 data Word8 = W8# Word8#


### PR DESCRIPTION
## Summary

- Import primitive word types in `GHC.Word`.
- Import `Addr#` in `GHC.Ptr`.
- Import `Int#` and `Word#` in `GHC.Internal.Integer`.

## Validation

- Run `just fmt` successfully.
- Run `just check` successfully.
- Confirm that `install-v2` completes name resolution for `aihc-base`.

## Progress counts

- No progress count changes.