### PR TITLE
test(fc2): generate all declaration forms

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -170,12 +170,13 @@ axiomDeclaration scopes = do
 
 primDeclaration :: ScopeTable -> Parser OpenDecl
 primDeclaration scopes = do
+  vis <- MP.option Pub (keyword "private" $> Private)
   _ <- keyword "foreign"
   _ <- keyword "import"
   _ <- keyword "prim"
   name <- topName scopes SortValue
   _ <- symbol "::"
-  OpenPrimDecl Pub name <$> fcType
+  OpenPrimDecl vis name <$> fcType
 
 valDeclaration :: ScopeTable -> Parser OpenDecl
 valDeclaration scopes = do
@@ -276,6 +277,7 @@ typeAtom =
 reservedWords :: [Text]
 reservedWords =
   [ "pub",
+    "private",
     "val",
     "type",
     "axiom",

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -148,7 +148,7 @@ typeOrSynonym scopes = do
     ]
 
 constructorBlock :: ScopeTable -> Parser [OpenCon]
-constructorBlock scopes = braces (MP.many (constructorDecl scopes))
+constructorBlock scopes = braces (MP.many (constructorDecl scopes <* MP.optional (symbol ";")))
 
 constructorDecl :: ScopeTable -> Parser OpenCon
 constructorDecl scopes = do
@@ -170,7 +170,7 @@ axiomDeclaration scopes = do
 
 primDeclaration :: ScopeTable -> Parser OpenDecl
 primDeclaration scopes = do
-  vis <- MP.option Pub (keyword "private" $> Private)
+  vis <- optionalPub
   _ <- keyword "foreign"
   _ <- keyword "import"
   _ <- keyword "prim"
@@ -277,7 +277,6 @@ typeAtom =
 reservedWords :: [Text]
 reservedWords =
   [ "pub",
-    "private",
     "val",
     "type",
     "axiom",

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -146,10 +146,15 @@ renderValDecl env scopes declaration =
 
 renderPrimDecl :: TypeEnv -> ScopeTable -> PrimDecl -> String
 renderPrimDecl env scopes declaration =
-  "foreign import prim "
+  renderPrimVis (primVis declaration)
+    <> "foreign import prim "
     <> renderTopName scopes (primName declaration)
     <> " :: "
     <> renderTypeWith env scopes PrecForAll (primType declaration)
+
+renderPrimVis :: Vis -> String
+renderPrimVis Pub = ""
+renderPrimVis Private = "private "
 
 renderType :: Program -> Type -> String
 renderType program =

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -77,20 +77,8 @@ renderConstructors :: TypeEnv -> ScopeTable -> [ConDecl] -> String
 renderConstructors _ _ [] = " {}"
 renderConstructors env scopes constructors =
   " {\n"
-    <> intercalate "\n" (renderConDecls env scopes constructors)
+    <> intercalate ";\n" (map (renderConDecl env scopes) constructors)
     <> "\n}"
-
-renderConDecls :: TypeEnv -> ScopeTable -> [ConDecl] -> [String]
-renderConDecls _ _ [] = []
-renderConDecls env scopes [constructor] = [renderConDecl env scopes constructor]
-renderConDecls env scopes (constructor : next : rest) =
-  (renderConDecl env scopes constructor <> renderConSeparator next)
-    : renderConDecls env scopes (next : rest)
-
-renderConSeparator :: ConDecl -> String
-renderConSeparator constructor
-  | conVis constructor == Private = ";"
-  | otherwise = ""
 
 renderConDecl :: TypeEnv -> ScopeTable -> ConDecl -> String
 renderConDecl env scopes declaration =

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -77,8 +77,20 @@ renderConstructors :: TypeEnv -> ScopeTable -> [ConDecl] -> String
 renderConstructors _ _ [] = " {}"
 renderConstructors env scopes constructors =
   " {\n"
-    <> intercalate "\n" (map (renderConDecl env scopes) constructors)
+    <> intercalate "\n" (renderConDecls env scopes constructors)
     <> "\n}"
+
+renderConDecls :: TypeEnv -> ScopeTable -> [ConDecl] -> [String]
+renderConDecls _ _ [] = []
+renderConDecls env scopes [constructor] = [renderConDecl env scopes constructor]
+renderConDecls env scopes (constructor : next : rest) =
+  (renderConDecl env scopes constructor <> renderConSeparator next)
+    : renderConDecls env scopes (next : rest)
+
+renderConSeparator :: ConDecl -> String
+renderConSeparator constructor
+  | conVis constructor == Private = ";"
+  | otherwise = ""
 
 renderConDecl :: TypeEnv -> ScopeTable -> ConDecl -> String
 renderConDecl env scopes declaration =
@@ -146,15 +158,11 @@ renderValDecl env scopes declaration =
 
 renderPrimDecl :: TypeEnv -> ScopeTable -> PrimDecl -> String
 renderPrimDecl env scopes declaration =
-  renderPrimVis (primVis declaration)
+  renderVis (primVis declaration)
     <> "foreign import prim "
     <> renderTopName scopes (primName declaration)
     <> " :: "
     <> renderTypeWith env scopes PrecForAll (primType declaration)
-
-renderPrimVis :: Vis -> String
-renderPrimVis Pub = ""
-renderPrimVis Private = "private "
 
 renderType :: Program -> Type -> String
 renderType program =
@@ -172,7 +180,7 @@ renderTypeWith env scopes prec ty =
           paren (prec < PrecFun) (renderTypeWith env scopes PrecApp argument <> " → " <> renderTypeWith env scopes PrecFun result)
       | otherwise ->
           paren
-            (prec < PrecApp)
+            (prec < PrecFun)
             ( "FUN @"
                 <> renderTypeWith env scopes PrecAtom r1
                 <> " @"

--- a/components/aihc-fc/test/Test/Fc2/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc2/Properties.hs
@@ -96,6 +96,12 @@ valueNameTop text = Name text SortValue (OriginTop testPackage "Test")
 dataNameTop :: Text -> Name
 dataNameTop text = Name text SortDataConstructor (OriginTop testPackage "Test")
 
+synonymNameTop :: Text -> Name
+synonymNameTop text = Name text SortSynonym (OriginTop testPackage "Test")
+
+axiomNameTop :: Text -> Name
+axiomNameTop text = Name text SortAxiom (OriginTop testPackage "Test")
+
 typeWired :: Text -> Name
 typeWired text = Name text SortSynonym (OriginTop primPackage "GHC.Types")
 
@@ -153,42 +159,122 @@ identityProgram =
     }
 
 genProgram :: Gen Program
-genProgram = do
-  suffix <- Gen.text (Range.linear 1 4) Gen.lower
-  let typeName = typeNameTop ("T" <> suffix)
-      consName = dataNameTop ("C" <> suffix)
-      valName = valueNameTop ("f" <> suffix)
-      result = TyCon (typeWired "Type")
-  pure
-    Program
-      { programScopes = scopes,
-        programDecls =
-          [ DeclType
-              TypeDecl
-                { typeVis = Pub,
-                  typeName = typeName,
-                  typeBinders = [],
-                  typeResult = result,
-                  typeRoles = [],
-                  typeCons = [ConDecl Pub consName (TyCon typeName)]
-                },
-            DeclVal
-              ValDecl
-                { valVis = Pub,
-                  valName = valName,
-                  valType =
-                    TyFun
-                      (TyCon (typeWired "LiftedRep"))
-                      (TyCon (typeWired "LiftedRep"))
-                      (TyCon typeName)
-                      (TyCon typeName),
-                  valBody =
-                    ExLam
-                      (Binder (localValue "x") (TyCon typeName))
-                      (ExVar (localValue "x"))
-                }
-          ]
-      }
+genProgram = Program scopes <$> Gen.list (Range.linear 0 10) genDecl
+
+genDecl :: Gen Decl
+genDecl =
+  Gen.choice
+    [ DeclType <$> genTypeDecl,
+      DeclSynonym <$> genSynonymDecl,
+      DeclAxiom <$> genAxiomDecl,
+      DeclVal <$> genValDecl,
+      DeclPrim <$> genPrimDecl
+    ]
+
+genTypeDecl :: Gen TypeDecl
+genTypeDecl = do
+  name <- typeNameTop . ("T" <>) <$> genSuffix
+  binders <- Gen.list (Range.linear 0 3) genTypeBinder
+  roles <- traverse (const genRole) binders
+  privateConstructors <- Gen.choice [pure [], (: []) <$> genConDecl Private name]
+  publicConstructors <- Gen.list (Range.linear 0 3) (genConDecl Pub name)
+  TypeDecl
+    <$> genVis
+    <*> pure name
+    <*> pure binders
+    <*> genType
+    <*> pure roles
+    <*> pure (privateConstructors <> publicConstructors)
+
+genConDecl :: Vis -> Name -> Gen ConDecl
+genConDecl visibility typeName =
+  (ConDecl visibility . dataNameTop . ("C" <>) <$> genSuffix)
+    <*> Gen.choice [pure (TyCon typeName), genType]
+
+genSynonymDecl :: Gen SynonymDecl
+genSynonymDecl =
+  SynonymDecl
+    <$> genVis
+    <*> (synonymNameTop . ("S" <>) <$> genSuffix)
+    <*> Gen.list (Range.linear 0 3) genTypeBinder
+    <*> genType
+    <*> genType
+
+genAxiomDecl :: Gen AxiomDecl
+genAxiomDecl =
+  AxiomDecl
+    <$> genVis
+    <*> (axiomNameTop . ("ax" <>) <$> genSuffix)
+    <*> Gen.list (Range.linear 0 3) genTypeBinder
+    <*> genRole
+    <*> genType
+    <*> genType
+
+genValDecl :: Gen ValDecl
+genValDecl =
+  ValDecl
+    <$> genVis
+    <*> (valueNameTop . ("f" <>) <$> genSuffix)
+    <*> genType
+    <*> (ExVar <$> genLocalValueName)
+
+genPrimDecl :: Gen PrimDecl
+genPrimDecl =
+  PrimDecl
+    <$> genVis
+    <*> (valueNameTop . ("prim" <>) <$> genSuffix)
+    <*> genType
+
+genType :: Gen Type
+genType =
+  Gen.recursive
+    Gen.choice
+    [ TyVar <$> genLocalTypeName,
+      TyCon <$> genTypeName
+    ]
+    [ TyApp <$> genType <*> genType,
+      TyFun liftedRep liftedRep <$> genType <*> genType,
+      TyForAll <$> genTypeBinder <*> genType,
+      TyEq <$> genType <*> genType
+    ]
+  where
+    liftedRep = TyCon (typeWired "LiftedRep")
+
+genTypeName :: Gen Name
+genTypeName =
+  Gen.choice
+    [ pure (typeWired "Type"),
+      pure (typeWired "LiftedRep"),
+      pure (typeWired "UnliftedRep"),
+      typeNameTop . ("T" <>) <$> genSuffix
+    ]
+
+genTypeBinder :: Gen Binder
+genTypeBinder =
+  Binder
+    <$> genLocalTypeName
+    <*> pure (TyCon (typeWired "Type"))
+
+genLocalTypeName :: Gen Name
+genLocalTypeName =
+  localTypeWith
+    <$> Gen.int (Range.linear 0 10000)
+    <*> (("tv" <>) <$> genSuffix)
+
+genLocalValueName :: Gen Name
+genLocalValueName =
+  localValueWith
+    <$> Gen.int (Range.linear 0 10000)
+    <*> (("x" <>) <$> genSuffix)
+
+genVis :: Gen Vis
+genVis = Gen.element [Pub, Private]
+
+genRole :: Gen Role
+genRole = Gen.element [Nominal, Representational, Phantom]
+
+genSuffix :: Gen Text
+genSuffix = Gen.text (Range.linear 1 4) Gen.lower
 
 genTidyProgram :: Gen Program
 genTidyProgram = do

--- a/components/aihc-fc/test/Test/Fc2/Properties.hs
+++ b/components/aihc-fc/test/Test/Fc2/Properties.hs
@@ -176,19 +176,19 @@ genTypeDecl = do
   name <- typeNameTop . ("T" <>) <$> genSuffix
   binders <- Gen.list (Range.linear 0 3) genTypeBinder
   roles <- traverse (const genRole) binders
-  privateConstructors <- Gen.choice [pure [], (: []) <$> genConDecl Private name]
-  publicConstructors <- Gen.list (Range.linear 0 3) (genConDecl Pub name)
   TypeDecl
     <$> genVis
     <*> pure name
     <*> pure binders
     <*> genType
     <*> pure roles
-    <*> pure (privateConstructors <> publicConstructors)
+    <*> Gen.list (Range.linear 0 3) (genConDecl name)
 
-genConDecl :: Vis -> Name -> Gen ConDecl
-genConDecl visibility typeName =
-  (ConDecl visibility . dataNameTop . ("C" <>) <$> genSuffix)
+genConDecl :: Name -> Gen ConDecl
+genConDecl typeName =
+  ConDecl
+    <$> genVis
+    <*> (dataNameTop . ("C" <>) <$> genSuffix)
     <*> Gen.choice [pure (TyCon typeName), genType]
 
 genSynonymDecl :: Gen SynonymDecl
@@ -204,7 +204,7 @@ genAxiomDecl :: Gen AxiomDecl
 genAxiomDecl =
   AxiomDecl
     <$> genVis
-    <*> (axiomNameTop . ("ax" <>) <$> genSuffix)
+    <*> (axiomNameTop . ("axiom" <>) <$> genSuffix)
     <*> Gen.list (Range.linear 0 3) genTypeBinder
     <*> genRole
     <*> genType
@@ -233,12 +233,10 @@ genType =
       TyCon <$> genTypeName
     ]
     [ TyApp <$> genType <*> genType,
-      TyFun liftedRep liftedRep <$> genType <*> genType,
+      TyFun <$> genType <*> genType <*> genType <*> genType,
       TyForAll <$> genTypeBinder <*> genType,
       TyEq <$> genType <*> genType
     ]
-  where
-    liftedRep = TyCon (typeWired "LiftedRep")
 
 genTypeName :: Gen Name
 genTypeName =

--- a/components/aihc-fc/test/Test/Fixtures/fc2/bool-id.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/bool-id.fc2
@@ -2,7 +2,7 @@ scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
 pub type 1.tBool :: 2.tType {
-    pub 1.vFalse :: 1.tBool
+    pub 1.vFalse :: 1.tBool;
     pub 1.vTrue :: 1.tBool
 }
 

--- a/components/aihc-fc/test/Test/Fixtures/fc2/dollar-names.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/dollar-names.fc2
@@ -2,7 +2,7 @@ scope 1 = "" Parent
 scope 2 = "aihc-prim" GHC.Types
 
 pub type 1.tFlag :: 2.tType {
-    pub 1.vOff :: 1.tFlag
+    pub 1.vOff :: 1.tFlag;
     pub 1.vOn :: 1.tFlag
 }
 

--- a/components/aihc-fc/test/Test/Fixtures/fc2/list.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2/list.fc2
@@ -2,6 +2,6 @@ scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
 pub type 1.t[] (a : 2.tType) :: 2.tType {
-    pub 1.v[] :: ∀(a : 2.tType). 1.t[] a
+    pub 1.v[] :: ∀(a : 2.tType). 1.t[] a;
     pub 1.v: :: ∀(a : 2.tType). a → 1.t[] a → 1.t[] a
 }

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-data.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-data.yaml
@@ -8,7 +8,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tBool :: 2.tType {
-      pub 1.vFalse :: 1.tBool
+      pub 1.vFalse :: 1.tBool;
       pub 1.vTrue :: 1.tBool
   }
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-not.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/bool-not.yaml
@@ -10,7 +10,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tBool :: 2.tType {
-      pub 1.vTrue :: 1.tBool
+      pub 1.vTrue :: 1.tBool;
       pub 1.vFalse :: 1.tBool
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-dictionary.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-dictionary.yaml
@@ -10,7 +10,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tFlag :: 2.tType {
-      pub 1.vOff :: 1.tFlag
+      pub 1.vOff :: 1.tFlag;
       pub 1.vOn :: 1.tFlag
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-instance.yaml
@@ -12,7 +12,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tFlag :: 2.tType {
-      pub 1.vOff :: 1.tFlag
+      pub 1.vOff :: 1.tFlag;
       pub 1.vOn :: 1.tFlag
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/class-superclass.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/class-superclass.yaml
@@ -12,7 +12,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tFlag :: 2.tType {
-      pub 1.vOff :: 1.tFlag
+      pub 1.vOff :: 1.tFlag;
       pub 1.vOn :: 1.tFlag
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim-use.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim-use.yaml
@@ -11,7 +11,7 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b
+  pub foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b
 
   pub val 1.vboom :: ∀(a : 2.tType) (b : 2.tType). a → b
    = Λ(a : 2.tType).

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/foreign-prim.yaml
@@ -10,6 +10,6 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b
+  pub foreign import prim 1.vraise# :: ∀(a : 2.tType) (b : 2.tType). a → b
 status: pass
 reason: A foreign import prim keeps its checked type.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/imported-type.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/imported-type.yaml
@@ -12,7 +12,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tFlag :: 2.tType {
-      pub 1.vOff :: 1.tFlag
+      pub 1.vOff :: 1.tFlag;
       pub 1.vOn :: 1.tFlag
   }
   scope 1 = "" Child

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/list-data.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/list-data.yaml
@@ -8,7 +8,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.t[] (a : 2.tType) :: 2.tType {
-      pub 1.vNil :: ∀(a : 2.tType). 1.t[] a
+      pub 1.vNil :: ∀(a : 2.tType). 1.t[] a;
       pub 1.vCons :: ∀(a : 2.tType). a → 1.t[] a → 1.t[] a
   }
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/private-constructors.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/private-constructors.yaml
@@ -1,0 +1,21 @@
+extensions:
+  - TypeFamilies
+modules:
+  - |
+    module Test where
+    data family Payload a
+    data instance Payload a = PayloadA a | PayloadB
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  pub type 1.tPayload (a : 2.tType) :: 2.tType @N {}
+
+  type 1.t$R$Payload$PayloadA (a : 2.tType) :: 2.tType {
+      1.vPayloadA :: ∀(a : 2.tType). a → 1.t$R$Payload$PayloadA a;
+      1.vPayloadB :: ∀(a : 2.tType). 1.t$R$Payload$PayloadA a
+  }
+
+  axiom 1.$ax$Payload$PayloadA (a : 2.tType) : 1.tPayload a ~N 1.t$R$Payload$PayloadA a
+status: pass
+reason: Private constructor declarations use uniform separators.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/signed-polymorphic-alias.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/signed-polymorphic-alias.yaml
@@ -12,7 +12,7 @@ expected: |-
   scope 1 = "" Test
   scope 2 = "aihc-prim" GHC.Types
 
-  foreign import prim 1.vunsafeCoerce# :: ∀(a : 2.tType) (b : 2.tType). a → b
+  pub foreign import prim 1.vunsafeCoerce# :: ∀(a : 2.tType) (b : 2.tType). a → b
 
   pub val 1.vunsafeCoerce :: ∀(a : 2.tType) (b : 2.tType). a → b
    = Λ(a : 2.tType).

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-and-liftedrep.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-and-liftedrep.yaml
@@ -37,12 +37,12 @@ expected: |-
    1.vBoxedRep 1.vUnlifted
 
   pub type 1.tRuntimeRep :: 1.tType {
-      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep;
       pub 1.vIntRep :: 1.tRuntimeRep
   }
 
   pub type 1.tLevity :: 1.tType {
-      pub 1.vLifted :: 1.tLevity
+      pub 1.vLifted :: 1.tLevity;
       pub 1.vUnlifted :: 1.tLevity
   }
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-application.yaml
@@ -11,7 +11,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tBool :: 2.tType {
-      pub 1.vTrue :: 1.tBool
+      pub 1.vTrue :: 1.tBool;
       pub 1.vFalse :: 1.tBool
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/type-family-instance.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/type-family-instance.yaml
@@ -11,7 +11,7 @@ expected: |-
   scope 2 = "aihc-prim" GHC.Types
 
   pub type 1.tFlag :: 2.tType {
-      pub 1.vOff :: 1.tFlag
+      pub 1.vOff :: 1.tFlag;
       pub 1.vOn :: 1.tFlag
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-int.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-int.yaml
@@ -41,12 +41,12 @@ expected: |-
    2.vBoxedRep 2.vLifted
 
   pub type 2.tRuntimeRep :: 2.tType {
-      pub 2.vBoxedRep :: 2.tLevity → 2.tRuntimeRep
+      pub 2.vBoxedRep :: 2.tLevity → 2.tRuntimeRep;
       pub 2.vIntRep :: 2.tRuntimeRep
   }
 
   pub type 2.tLevity :: 2.tType {
-      pub 2.vLifted :: 2.tLevity
+      pub 2.vLifted :: 2.tLevity;
       pub 2.vUnlifted :: 2.tLevity
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-tuple.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unboxed-tuple.yaml
@@ -40,17 +40,17 @@ expected: |-
    1.vBoxedRep 1.vLifted
 
   pub type 1.tRuntimeRep :: 1.tType {
-      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep;
       pub 1.vTupleRep :: 1.t[] 1.tRuntimeRep → 1.tRuntimeRep
   }
 
   pub type 1.tLevity :: 1.tType {
-      pub 1.vLifted :: 1.tLevity
+      pub 1.vLifted :: 1.tLevity;
       pub 1.vUnlifted :: 1.tLevity
   }
 
   pub type 1.t[] (a : 1.tType) :: 1.tType {
-      pub 1.v[] :: ∀(a : 1.tType). 1.t[] a
+      pub 1.v[] :: ∀(a : 1.tType). 1.t[] a;
       pub 1.v: :: ∀(a : 1.tType). a → 1.t[] a → 1.t[] a
   }
 

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
@@ -66,6 +66,6 @@ expected: |-
 
   pub type 1.tInt# :: 2.tTYPE 2.vIntRep {}
 
-  foreign import prim 1.veqStableName# :: ∀(a : 2.tType) (b : 2.tType). FUN @2.tUnliftedRep @2.tLiftedRep (1.tStableName# a) (FUN @2.tUnliftedRep @2.vIntRep (1.tStableName# b) 1.tInt#)
+  pub foreign import prim 1.veqStableName# :: ∀(a : 2.tType) (b : 2.tType). FUN @2.tUnliftedRep @2.tLiftedRep (1.tStableName# a) (FUN @2.tUnliftedRep @2.vIntRep (1.tStableName# b) 1.tInt#)
 status: pass
 reason: An unlifted foreign import prim uses UnliftedRep on FUN.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-prim.yaml
@@ -51,12 +51,12 @@ expected: |-
    1.vBoxedRep 1.vUnlifted
 
   pub type 1.tRuntimeRep :: 1.tType {
-      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep
+      pub 1.vBoxedRep :: 1.tLevity → 1.tRuntimeRep;
       pub 1.vIntRep :: 1.tRuntimeRep
   }
 
   pub type 1.tLevity :: 1.tType {
-      pub 1.vLifted :: 1.tLevity
+      pub 1.vLifted :: 1.tLevity;
       pub 1.vUnlifted :: 1.tLevity
   }
   scope 1 = "aihc-prim" GHC.Prim

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-type-kind.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/unlifted-type-kind.yaml
@@ -58,7 +58,7 @@ expected: |-
   }
 
   pub type 1.tLevity :: 1.tType {
-      pub 1.vLifted :: 1.tLevity
+      pub 1.vLifted :: 1.tLevity;
       pub 1.vUnlifted :: 1.tLevity
   }
   scope 1 = "aihc-prim" GHC.Prim


### PR DESCRIPTION
## Summary

- Generate System FC2 programs with zero or more declarations.
- Generate type, synonym, axiom, value, and primitive declarations.
- Preserve private primitive visibility in System FC2 text.
- Separate all constructor declarations with the same syntax.
- Cover private constructor separators with a golden fixture.

## Validation

- `just fmt`
- `just check`
- `cabal test -v0 aihc-fc:spec --test-options="--pattern SystemFC2 --hedgehog-tests 1000 --hide-successes"`

## Progress counts

- System FC2 golden cases increase by one.
- Total `aihc-fc` test cases increase from 134 to 135.