### PR TITLE
fix(fc2): bind variable fallback patterns

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -402,18 +402,19 @@ desugarMatchArguments resultType (argument : arguments) matches
   | otherwise = do
       caseBinder <- freshBinderFromType "_scrut" (binderType argument)
       resultType' <- convertCheckedType resultType
-      alternatives <- mapM (desugarPatternGroup resultType arguments) (groupPatterns matches)
+      alternatives <- mapM (desugarPatternGroup caseBinder resultType arguments) (groupPatterns matches)
       pure (ExCase (ExVar (binderName argument)) caseBinder resultType' alternatives)
 
-desugarPatternGroup :: TcType -> [Binder] -> (Syn.Pattern, [Syn.Match]) -> ValueM Alt
-desugarPatternGroup resultType remaining (pattern', matches) = do
+desugarPatternGroup :: Binder -> TcType -> [Binder] -> (Syn.Pattern, [Syn.Match]) -> ValueM Alt
+desugarPatternGroup caseBinder resultType remaining (pattern', matches) = do
   constructor <- patternConstructor pattern'
   let subpatterns = patternChildren pattern'
   fieldTypes <- mapM requiredPatternType subpatterns
   fields <- zipWithM freshPatternBinder subpatterns fieldTypes
-  let localBindings = concat (zipWith patternLocalBindings subpatterns fields)
+  let rootBindings = patternLocalBindings pattern' caseBinder
+      localBindings = concat (zipWith patternLocalBindings subpatterns fields)
       expanded = map (expandFirstPattern subpatterns) matches
-  body <- withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded)
+  body <- withLocals (rootBindings <> localBindings) (desugarMatchArguments resultType (fields <> remaining) expanded)
   pure (Alt constructor fields body)
 
 groupPatterns :: [Syn.Match] -> [(Syn.Pattern, [Syn.Match])]

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/constructor-pattern-variable-fallback.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/constructor-pattern-variable-fallback.yaml
@@ -1,0 +1,26 @@
+extensions: []
+modules:
+  - |
+    module Test where
+    data Value = Negative | Positive
+    absolute Negative = Positive
+    absolute value = value
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  pub type 1.tValue :: 2.tType {
+      pub 1.vNegative :: 1.tValue
+      pub 1.vPositive :: 1.tValue
+  }
+
+  pub val 1.vabsolute :: 1.tValue → 1.tValue
+   = λ(x : 1.tValue).
+    case x as (_scrut : 1.tValue) return (1.tValue) of {
+        1.vNegative →
+            1.vPositive;
+        _ →
+            _scrut
+    }
+status: pass
+reason: A variable fallback keeps its local binding after a constructor equation.


### PR DESCRIPTION
## Summary

- Bind root variable patterns to generated Core-v2 case binders.
- Add a golden-v2 regression for a variable fallback after a constructor equation.

## Tests

- `cabal test -v0 aihc-fc:spec --test-options="--pattern constructor-pattern-variable-fallback --hide-successes"`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`

## Progress

- System FC 2 golden fixtures: 28 to 29.
- `aihc-fc` test cases: 133 to 134.