### PR TITLE
refactor(fc2): remove the program module field

### DIFF
--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -281,7 +281,7 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
     if typeChanged || not coreV2Exists
       then do
         (checkedModules, completeInterface) <- maybe checkUnit pure checkedResult
-        writeCoreV2Files verbose primIdentity completeInterface (takeDirectory storePath) coreV2Path checkedModules
+        writeCoreV2Files verbose (packageId resolvePackage) primIdentity completeInterface (takeDirectory storePath) coreV2Path checkedModules
         pure True
       else do
         mapM_ (verbose . ("Reuse Core-v2: " <>) . T.unpack) unitNames
@@ -302,13 +302,18 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
   where
     sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
 
-writeCoreV2Files :: (String -> IO ()) -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> [Module] -> IO ()
-writeCoreV2Files verbose primIdentity interface storeRoot coreV2Path checkedModules = do
+writeCoreV2Files :: (String -> IO ()) -> PackageId -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> [Module] -> IO ()
+writeCoreV2Files verbose currentPackage primIdentity interface storeRoot coreV2Path checkedModules = do
   let bindings = tcInterfaceBindings interface <> concatMap tcModuleBindings checkedModules
       config = DesugarConfig primIdentity
       results2 = map (desugarModuleFc2 config bindings interface) checkedModules
+      currentModules = Set.fromList (map (fromMaybe "Main" . moduleName) checkedModules)
+      storeLoader = Fc2.storeModuleLoader storeRoot
+      dependencyLoader package name
+        | package == currentPackage && name `Set.member` currentModules = pure Nothing
+        | otherwise = storeLoader package name
   unless (all ds2Success results2) (ioError (userError ("Core-v2 generation failed: " <> unlines (concatMap ds2Errors results2))))
-  loadedFc2 <- Fc2.loadScopeClosure (Fc2.storeModuleLoader storeRoot) (map ds2Program results2)
+  loadedFc2 <- Fc2.loadScopeClosure dependencyLoader (map ds2Program results2)
   let fc2Errors = Fc2.lintPrograms loadedFc2
       fc2Report = map (("    " <>) . show) fc2Errors
   unless (null fc2Errors) $ do

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -78,14 +78,14 @@ desugarModuleFc2 config bindings interface checked =
   if not (tcModuleSuccess checked)
     then
       Fc2DesugarResult
-        { ds2Program = Program (ModuleId "" (fromMaybe "Main" (Syn.moduleName checked))) emptyScopeTable [],
+        { ds2Program = Program emptyScopeTable [],
           ds2Success = False,
           ds2Errors = fmap show (tcModuleDiagnostics checked)
         }
     else case desugarChecked config bindings interface checked of
       Left errors ->
         Fc2DesugarResult
-          { ds2Program = Program (ModuleId "" (fromMaybe "Main" (Syn.moduleName checked))) emptyScopeTable [],
+          { ds2Program = Program emptyScopeTable [],
             ds2Success = False,
             ds2Errors = [errors]
           }
@@ -99,7 +99,7 @@ desugarModuleFc2 config bindings interface checked =
 desugarChecked :: DesugarConfig -> [TcBindingResult] -> TcInterface -> Module -> Either String Program
 desugarChecked config bindings interface checked = do
   let (packageId, currentModule) = resolvedModuleOrigin checked
-      moduleId = ModuleId packageId currentModule
+      moduleOrigin = (packageId, currentModule)
       dataTypes = tcInterfaceDataTypes interface
       tyCons = tcInterfaceTyCons interface
       classes = tcInterfaceClasses interface
@@ -116,8 +116,8 @@ desugarChecked config bindings interface checked = do
         (Syn.moduleDecls checked)
   valueDecls <- convertFcValues config bindings interface checked env
   let decls = typeDecls <> valueDecls
-      scopes = buildScopes moduleId decls
-  pure (Program moduleId scopes decls)
+      scopes = buildScopes moduleOrigin decls
+  pure (Program scopes decls)
 
 axiomEntries :: PackageId -> Text -> [DataTypeInfo] -> [DataFamilyInstanceInfo] -> [TypeFamilyInstanceInfo] -> [(Text, Name)]
 axiomEntries package moduleName' dataTypes dataFamilyInstances typeFamilyInstances =
@@ -617,8 +617,8 @@ synonymResult env tyCon params =
     dropParams remaining (KFun _ result) = dropParams (remaining - 1) result
     dropParams _ kind = kind
 
-buildScopes :: ModuleId -> [Decl] -> ScopeTable
-buildScopes moduleId decls =
+buildScopes :: (PackageId, Text) -> [Decl] -> ScopeTable
+buildScopes moduleOrigin decls =
   foldl
     ( \table (index, (package, moduleName')) ->
         insertScope index package moduleName' table
@@ -629,7 +629,7 @@ buildScopes moduleId decls =
     origins =
       sort
         ( nub
-            ( (modulePackage moduleId, Aihc.Fc2.Name.moduleName moduleId)
+            ( moduleOrigin
                 : concatMap declOrigins decls
             )
         )

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -20,7 +20,7 @@ import Control.Monad (foldM, unless, when)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Maybe (catMaybes, listToMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -51,34 +51,18 @@ lintPrograms programs =
 
 loadScopeClosure :: ModuleLoader -> [Program] -> IO [Program]
 loadScopeClosure loader seeds = do
-  loaded <- go initial (concatMap scopeKeys seeds)
-  pure (List.nub (unkeyedSeeds <> Map.elems loaded))
+  resolved <- go Map.empty (concatMap scopeKeys seeds)
+  pure (List.nub (seeds <> catMaybes (Map.elems resolved)))
   where
-    initial = Map.fromList [(key, program) | program <- seeds, key <- programKeys program]
-    unkeyedSeeds = filter (null . programKeys) seeds
-
-    go seen [] = pure seen
-    go seen (key : rest)
-      | alreadyLoaded seen key = go seen rest
+    go resolved [] = pure resolved
+    go resolved (key : rest)
+      | Map.member key resolved = go resolved rest
       | otherwise = do
           loaded <- uncurry loader key
           case loaded of
-            Nothing -> go seen rest
+            Nothing -> go (Map.insert key Nothing resolved) rest
             Just program ->
-              go (Map.insert key program seen) (rest <> filter (not . alreadyLoaded seen) (scopeKeys program))
-
-    alreadyLoaded seen (package, name) =
-      Map.member (package, name) seen
-        || (isEmptyPackage package && hasModuleName seen name)
-        || hasEmptyPackageModule seen name
-
-    isEmptyPackage package = packageIdText package == ""
-
-    hasModuleName seen name =
-      any ((== name) . snd) (Map.keys seen)
-
-    hasEmptyPackageModule seen name =
-      Map.member (PackageId "", name) seen
+              go (Map.insert key (Just program) resolved) (rest <> scopeKeys program)
 
 storeModuleLoader :: FilePath -> ModuleLoader
 storeModuleLoader storeRoot package moduleName = do
@@ -95,22 +79,6 @@ storeModuleLoader storeRoot package moduleName = do
 moduleDirectoryText :: Text -> FilePath
 moduleDirectoryText name =
   List.foldl' (</>) "" (map T.unpack (T.splitOn "." name))
-
-programKeys :: Program -> [(PackageId, Text)]
-programKeys = List.nub . mapMaybe declKey . programDecls
-  where
-    declKey decl =
-      case nameOrigin (declName decl) of
-        OriginTop package name -> Just (package, name)
-        OriginLocal {} -> Nothing
-
-    declName decl =
-      case decl of
-        DeclType declaration -> typeName declaration
-        DeclSynonym declaration -> synName declaration
-        DeclAxiom declaration -> axiomName declaration
-        DeclVal declaration -> valName declaration
-        DeclPrim declaration -> primName declaration
 
 scopeKeys :: Program -> [(PackageId, Text)]
 scopeKeys program =

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -20,7 +20,7 @@ import Control.Monad (foldM, unless, when)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (listToMaybe)
+import Data.Maybe (listToMaybe, mapMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -50,8 +50,13 @@ lintPrograms programs =
         <> concatMap (lintDeclBodies env) (allDecls programs)
 
 loadScopeClosure :: ModuleLoader -> [Program] -> IO [Program]
-loadScopeClosure loader seeds = Map.elems <$> go (Map.fromList [(moduleKey program, program) | program <- seeds]) (concatMap scopeKeys seeds)
+loadScopeClosure loader seeds = do
+  loaded <- go initial (concatMap scopeKeys seeds)
+  pure (List.nub (unkeyedSeeds <> Map.elems loaded))
   where
+    initial = Map.fromList [(key, program) | program <- seeds, key <- programKeys program]
+    unkeyedSeeds = filter (null . programKeys) seeds
+
     go seen [] = pure seen
     go seen (key : rest)
       | alreadyLoaded seen key = go seen rest
@@ -70,15 +75,10 @@ loadScopeClosure loader seeds = Map.elems <$> go (Map.fromList [(moduleKey progr
     isEmptyPackage package = packageIdText package == ""
 
     hasModuleName seen name =
-      any (\program -> moduleName (programModule program) == name) (Map.elems seen)
+      any ((== name) . snd) (Map.keys seen)
 
     hasEmptyPackageModule seen name =
-      any
-        ( \program ->
-            moduleName (programModule program) == name
-              && isEmptyPackage (modulePackage (programModule program))
-        )
-        (Map.elems seen)
+      Map.member (PackageId "", name) seen
 
 storeModuleLoader :: FilePath -> ModuleLoader
 storeModuleLoader storeRoot package moduleName = do
@@ -96,9 +96,21 @@ moduleDirectoryText :: Text -> FilePath
 moduleDirectoryText name =
   List.foldl' (</>) "" (map T.unpack (T.splitOn "." name))
 
-moduleKey :: Program -> (PackageId, Text)
-moduleKey program =
-  (modulePackage (programModule program), moduleName (programModule program))
+programKeys :: Program -> [(PackageId, Text)]
+programKeys = List.nub . mapMaybe declKey . programDecls
+  where
+    declKey decl =
+      case nameOrigin (declName decl) of
+        OriginTop package name -> Just (package, name)
+        OriginLocal {} -> Nothing
+
+    declName decl =
+      case decl of
+        DeclType declaration -> typeName declaration
+        DeclSynonym declaration -> synName declaration
+        DeclAxiom declaration -> axiomName declaration
+        DeclVal declaration -> valName declaration
+        DeclPrim declaration -> primName declaration
 
 scopeKeys :: Program -> [(PackageId, Text)]
 scopeKeys program =

--- a/components/aihc-fc/src/Aihc/Fc2/Name.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Name.hs
@@ -6,7 +6,6 @@ module Aihc.Fc2.Name
     Origin (..),
     Name (..),
     nameEquals,
-    ModuleId (..),
     ScopeTable (..),
     emptyScopeTable,
     lookupScope,
@@ -79,12 +78,6 @@ nameEquals left right =
   nameClass (nameSort left) == nameClass (nameSort right)
     && nameText left == nameText right
     && nameOrigin left == nameOrigin right
-
-data ModuleId = ModuleId
-  { modulePackage :: PackageId,
-    moduleName :: Text
-  }
-  deriving (Eq, Ord, Show, Read)
 
 newtype ScopeTable = ScopeTable (Map Int (PackageId, Text))
   deriving (Eq, Ord, Show, Read)

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -75,28 +75,8 @@ scopeDeclaration = do
 
 program :: ScopeTable -> Parser Program
 program scopes = do
-  moduleId <- moduleHeader
   openDecls <- MP.many (declaration scopes)
-  fillProgram scopes moduleId openDecls
-
-moduleHeader :: Parser ModuleId
-moduleHeader = do
-  _ <- keyword "module"
-  (package, moduleName) <- scopedModuleName
-  _ <- keyword "where"
-  pure (ModuleId package moduleName)
-
-scopedModuleName :: Parser (PackageId, Text)
-scopedModuleName = do
-  scopeId <- int
-  _ <- symbol "."
-  moduleName <- qualifiedModuleName
-  scopes <- ask
-  case lookupScope scopeId scopes of
-    Just (package, boundName)
-      | boundName == moduleName -> pure (package, moduleName)
-      | otherwise -> fail ("module name does not match scope " <> show scopeId)
-    Nothing -> fail ("unknown scope " <> show scopeId)
+  fillProgram scopes openDecls
 
 data OpenBinder = OpenBinder Name OpenType
   deriving (Eq, Show)
@@ -607,11 +587,11 @@ bracesInt = do
   _ <- MPC.char '}'
   pure value
 
-fillProgram :: ScopeTable -> ModuleId -> [OpenDecl] -> Parser Program
-fillProgram scopes moduleId openDecls =
+fillProgram :: ScopeTable -> [OpenDecl] -> Parser Program
+fillProgram scopes openDecls =
   case fillDecls scopes openDecls of
     Left message -> fail message
-    Right decls -> pure (normalizeProgram (Program moduleId scopes decls))
+    Right decls -> pure (normalizeProgram (Program scopes decls))
 
 fillDecls :: ScopeTable -> [OpenDecl] -> Either String [Decl]
 fillDecls scopes openDecls = do

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -34,7 +34,7 @@ data Prec
 
 renderProgram :: Program -> String
 renderProgram program =
-  intercalate "\n\n" (filter (not . null) (renderScopes scopes : renderModule scopes (programModule program) : map (renderDecl env scopes Set.empty) (programDecls program)))
+  intercalate "\n\n" (filter (not . null) (renderScopes scopes : map (renderDecl env scopes Set.empty) (programDecls program)))
   where
     scopes = programScopes program
     env = typeEnvFromProgram program
@@ -46,10 +46,6 @@ renderScopes table =
 renderScopeEntry :: Int -> PackageId -> Text -> String
 renderScopeEntry scopeId package moduleName =
   "scope " <> show scopeId <> " = " <> show (T.unpack (packageIdText package)) <> " " <> T.unpack moduleName
-
-renderModule :: ScopeTable -> ModuleId -> String
-renderModule scopes moduleId =
-  "module " <> scopePrefix scopes (modulePackage moduleId) (moduleName moduleId) <> T.unpack (moduleName moduleId) <> " where"
 
 renderDecl :: TypeEnv -> ScopeTable -> Set Text -> Decl -> String
 renderDecl env scopes seen decl =

--- a/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
@@ -97,8 +97,7 @@ data Coercion
   deriving (Eq, Ord, Show, Read)
 
 data Program = Program
-  { programModule :: ModuleId,
-    programScopes :: ScopeTable,
+  { programScopes :: ScopeTable,
     programDecls :: [Decl]
   }
   deriving (Eq, Ord, Show, Read)

--- a/components/aihc-fc/test/Test/Fc2/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc2/Properties.hs
@@ -90,8 +90,7 @@ localValue text = Name text SortValue (OriginLocal (Unique 0))
 identityProgram :: Program
 identityProgram =
   Program
-    { programModule = ModuleId testPackage "Test",
-      programScopes = scopes,
+    { programScopes = scopes,
       programDecls =
         [ DeclType
             TypeDecl
@@ -138,8 +137,7 @@ genProgram = do
       result = TyCon (typeWired "Type")
   pure
     Program
-      { programModule = ModuleId testPackage "Test",
-        programScopes = scopes,
+      { programScopes = scopes,
         programDecls =
           [ DeclType
               TypeDecl

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/app-mismatch.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/app-mismatch.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/cast-source.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/cast-source.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt-lifted.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt-lifted.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-alt.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-secret.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/lit-secret.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tIntRep :: 2.tRuntimeRep {}
 
 pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/shadowed.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/shadowed.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-origin.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-origin.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 2.tChar :: 2.tType {}
 
 pub type 2.t[] (a : 2.tType) :: 2.tType {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-type.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/string-literal-type.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tyapp-kind.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tyapp-kind.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tycon-co-arity.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/tycon-co-arity.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tMaybe (a : 2.tType) :: 2.tType {
     pub 1.vNothing :: ∀(a : 2.tType). 1.tMaybe a
 }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/unbound.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/unbound.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Prim.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Prim.fc2
@@ -1,6 +1,4 @@
 scope 1 = "aihc-prim" GHC.Prim
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.GHC.Prim where
-
 pub type 1.tInt# :: 2.tTYPE 2.vIntRep {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Types.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/mutual/GHC.Types.fc2
@@ -1,8 +1,6 @@
 scope 1 = "aihc-prim" GHC.Types
 scope 2 = "aihc-prim" GHC.Prim
 
-module 1.GHC.Types where
-
 pub type 1.tType :: 1.tType {}
 
 pub type 1.tRuntimeRep :: 1.tType {

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/addr-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/addr-literal.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 2.tRuntimeRep :: 2.tType {
     pub 2.vAddrRep :: 2.tRuntimeRep
 }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/foreign-prim.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/foreign-prim.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b
 
 val 1.vboom :: ∀(a : 2.tType) (b : 2.tType). a → b

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/fun-explicit.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/fun-explicit.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tIntRep :: 2.tRuntimeRep {}
 
 pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/identity.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/identity.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/lambda-app-case.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/lambda-app-case.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/newtype-cast.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/newtype-cast.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tInt :: 2.tType {
     pub 1.vI :: 1.tInt
 }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal-ghc.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal-ghc.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 2.tChar :: 2.tType {}
 
 pub type 2.t[] (a : 2.tType) :: 2.tType {

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tChar :: 2.tType {}
 
 pub type 1.t[] (a : 2.tType) :: 2.tType {

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/tycon-co.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/tycon-co.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tMaybe (a : 2.tType) :: 2.tType {
     pub 1.vNothing :: ∀(a : 2.tType). 1.tMaybe a
 }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/unboxed-lit.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/unboxed-lit.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tIntRep :: 2.tRuntimeRep {}
 
 pub type 1.tInt# :: 2.tTYPE 1.tIntRep {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2/addr-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/addr-literal.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 2.tRuntimeRep :: 2.tType {
     pub 2.vAddrRep :: 2.tRuntimeRep
 }

--- a/components/aihc-fc/test/Test/Fixtures/fc2/axiom-cast.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/axiom-cast.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tInt :: 2.tType {}
 
 pub type 1.tAge :: 2.tType {}

--- a/components/aihc-fc/test/Test/Fixtures/fc2/bool-id.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/bool-id.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/fc2/dollar-names.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/dollar-names.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Parent
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Parent where
-
 pub type 1.tFlag :: 2.tType {
     pub 1.vOff :: 1.tFlag
     pub 1.vOn :: 1.tFlag

--- a/components/aihc-fc/test/Test/Fixtures/fc2/foreign-prim.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/foreign-prim.fc2
@@ -1,6 +1,4 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b

--- a/components/aihc-fc/test/Test/Fixtures/fc2/fun-explicit.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/fun-explicit.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 val 1.vidBool :: 2.tBool → 2.tBool
  = λ(x : 2.tBool).
   x

--- a/components/aihc-fc/test/Test/Fixtures/fc2/fun-nested-arrow.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/fun-nested-arrow.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBox :: 2.tTYPE 2.tUnliftedRep {}
 
 pub type 1.tFlag :: 2.tType {

--- a/components/aihc-fc/test/Test/Fixtures/fc2/list.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/list.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.t[] (a : 2.tType) :: 2.tType {
     pub 1.v[] :: ∀(a : 2.tType). 1.t[] a
     pub 1.v: :: ∀(a : 2.tType). a → 1.t[] a → 1.t[] a

--- a/components/aihc-fc/test/Test/Fixtures/fc2/tuple-con.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/tuple-con.fc2
@@ -1,8 +1,6 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tPair (a : 2.tType) (b : 2.tType) :: 2.tType {
     pub 1.v(,) :: ∀(a : 2.tType) (b : 2.tType). a → b → 1.tPair a b
 }

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-data.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-data.yaml
@@ -7,8 +7,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tBool :: 2.tType {
       pub 1.vFalse :: 1.tBool
       pub 1.vTrue :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-not.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-not.yaml
@@ -9,8 +9,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tBool :: 2.tType {
       pub 1.vTrue :: 1.tBool
       pub 1.vFalse :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-dictionary.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-dictionary.yaml
@@ -9,8 +9,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tFlag :: 2.tType {
       pub 1.vOff :: 1.tFlag
       pub 1.vOn :: 1.tFlag

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-instance.yaml
@@ -11,8 +11,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tFlag :: 2.tType {
       pub 1.vOff :: 1.tFlag
       pub 1.vOn :: 1.tFlag

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-superclass.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-superclass.yaml
@@ -11,8 +11,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tFlag :: 2.tType {
       pub 1.vOff :: 1.tFlag
       pub 1.vOn :: 1.tFlag

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/data-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/data-family-instance.yaml
@@ -9,8 +9,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tPayload (a : 2.tType) :: 2.tType @N {}
 
   type 1.t$R$Payload$PayloadValue (a{12} : 2.tType) :: 2.tType {

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/empty-data.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/empty-data.yaml
@@ -15,8 +15,6 @@ expected: |-
   scope 1 = "aihc-prim" GHC.Prim
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.GHC.Prim where
-
   pub type 1.tMutVar# (d{18} : 2.tType) (a{20} : 2.tType) :: 2.tTYPE 2.tUnliftedRep {}
 status: pass
 reason: An empty data type keeps its checked parameters and result kind.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim-use.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim-use.yaml
@@ -11,8 +11,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   foreign import prim 1.vraise# :: ∀(a{10} : 2.tType) (b{11} : 2.tType). a{10} → b{11}
 
   pub val 1.vboom :: ∀(a{22} : 2.tType) (b{23} : 2.tType). a{22} → b{23}

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim.yaml
@@ -10,8 +10,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   foreign import prim 1.vraise# :: ∀(a{10} : 2.tType) (b{11} : 2.tType). a{10} → b{11}
 status: pass
 reason: A foreign import prim keeps its checked type.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/identity.yaml
@@ -7,8 +7,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub val 1.vid :: ∀(a{14} : 2.tType). a{14} → a{14}
    = Λ(a{14} : 2.tType).
     λ(x{1001} : a{14}).

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/imported-type.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/imported-type.yaml
@@ -11,8 +11,6 @@ expected: |-
   scope 1 = "" Parent
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Parent where
-
   pub type 1.tFlag :: 2.tType {
       pub 1.vOff :: 1.tFlag
       pub 1.vOn :: 1.tFlag
@@ -20,8 +18,6 @@ expected: |-
   scope 1 = "" Child
   scope 2 = "" Parent
   scope 3 = "aihc-prim" GHC.Types
-
-  module 1.Child where
 
   pub type 1.tBox :: 3.tType {
       pub 1.vBox :: 2.tFlag → 1.tBox

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/lambda-identity.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/lambda-identity.yaml
@@ -7,8 +7,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub val 1.vid :: ∀(a{12} : 2.tType). a{12} → a{12}
    = Λ(a{12} : 2.tType).
     λ(x{1001} : a{12}).

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/list-data.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/list-data.yaml
@@ -7,8 +7,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.t[] (a{12} : 2.tType) :: 2.tType {
       pub 1.vNil :: ∀(a{12} : 2.tType). 1.t[] a{12}
       pub 1.vCons :: ∀(a{12} : 2.tType). a{12} → 1.t[] a{12} → 1.t[] a{12}

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-age.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-age.yaml
@@ -9,8 +9,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tInt :: 2.tType {
       pub 1.vI :: 1.tInt
   }

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-family-instance.yaml
@@ -10,8 +10,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tUnit :: 2.tType {
       pub 1.vUnit :: 1.tUnit
   }

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/signed-polymorphic-alias.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/signed-polymorphic-alias.yaml
@@ -12,8 +12,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   foreign import prim 1.vunsafeCoerce# :: ∀(a{14} : 2.tType) (b{15} : 2.tType). a{14} → b{15}
 
   pub val 1.vunsafeCoerce :: ∀(a{18} : 2.tType) (b{19} : 2.tType). a{18} → b{19}

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/synonym.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/synonym.yaml
@@ -8,8 +8,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tInt :: 2.tType {
       pub 1.vI :: 1.tInt
   }

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-and-liftedrep.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-and-liftedrep.yaml
@@ -25,8 +25,6 @@ modules:
 expected: |-
   scope 1 = "aihc-prim" GHC.Types
 
-  module 1.GHC.Types where
-
   pub type 1.tTYPE (rep{13} : 1.tRuntimeRep) :: 1.tType {}
 
   pub type 1.tType :: 1.tType =

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-application.yaml
@@ -10,8 +10,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tBool :: 2.tType {
       pub 1.vTrue :: 1.tBool
       pub 1.vFalse :: 1.tBool

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-family-instance.yaml
@@ -10,8 +10,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  module 1.Test where
-
   pub type 1.tFlag :: 2.tType {
       pub 1.vOff :: 1.tFlag
       pub 1.vOn :: 1.tFlag

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-int.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-int.yaml
@@ -32,8 +32,6 @@ expected: |-
   scope 1 = "aihc-prim" GHC.Prim
   scope 2 = "aihc-prim" GHC.Types
 
-  module 2.GHC.Types where
-
   pub type 2.tTYPE (rep{8} : 2.tRuntimeRep) :: 2.tType {}
 
   pub type 2.tType :: 2.tType =
@@ -57,8 +55,6 @@ expected: |-
   }
   scope 1 = "aihc-prim" GHC.Prim
   scope 2 = "aihc-prim" GHC.Types
-
-  module 1.GHC.Prim where
 
   pub type 1.tInt# :: 2.tTYPE 2.vIntRep {}
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-tuple.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-tuple.yaml
@@ -31,8 +31,6 @@ modules:
 expected: |-
   scope 1 = "aihc-prim" GHC.Types
 
-  module 1.GHC.Types where
-
   pub type 1.tTYPE (rep{23} : 1.tRuntimeRep) :: 1.tType {}
 
   pub type 1.tType :: 1.tType =

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
@@ -39,8 +39,6 @@ modules:
 expected: |-
   scope 1 = "aihc-prim" GHC.Types
 
-  module 1.GHC.Types where
-
   pub type 1.tTYPE (rep{13} : 1.tRuntimeRep) :: 1.tType {}
 
   pub type 1.tType :: 1.tType =
@@ -63,8 +61,6 @@ expected: |-
   }
   scope 1 = "aihc-prim" GHC.Prim
   scope 2 = "aihc-prim" GHC.Types
-
-  module 1.GHC.Prim where
 
   pub type 1.tStableName# (a{18} : 2.tType) :: 2.tTYPE 2.tUnliftedRep {}
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-type-kind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-type-kind.yaml
@@ -36,8 +36,6 @@ modules:
 expected: |-
   scope 1 = "aihc-prim" GHC.Types
 
-  module 1.GHC.Types where
-
   pub type 1.tTYPE (rep{17} : 1.tRuntimeRep) :: 1.tType {}
 
   pub type 1.tType :: 1.tType =
@@ -65,8 +63,6 @@ expected: |-
   }
   scope 1 = "aihc-prim" GHC.Prim
   scope 2 = "aihc-prim" GHC.Types
-
-  module 1.GHC.Prim where
 
   pub type 1.tMutVar# (d{23} : 2.tType) (a{25} : 2.tType) :: 2.tTYPE 2.tUnliftedRep {}
 status: pass

--- a/docs/system-fc2.md
+++ b/docs/system-fc2.md
@@ -120,8 +120,6 @@ source
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-module 1.Test where
-
 pub type 1.tBool :: 2.tType {
     pub 1.vFalse :: 1.tBool
     pub 1.vTrue :: 1.tBool


### PR DESCRIPTION
## Summary

- Remove the System FC 2 program module field and its module identifier type.
- Parse and print programs without a module header.
- Load each dependency from its exact scope table entry.
- Keep current install-unit programs separate from stored dependency files.
- Update all System FC 2 text fixtures and golden outputs.

## Tests

- `just check`

## Progress counts

- No progress count changed.
