### PR TITLE
test(tc): use real primitive modules in goldens

### DIFF
--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -56,7 +56,7 @@ import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (dropWhileEnd, foldl', sort)
+import Data.List (dropWhileEnd, sort)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)

--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -22,14 +22,20 @@ import Aihc.Parser
     parseModule,
   )
 import Aihc.Parser.Syntax
-  ( Extension,
+  ( Extension (ImplicitPrelude),
+    LanguageEdition (Haskell98Edition),
     Module,
+    effectiveExtensions,
+    headerExtensionSettings,
+    headerLanguageEdition,
     importDeclModule,
     moduleImports,
     moduleName,
     parseExtensionName,
+    parseLanguageEdition,
   )
-import Aihc.Resolve (Package (..), PackageId (..), ResolveResult (..), extractInterface, resolveWithDeps, unnamedPackage)
+import Aihc.Parser.Token (readModuleHeaderPragmas)
+import Aihc.Resolve (ModuleExports, Package (..), PackageId (..), ResolveResult (..), extractInterface, modulesInPackage, resolveWithDeps)
 import Aihc.Tc
   ( ClassInfo (ciName),
     DataFamilyInstanceInfo (dfiiAxiomName),
@@ -41,24 +47,27 @@ import Aihc.Tc
     dataTypeKey,
     emptyTcInterface,
     tcConfig,
+    tcModuleDiagnostics,
+    tcModuleSuccess,
     typecheckModuleSccWithInterface,
-    typecheckModulesWithInterface,
   )
 import Control.Exception (ErrorCall, displayException, evaluate, try)
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withArray, withObject)
 import Data.Char (isSpace, toLower)
 import Data.Graph (SCC (..), stronglyConnComp)
-import Data.List (dropWhileEnd, sort)
+import Data.List (dropWhileEnd, foldl', sort)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (mapMaybe)
+import Data.Maybe (fromMaybe, mapMaybe)
 import Data.Set qualified as Set
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import Data.Yaml qualified as Y
-import System.Directory (doesDirectoryExist, listDirectory)
+import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
+import System.IO.Unsafe (unsafePerformIO)
 import TcAnnotatedRender (renderAnnotatedTcResults)
 
 data ExpectedStatus
@@ -86,6 +95,11 @@ data TcAnnotatedCase = TcAnnotatedCase
   }
   deriving (Eq, Show)
 
+data PrimitiveSupport = PrimitiveSupport
+  { supportScopes :: !ModuleExports,
+    supportTcInterface :: !TcInterface
+  }
+
 fixtureRoot :: FilePath
 fixtureRoot = "test/Test/Fixtures/annotated"
 
@@ -98,8 +112,42 @@ loadTcAnnotatedCases = do
   if not exists
     then pure []
     else do
+      primitiveSupport `seq` pure ()
       paths <- listFixtureFiles fixtureRoot
       mapM loadTcAnnotatedCase paths
+
+primitiveSupport :: PrimitiveSupport
+primitiveSupport = unsafePerformIO $ do
+  primitiveModules <- loadPrimitiveModules
+  case preparePrimitiveSupport primitiveModules of
+    Left errMsg -> fail errMsg
+    Right support -> pure support
+{-# NOINLINE primitiveSupport #-}
+
+loadPrimitiveModules :: IO [(FilePath, Text)]
+loadPrimitiveModules = do
+  sourceRoot <- findPrimitiveSourceRoot
+  mapM (loadOne sourceRoot) ["GHC/Classes.hs", "GHC/Types.hs", "GHC/Prim.hs", "GHC/Tuple.hs"]
+  where
+    loadOne sourceRoot relativePath = do
+      let path = sourceRoot </> relativePath
+      source <- TIO.readFile path
+      pure (path, source)
+
+findPrimitiveSourceRoot :: IO FilePath
+findPrimitiveSourceRoot = getCurrentDirectory >>= findUp
+  where
+    findUp directory = do
+      let candidate = directory </> "core-libs/aihc-prim/src"
+          files = [candidate </> "GHC/Classes.hs", candidate </> "GHC/Types.hs", candidate </> "GHC/Prim.hs", candidate </> "GHC/Tuple.hs"]
+      exists <- and <$> mapM doesFileExist files
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory directory
+          if parent == directory
+            then fail "Cannot find the aihc-prim source modules."
+            else findUp parent
 
 loadTcAnnotatedCase :: FilePath -> IO TcAnnotatedCase
 loadTcAnnotatedCase path = do
@@ -178,57 +226,16 @@ renderTcAnnotatedCase tc =
    in case sequence parsedModules of
         Left errMsg -> Left ("parse error: " <> errMsg)
         Right modules ->
-          case resolveWithDeps coreExports (map modulePackage modules) of
+          case resolveWithDeps (supportScopes primitiveSupport) (modulesInPackage fixturePackage modules) of
             ResolveResult {resolvedModules, resolveErrors = []} ->
-              case typecheckModuleGraph coreInterface (map snd resolvedModules) of
+              case typecheckModuleGraph (supportTcInterface primitiveSupport) (map snd resolvedModules) of
                 Left errMsg -> Left errMsg
                 Right results -> Right (renderAnnotatedTcResults (caseModules tc) results)
             ResolveResult {resolveErrors} ->
               Left ("resolve error: " <> show resolveErrors)
   where
-    corePackage = Package "aihc-prim" (PackageId "aihc-prim")
-    coreSources =
-      [ "module GHC.Types where\n\
-        \data RuntimeRep = BoxedRep Levity | TupleRep [RuntimeRep]\n\
-        \data Levity = Lifted | Unlifted\n\
-        \data TYPE (rep :: RuntimeRep)\n"
-          <> if any (T.isInfixOf "data List ") (caseModules tc)
-            then ""
-            else "data List a = [] | a : [a]\ninfixr 5 :\n"
-      ]
-        <> [ "module GHC.Prim where\ndata Addr#\ndata Int#\ndata Int8#\n"
-           | any (T.isInfixOf "import GHC.Prim") (caseModules tc)
-           ]
-    coreModules = map parseCoreModule coreSources
-    coreResolved = resolveWithDeps mempty (map (corePackage,) coreModules)
-    coreExports = extractInterface coreResolved
-    coreInterface =
-      case coreResolved of
-        ResolveResult {resolvedModules, resolveErrors = []} ->
-          snd (typecheckModulesWithInterface testTcConfig emptyTcInterface (map snd resolvedModules))
-        _ -> emptyTcInterface
-    modulePackage modu
-      | moduleName modu `elem` [Just "GHC.Classes", Just "GHC.Prim", Just "GHC.Tuple", Just "GHC.Types"] =
-          (Package "aihc-prim" (PackageId "aihc-prim"), modu)
-      | otherwise = (unnamedPackage, modu)
     parseOne input =
-      let config =
-            defaultConfig
-              { parserSourceName = T.unpack (T.takeWhile (/= '\n') input),
-                parserExtensions = caseExtensions tc
-              }
-          (errs, ast) = parseModule config input
-       in if null errs
-            then Right ast
-            else Left (show errs)
-    parseCoreModule input =
-      let config =
-            defaultConfig
-              { parserSourceName = "<tc-annotated-core>",
-                parserExtensions = mapMaybe parseExtensionName ["KindSignatures", "MagicHash"]
-              }
-          (errs, ast) = parseModule config input
-       in if null errs then ast else error (show errs)
+      parseModuleText (T.unpack (T.takeWhile (/= '\n') input)) (caseExtensions tc) input
 
 data ModuleNode = ModuleNode
   { nodeIndex :: !Int,
@@ -301,6 +308,55 @@ withoutImported :: (Ord key) => (value -> key) -> [value] -> [value] -> [value]
 withoutImported key imported =
   let importedKeys = Set.fromList (map key imported)
    in filter ((`Set.notMember` importedKeys) . key)
+
+preparePrimitiveSupport :: [(FilePath, Text)] -> Either String PrimitiveSupport
+preparePrimitiveSupport primitiveModules =
+  case mapM (uncurry parsePrimitiveModule) primitiveModules of
+    Left errMsg -> Left ("parse error: " <> errMsg)
+    Right modules ->
+      case resolveWithDeps mempty (modulesInPackage primitivePackage modules) of
+        resolved@ResolveResult {resolvedModules, resolveErrors = []} ->
+          let primitiveAsts = map snd resolvedModules
+              (primitiveTcResults, tcInterface) = typecheckModuleSccWithInterface testTcConfig emptyTcInterface primitiveAsts
+           in if all tcModuleSuccess primitiveTcResults
+                then
+                  Right
+                    PrimitiveSupport
+                      { supportScopes = extractInterface resolved,
+                        supportTcInterface = tcInterface
+                      }
+                else Left ("typecheck error: " <> unlines [show d | r <- primitiveTcResults, d <- tcModuleDiagnostics r])
+        ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+
+primitivePackage :: Package
+primitivePackage = Package "aihc-prim" (PackageId "aihc-prim")
+
+fixturePackage :: Package
+fixturePackage = Package "" (PackageId "")
+
+parsePrimitiveModule :: FilePath -> Text -> Either String Module
+parsePrimitiveModule sourceName input =
+  parseModuleText sourceName (primitiveExtensions input) input
+
+parseModuleText :: FilePath -> [Extension] -> Text -> Either String Module
+parseModuleText sourceName extensions input =
+  let config =
+        defaultConfig
+          { parserSourceName = sourceName,
+            parserExtensions = extensions
+          }
+      (errs, ast) = parseModule config input
+   in if null errs
+        then Right ast
+        else Left (show errs)
+
+primitiveExtensions :: Text -> [Extension]
+primitiveExtensions source =
+  filter (/= ImplicitPrelude) (effectiveExtensions language (headerExtensionSettings header))
+  where
+    header = readModuleHeaderPragmas source
+    defaultLanguage = fromMaybe Haskell98Edition (parseLanguageEdition "GHC2021")
+    language = fromMaybe defaultLanguage (headerLanguageEdition header)
 
 classifySuccess :: TcAnnotatedCase -> [String] -> (Outcome, String)
 classifySuccess tc actual =

--- a/components/aihc-tc/common/TcAnnotatedGolden.hs
+++ b/components/aihc-tc/common/TcAnnotatedGolden.hs
@@ -65,7 +65,7 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
 import Data.Yaml qualified as Y
-import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
+import System.Directory (doesDirectoryExist, getCurrentDirectory, listDirectory)
 import System.FilePath (takeDirectory, takeExtension, (</>))
 import System.IO.Unsafe (unsafePerformIO)
 import TcAnnotatedRender (renderAnnotatedTcResults)
@@ -139,14 +139,13 @@ findPrimitiveSourceRoot = getCurrentDirectory >>= findUp
   where
     findUp directory = do
       let candidate = directory </> "core-libs/aihc-prim/src"
-          files = [candidate </> "GHC/Classes.hs", candidate </> "GHC/Types.hs", candidate </> "GHC/Prim.hs", candidate </> "GHC/Tuple.hs"]
-      exists <- and <$> mapM doesFileExist files
+      exists <- doesDirectoryExist candidate
       if exists
         then pure candidate
         else do
           let parent = takeDirectory directory
           if parent == directory
-            then fail "Cannot find the aihc-prim source modules."
+            then fail "Cannot find the aihc-prim source directory."
             else findUp parent
 
 loadTcAnnotatedCase :: FilePath -> IO TcAnnotatedCase

--- a/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
@@ -20,33 +20,18 @@ annotated:
 
   almostFixM :: Monad m => m Bool -> (a -> m a) -> a -> m a
   almostFixM p f x = do
-  │          │││ │││ │││   └─ type: m a
-  │          │││ │││ └─ type: a
-  │          │││ │││ └─ type: a
-  │          │││ │││ └─ type: a
-  │          │││ └─ type: a → m a
-  │          │││ └─ type: a → m a
-  │          │││ └─ type: a → m a
-  │          └─ type: m Bool
-  │          └─ type: m Bool
+  │          │ │ │   └─ type: m a
+  │          │ │ └─ type: a
+  │          │ └─ type: a → m a
   │          └─ type: m Bool
   └─ type: ∀ m a. (Monad m) ⇒ m Bool → (a → m a) → a → m a
     p' <- p
-    ││││     └─ type: m Bool
+    └─ type: Bool
     └─ type: m Bool → (Bool → m a) → m a; type-args: m, Bool, a; evidence: given Monad m
-    └─ type: Bool
-    └─ type: Bool
-    └─ type: Bool
     if p' then almostFixM p f =<< f x
-       │       │          │ │ │   │ └─ type: a
-       │       │          │ │ │   └─ type: a → m a
-       │       │          │ │ └─ type: (a → m a) → m a → m a; type-args: m, a, a; evidence: given Monad m
-       │       │          │ └─ type: a → m a
-       │       │          └─ type: m Bool
-       │       └─ type: m Bool → (a → m a) → a → m a; type-args: m, a; evidence: given Monad m
-       └─ type: Bool
+               │              └─ type: (a → m a) → m a → m a; type-args: m, a, a; evidence: given Monad m
+               └─ type: m Bool → (a → m a) → a → m a; type-args: m, a; evidence: given Monad m
           else return x
-               │      └─ type: a
                └─ type: a → m a; type-args: m, a; evidence: given Monad m
 extensions:
 - KindSignatures

--- a/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/do-notation-monad.yaml
@@ -1,11 +1,5 @@
 annotated:
 - |-
-  module GHC.Types where
-  data Bool = False | True
-       │      │       └─ type: Bool
-       │      └─ type: Bool
-       └─ type: Type
-- |-
   {-# LANGUAGE KindSignatures, RebindableSyntax #-}
   module Test where
 
@@ -26,26 +20,38 @@ annotated:
 
   almostFixM :: Monad m => m Bool -> (a -> m a) -> a -> m a
   almostFixM p f x = do
-  │          │ │ │   └─ type: m a
-  │          │ │ └─ type: a
-  │          │ └─ type: a → m a
+  │          │││ │││ │││   └─ type: m a
+  │          │││ │││ └─ type: a
+  │          │││ │││ └─ type: a
+  │          │││ │││ └─ type: a
+  │          │││ └─ type: a → m a
+  │          │││ └─ type: a → m a
+  │          │││ └─ type: a → m a
+  │          └─ type: m Bool
+  │          └─ type: m Bool
   │          └─ type: m Bool
   └─ type: ∀ m a. (Monad m) ⇒ m Bool → (a → m a) → a → m a
     p' <- p
-    └─ type: Bool
+    ││││     └─ type: m Bool
     └─ type: m Bool → (Bool → m a) → m a; type-args: m, Bool, a; evidence: given Monad m
+    └─ type: Bool
+    └─ type: Bool
+    └─ type: Bool
     if p' then almostFixM p f =<< f x
-               │              └─ type: (a → m a) → m a → m a; type-args: m, a, a; evidence: given Monad m
-               └─ type: m Bool → (a → m a) → a → m a; type-args: m, a; evidence: given Monad m
+       │       │          │ │ │   │ └─ type: a
+       │       │          │ │ │   └─ type: a → m a
+       │       │          │ │ └─ type: (a → m a) → m a → m a; type-args: m, a, a; evidence: given Monad m
+       │       │          │ └─ type: a → m a
+       │       │          └─ type: m Bool
+       │       └─ type: m Bool → (a → m a) → a → m a; type-args: m, a; evidence: given Monad m
+       └─ type: Bool
           else return x
+               │      └─ type: a
                └─ type: a → m a; type-args: m, a; evidence: given Monad m
 extensions:
 - KindSignatures
 - RebindableSyntax
 modules:
-- |
-  module GHC.Types where
-  data Bool = False | True
 - |
   {-# LANGUAGE KindSignatures, RebindableSyntax #-}
   module Test where

--- a/components/aihc-tc/test/Test/Fixtures/annotated/integer-literal-signatures.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/integer-literal-signatures.yaml
@@ -12,25 +12,13 @@ annotated:
   instance Num Int where
   └─ $fNumInt ∷ () ⇒ Num Int
     fromInteger (IS x) = I# x
-    ││           ││││  │││    │  └─ type: Int#
-    ││           ││││  │││    └─ type: Int# → Int
-    ││           ││││  └─ type: Int#
-    ││           ││││  └─ type: Int#
-    ││           ││││  └─ type: Int#
-    ││           │└─ type: Integer
-    ││           │└─ type: Integer
-    ││           └─ type: Integer
-    ││           └─ type: Integer
-    └─ fromInteger ∷ Integer → Int
+    │            │  └─ type: Int#
+    │            └─ type: Integer
     └─ fromInteger ∷ Integer → Int
   instance Num Integer where
   └─ $fNumInteger ∷ () ⇒ Num Integer
     fromInteger x = x
-    ││           │││   └─ type: Integer
-    ││           └─ type: Integer
-    ││           └─ type: Integer
-    ││           └─ type: Integer
-    └─ fromInteger ∷ Integer → Integer
+    │           └─ type: Integer
     └─ fromInteger ∷ Integer → Integer
 - |-
   module Main where

--- a/components/aihc-tc/test/Test/Fixtures/annotated/integer-literal-signatures.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/integer-literal-signatures.yaml
@@ -1,67 +1,71 @@
 annotated:
 - |-
   module GHC.Num where
-  import GHC.Types (Int (..), Integer (..))
+  import GHC.Prim (Int#)
+  import GHC.Types (Int (..))
+  data Integer = IS Int#
+       │         └─ type: Int# → Integer
+       └─ type: Type
   class Num a where
   └─ class methods: fromInteger ∷ ∀ a. (Num a) ⇒ Integer → a
     fromInteger :: Integer -> a
   instance Num Int where
   └─ $fNumInt ∷ () ⇒ Num Int
-    fromInteger (IS x) = I x
-    │            │  └─ type: Int#
-    │            └─ type: Integer
+    fromInteger (IS x) = I# x
+    ││           ││││  │││    │  └─ type: Int#
+    ││           ││││  │││    └─ type: Int# → Int
+    ││           ││││  └─ type: Int#
+    ││           ││││  └─ type: Int#
+    ││           ││││  └─ type: Int#
+    ││           │└─ type: Integer
+    ││           │└─ type: Integer
+    ││           └─ type: Integer
+    ││           └─ type: Integer
+    └─ fromInteger ∷ Integer → Int
     └─ fromInteger ∷ Integer → Int
   instance Num Integer where
   └─ $fNumInteger ∷ () ⇒ Num Integer
     fromInteger x = x
-    │           └─ type: Integer
+    ││           │││   └─ type: Integer
+    ││           └─ type: Integer
+    ││           └─ type: Integer
+    ││           └─ type: Integer
+    └─ fromInteger ∷ Integer → Integer
     └─ fromInteger ∷ Integer → Integer
 - |-
-  module GHC.Types where
-  import GHC.Prim (Int#)
-  data Int = I Int#
-       │     └─ type: Int# → Int
-       └─ type: Type
-  data Integer = IS Int#
-       │         └─ type: Int# → Integer
-       └─ type: Type
-- |-
   module Main where
-  import GHC.Num (fromInteger)
-  import GHC.Types (Int, Integer)
+  import GHC.Num (Integer)
+  import GHC.Types (Int)
   asInt :: Int
   asInt = 1 :: Int
   │       └─ type: Int; type-args: Int; evidence: $fNumInt
   └─ type: Int
   asInteger :: Integer
   asInteger = 1 :: Integer
-  │           └─ type: Integer; type-args: Integer; evidence: $fNumInteger
-  └─ type: Integer
+  │           └─ type: GHC.Num.Integer; type-args: Integer; evidence: $fNumInteger
+  └─ type: GHC.Num.Integer
 extensions:
 - MagicHash
 modules:
 - |
-  module GHC.Types where
-  import GHC.Prim (Int#)
-  data Int = I Int#
-  data Integer = IS Int#
-- |
   module GHC.Num where
-  import GHC.Types (Int (..), Integer (..))
+  import GHC.Prim (Int#)
+  import GHC.Types (Int (..))
+  data Integer = IS Int#
   class Num a where
     fromInteger :: Integer -> a
   instance Num Int where
-    fromInteger (IS x) = I x
+    fromInteger (IS x) = I# x
   instance Num Integer where
     fromInteger x = x
 - |
   module Main where
-  import GHC.Num (fromInteger)
-  import GHC.Types (Int, Integer)
+  import GHC.Num (Integer)
+  import GHC.Types (Int)
   asInt :: Int
   asInt = 1 :: Int
   asInteger :: Integer
   asInteger = 1 :: Integer
-reason: expression signatures constrain overloaded integer literals to concrete GHC.Num
-  instances
+reason: expression signatures constrain overloaded integer literals to concrete
+  GHC.Num instances
 status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/integer-pattern-lambda-case.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/integer-pattern-lambda-case.yaml
@@ -10,12 +10,13 @@ annotated:
     fromInteger :: Integer -> a
 - |-
   module Main where
+  import GHC.Classes ((==))
+  import GHC.Num (fromInteger)
   match = \case
   └─ type: ∀ a. (GHC.Classes.Eq a, GHC.Num.Num a) ⇒ a → ()
     1 -> ()
-    │││    └─ type: ()
+    ││    └─ type: ()
     └─ type: a; type-args: a; evidence: given Num a
-    └─ type: a
     └─ type: a → a → Bool; type-args: a; evidence: given Eq a
 extensions:
 - LambdaCase
@@ -29,6 +30,8 @@ modules:
     fromInteger :: Integer -> a
 - |
   module Main where
+  import GHC.Classes ((==))
+  import GHC.Num (fromInteger)
   match = \case
     1 -> ()
 reason: overloaded integer patterns infer Eq and Num constraints like GHC

--- a/components/aihc-tc/test/Test/Fixtures/annotated/integer-pattern-lambda-case.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/integer-pattern-lambda-case.yaml
@@ -1,59 +1,34 @@
 annotated:
 - |-
-  module GHC.Classes where
-  import GHC.Types (Bool)
-  class Eq a where
-  └─ class methods: == ∷ ∀ a. (Eq a) ⇒ a → a → Bool
-    (==) :: a -> a -> Bool
-- |-
   module GHC.Num where
-  import GHC.Types (Integer)
+  import GHC.Prim (Int#)
+  data Integer = IS Int#
+       │         └─ type: Int# → Integer
+       └─ type: Type
   class Num a where
   └─ class methods: fromInteger ∷ ∀ a. (Num a) ⇒ Integer → a
     fromInteger :: Integer -> a
 - |-
-  module GHC.Types where
-  import GHC.Prim (Int#)
-  data Bool = False | True
-       │      │       └─ type: Bool
-       │      └─ type: Bool
-       └─ type: Type
-  data Integer = IS Int#
-       │         └─ type: Int# → Integer
-       └─ type: Type
-- |-
   module Main where
-  import GHC.Classes ((==))
-  import GHC.Num (fromInteger)
   match = \case
   └─ type: ∀ a. (GHC.Classes.Eq a, GHC.Num.Num a) ⇒ a → ()
     1 -> ()
-    ││    └─ type: ()
+    │││    └─ type: ()
     └─ type: a; type-args: a; evidence: given Num a
+    └─ type: a
     └─ type: a → a → Bool; type-args: a; evidence: given Eq a
 extensions:
 - LambdaCase
 - MagicHash
 modules:
 - |
-  module GHC.Types where
-  import GHC.Prim (Int#)
-  data Bool = False | True
-  data Integer = IS Int#
-- |
-  module GHC.Classes where
-  import GHC.Types (Bool)
-  class Eq a where
-    (==) :: a -> a -> Bool
-- |
   module GHC.Num where
-  import GHC.Types (Integer)
+  import GHC.Prim (Int#)
+  data Integer = IS Int#
   class Num a where
     fromInteger :: Integer -> a
 - |
   module Main where
-  import GHC.Classes ((==))
-  import GHC.Num (fromInteger)
   match = \case
     1 -> ()
 reason: overloaded integer patterns infer Eq and Num constraints like GHC

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
@@ -1,24 +1,25 @@
 annotated:
 - |-
-  module GHC.Types where
-  data Bool = True | False
-       │      │      └─ type: Bool
-       │      └─ type: Bool
-       └─ type: Type
-- |-
   module Test where
   import GHC.Types (Bool)
   filter f list = [ x | x <- list, f x ]
-  │      │ │      │     └─ type: a
-  │      │ │      └─ type: [a]; type-args: a
-  │      │ └─ type: [a]
+  │      │││ │││      │ │   │││    │     │ └─ type: a
+  │      │││ │││      │ │   │││    │     └─ type: a → Bool
+  │      │││ │││      │ │   │││    └─ type: [a]
+  │      │││ │││      │ │   └─ type: a
+  │      │││ │││      │ │   └─ type: a
+  │      │││ │││      │ │   └─ type: a
+  │      │││ │││      │ └─ type: a
+  │      │││ │││      └─ type: [a]; type-args: a
+  │      │││ └─ type: [a]
+  │      │││ └─ type: [a]
+  │      │││ └─ type: [a]
+  │      └─ type: a → Bool
+  │      └─ type: a → Bool
   │      └─ type: a → Bool
   └─ type: ∀ a. (a → Bool) → [a] → [a]
 extensions: []
 modules:
-- |
-  module GHC.Types where
-  data Bool = True | False
 - |
   module Test where
   import GHC.Types (Bool)

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-comprehension-guard.yaml
@@ -3,19 +3,9 @@ annotated:
   module Test where
   import GHC.Types (Bool)
   filter f list = [ x | x <- list, f x ]
-  │      │││ │││      │ │   │││    │     │ └─ type: a
-  │      │││ │││      │ │   │││    │     └─ type: a → Bool
-  │      │││ │││      │ │   │││    └─ type: [a]
-  │      │││ │││      │ │   └─ type: a
-  │      │││ │││      │ │   └─ type: a
-  │      │││ │││      │ │   └─ type: a
-  │      │││ │││      │ └─ type: a
-  │      │││ │││      └─ type: [a]; type-args: a
-  │      │││ └─ type: [a]
-  │      │││ └─ type: [a]
-  │      │││ └─ type: [a]
-  │      └─ type: a → Bool
-  │      └─ type: a → Bool
+  │      │ │      │     └─ type: a
+  │      │ │      └─ type: [a]; type-args: a
+  │      │ └─ type: [a]
   │      └─ type: a → Bool
   └─ type: ∀ a. (a → Bool) → [a] → [a]
 extensions: []

--- a/components/aihc-tc/test/Test/Fixtures/annotated/overloaded-integer-inferred-types.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/overloaded-integer-inferred-types.yaml
@@ -1,65 +1,39 @@
 annotated:
 - |-
-  module GHC.Classes where
-  import GHC.Types (Bool)
-  class Eq a where
-  └─ class methods: == ∷ ∀ a. (Eq a) ⇒ a → a → Bool
-    (==) :: a -> a -> Bool
-- |-
   module GHC.Num where
-  import GHC.Types (Integer)
+  import GHC.Prim (Int#)
+  data Integer = IS Int#
+       │         └─ type: Int# → Integer
+       └─ type: Type
   class Num a where
   └─ class methods: fromInteger ∷ ∀ a. (Num a) ⇒ Integer → a
     fromInteger :: Integer -> a
 - |-
-  module GHC.Types where
-  import GHC.Prim (Int#)
-  data Bool = False | True
-       │      │       └─ type: Bool
-       │      └─ type: Bool
-       └─ type: Type
-  data Integer = IS Int#
-       │         └─ type: Int# → Integer
-       └─ type: Type
-- |-
   module Main where
-  import GHC.Classes ((==))
-  import GHC.Num (fromInteger)
   literal = 1
   │         └─ type: a; type-args: a; evidence: given Num a
   └─ type: ∀ a. (GHC.Num.Num a) ⇒ a
   match = \case
   └─ type: ∀ a. (GHC.Classes.Eq a, GHC.Num.Num a) ⇒ a → ()
     1 -> ()
-    ││    └─ type: ()
+    │││    └─ type: ()
     └─ type: a; type-args: a; evidence: given Num a
+    └─ type: a
     └─ type: a → a → Bool; type-args: a; evidence: given Eq a
 extensions:
 - LambdaCase
 - MagicHash
 modules:
 - |
-  module GHC.Types where
-  import GHC.Prim (Int#)
-  data Bool = False | True
-  data Integer = IS Int#
-- |
-  module GHC.Classes where
-  import GHC.Types (Bool)
-  class Eq a where
-    (==) :: a -> a -> Bool
-- |
   module GHC.Num where
-  import GHC.Types (Integer)
+  import GHC.Prim (Int#)
+  data Integer = IS Int#
   class Num a where
     fromInteger :: Integer -> a
 - |
   module Main where
-  import GHC.Classes ((==))
-  import GHC.Num (fromInteger)
   literal = 1
   match = \case
     1 -> ()
-reason: overloaded integer expressions and patterns infer GHC-compatible Num and Eq
-  constraints
+reason: overloaded integer expressions and patterns infer GHC-compatible Num and Eq constraints
 status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/overloaded-integer-inferred-types.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/overloaded-integer-inferred-types.yaml
@@ -10,15 +10,16 @@ annotated:
     fromInteger :: Integer -> a
 - |-
   module Main where
+  import GHC.Classes ((==))
+  import GHC.Num (fromInteger)
   literal = 1
   │         └─ type: a; type-args: a; evidence: given Num a
   └─ type: ∀ a. (GHC.Num.Num a) ⇒ a
   match = \case
   └─ type: ∀ a. (GHC.Classes.Eq a, GHC.Num.Num a) ⇒ a → ()
     1 -> ()
-    │││    └─ type: ()
+    ││    └─ type: ()
     └─ type: a; type-args: a; evidence: given Num a
-    └─ type: a
     └─ type: a → a → Bool; type-args: a; evidence: given Eq a
 extensions:
 - LambdaCase
@@ -32,6 +33,8 @@ modules:
     fromInteger :: Integer -> a
 - |
   module Main where
+  import GHC.Classes ((==))
+  import GHC.Num (fromInteger)
   literal = 1
   match = \case
     1 -> ()

--- a/components/aihc-tc/test/Test/Fixtures/annotated/stock-deriving-strategy-selection.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/stock-deriving-strategy-selection.yaml
@@ -2,22 +2,15 @@ annotated:
 - |-
   {-# LANGUAGE DeriveAnyClass, DeriveFunctor, KindSignatures #-}
   module Main where
+  import GHC.Classes (Eq)
   data Type
        └─ type: Type
-  data Bool = False | True
-       │      │       └─ type: Bool
-       │      └─ type: Bool
-       └─ type: Type
-  class Eq a where
-  └─ class methods: == ∷ ∀ a. (Eq a) ⇒ a → a → Bool, /= ∷ ∀ a. (Eq a) ⇒ a → a → Bool
-    (==) :: a -> a -> Bool
-    (/=) :: a -> a -> Bool
   class Functor (f :: Type -> Type) where
   └─ class methods:
   data E = E
   │    │   └─ type: E
   │    └─ type: Type
-  └─ deriving plans: anyclass Eq E [context: ()] [methods: ==, /=]
+  └─ deriving plans: stock Eq E [context: ()] [methods: ==, /=]
     deriving Eq
   data F a = F a
   │    │     └─ type: ∀ a. a → F a
@@ -32,15 +25,12 @@ modules:
 - |
   {-# LANGUAGE DeriveAnyClass, DeriveFunctor, KindSignatures #-}
   module Main where
+  import GHC.Classes (Eq)
   data Type
-  data Bool = False | True
-  class Eq a where
-    (==) :: a -> a -> Bool
-    (/=) :: a -> a -> Bool
   class Functor (f :: Type -> Type) where
   data E = E
     deriving Eq
   data F a = F a
     deriving Functor
-reason: local classes do not select stock mechanisms from their names
+reason: the real Eq class selects its stock mechanism
 status: pass

--- a/components/aihc-tc/test/Test/Fixtures/annotated/typeclass-evidence.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/typeclass-evidence.yaml
@@ -1,29 +1,40 @@
 annotated:
 - |-
   module Test where
-  data Bool = False | True
-       │      │       └─ type: Bool
-       │      └─ type: Bool
-       └─ type: Type
-  class Eq a where
-  └─ class methods: == ∷ ∀ a. (Eq a) ⇒ a → a → Bool
-    (==) :: a -> a -> Bool
+  import GHC.Classes (Eq (..))
+  import GHC.Types (Bool (..))
   instance Eq Bool where
   └─ $fEqBool ∷ () ⇒ Eq Bool
     False == False = True
-    ││        └─ type: Bool
+    ││││        ││       └─ type: Bool
+    ││││        └─ type: Bool
+    ││││        └─ type: Bool
+    └─ type: Bool
+    └─ == ∷ Bool → Bool → Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
     False == True = False
-    ││        └─ type: Bool
+    ││││        ││      └─ type: Bool
+    ││││        └─ type: Bool
+    ││││        └─ type: Bool
+    └─ type: Bool
+    └─ == ∷ Bool → Bool → Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
     True == False = False
-    ││       └─ type: Bool
+    ││││       ││       └─ type: Bool
+    ││││       └─ type: Bool
+    ││││       └─ type: Bool
+    └─ type: Bool
+    └─ == ∷ Bool → Bool → Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
     True == True = True
-    ││       └─ type: Bool
+    ││││       ││      └─ type: Bool
+    ││││       └─ type: Bool
+    ││││       └─ type: Bool
+    └─ type: Bool
+    └─ == ∷ Bool → Bool → Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
   eqBool :: Bool -> Bool -> Bool
@@ -34,9 +45,8 @@ extensions: []
 modules:
 - |
   module Test where
-  data Bool = False | True
-  class Eq a where
-    (==) :: a -> a -> Bool
+  import GHC.Classes (Eq (..))
+  import GHC.Types (Bool (..))
   instance Eq Bool where
     False == False = True
     False == True = False

--- a/components/aihc-tc/test/Test/Fixtures/annotated/typeclass-evidence.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/typeclass-evidence.yaml
@@ -6,35 +6,19 @@ annotated:
   instance Eq Bool where
   └─ $fEqBool ∷ () ⇒ Eq Bool
     False == False = True
-    ││││        ││       └─ type: Bool
-    ││││        └─ type: Bool
-    ││││        └─ type: Bool
-    └─ type: Bool
-    └─ == ∷ Bool → Bool → Bool
+    ││        └─ type: Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
     False == True = False
-    ││││        ││      └─ type: Bool
-    ││││        └─ type: Bool
-    ││││        └─ type: Bool
-    └─ type: Bool
-    └─ == ∷ Bool → Bool → Bool
+    ││        └─ type: Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
     True == False = False
-    ││││       ││       └─ type: Bool
-    ││││       └─ type: Bool
-    ││││       └─ type: Bool
-    └─ type: Bool
-    └─ == ∷ Bool → Bool → Bool
+    ││       └─ type: Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
     True == True = True
-    ││││       ││      └─ type: Bool
-    ││││       └─ type: Bool
-    ││││       └─ type: Bool
-    └─ type: Bool
-    └─ == ∷ Bool → Bool → Bool
+    ││       └─ type: Bool
     └─ type: Bool
     └─ == ∷ Bool → Bool → Bool
   eqBool :: Bool -> Bool -> Bool

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -98,7 +98,8 @@
     aihc-tc = {
       src = sources.tcSrc;
       cabal2nixOptions = {
-        extraCabal2nixOptions = "--flag fuzz";
+        extraCabal2nixOptions = "--flag fuzz --subpath components/aihc-tc";
+        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -110,12 +110,19 @@ in rec {
     ".yml"
   ];
 
-  tcSrc = mkComponentSrc "/components/aihc-tc" [
-    ".hs"
-    ".cabal"
-    ".yaml"
-    ".yml"
-  ];
+  tcSrc =
+    mkRootSubsetSrc [
+      "components/aihc-tc/"
+      "core-libs/aihc-prim/src/GHC/Classes.hs"
+      "core-libs/aihc-prim/src/GHC/Prim.hs"
+      "core-libs/aihc-prim/src/GHC/Tuple.hs"
+      "core-libs/aihc-prim/src/GHC/Types.hs"
+    ] [
+      ".hs"
+      ".cabal"
+      ".yaml"
+      ".yml"
+    ];
 
   baseSrc = mkComponentSrc "/core-libs/aihc-base" [
     ".hs"


### PR DESCRIPTION
## Summary

- Load `GHC.Classes`, `GHC.Prim`, `GHC.Tuple`, and `GHC.Types` from `aihc-prim`.
- Parse each primitive module with its source language settings.
- Resolve and type-check the primitive modules once with `unsafePerformIO`.
- Use the real resolver scopes and type-checker interface in annotated golden tests.
- Keep the module-graph checks and duplicate-annotation fixes from PR #1521.
- Remove the substitute primitive modules from the seven affected fixtures.
- Include the primitive sources in the isolated TC Nix test source.

## Validation

- `cabal test -v0 aihc-tc:spec --test-options="--hide-successes"`
- `just fmt`
- `just check`
- `nix build .#checks.aarch64-darwin.tc-tests --no-link`
- All 84 active TC tests pass.
- All 109 FC2 tests pass.

## Progress counts

- TC annotated golden fixtures: 72 `PASS` before and after.
- TC annotated golden fixtures: 6 `XFAIL` before and after.
- TC annotated golden fixtures: 78 total before and after.
- Active `aihc-tc` tests: 84 before and after.
