### PR TITLE
fix(fc2): bind existential types in alternatives

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -684,7 +684,6 @@ bindOrigins bind = binderOrigins (bindBinder bind) <> exprOrigins (bindRhs bind)
 altOrigins :: Alt -> [(PackageId, Text)]
 altOrigins alternative =
   altConOrigins (altCon alternative)
-    <> concatMap binderOrigins (altTypeBinders alternative)
     <> concatMap binderOrigins (altBinders alternative)
     <> exprOrigins (altRhs alternative)
 

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -690,7 +690,7 @@ altOrigins alternative =
 altConOrigins :: AltCon -> [(PackageId, Text)]
 altConOrigins alternative =
   case alternative of
-    AltData name -> nameOriginPair name
+    AltData name binders -> nameOriginPair name <> concatMap binderOrigins binders
     AltLit literal -> literalOrigins literal
     AltDefault -> []
 

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -684,13 +684,14 @@ bindOrigins bind = binderOrigins (bindBinder bind) <> exprOrigins (bindRhs bind)
 altOrigins :: Alt -> [(PackageId, Text)]
 altOrigins alternative =
   altConOrigins (altCon alternative)
+    <> concatMap binderOrigins (altTypeBinders alternative)
     <> concatMap binderOrigins (altBinders alternative)
     <> exprOrigins (altRhs alternative)
 
 altConOrigins :: AltCon -> [(PackageId, Text)]
 altConOrigins alternative =
   case alternative of
-    AltData name binders -> nameOriginPair name <> concatMap binderOrigins binders
+    AltData name -> nameOriginPair name
     AltLit literal -> literalOrigins literal
     AltDefault -> []
 

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar.hs
@@ -684,6 +684,7 @@ bindOrigins bind = binderOrigins (bindBinder bind) <> exprOrigins (bindRhs bind)
 altOrigins :: Alt -> [(PackageId, Text)]
 altOrigins alternative =
   altConOrigins (altCon alternative)
+    <> concatMap binderOrigins (altTypeBinders alternative)
     <> concatMap binderOrigins (altBinders alternative)
     <> exprOrigins (altRhs alternative)
 

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -23,7 +23,6 @@ import Aihc.Tc
     TcBindingResult (..),
     TcInterface (..),
     TyConFlavor (..),
-    dataConArgTypes,
   )
 import Aihc.Tc.Annotations
   ( TcAnnotation (..),
@@ -74,7 +73,6 @@ data ValueState = ValueState
     vsLocals :: !(Map Text (Binder, TcType)),
     vsDictionaries :: !(Map Text Binder),
     vsConstructors :: !(Map Text [Name]),
-    vsDataConstructors :: !(Map (PackageId, Text, Text) DataConInfo),
     vsNewtypeConstructors :: !(Map (PackageId, Text, Text) DataTypeInfo)
   }
 
@@ -106,13 +104,6 @@ desugarValues convertEnv bindings interface moduleOrigin checked = do
             constructor <- dtiConstructors dataType,
             let (package, moduleName') = dciOrigin constructor
           ]
-      dataConstructors =
-        Map.fromList
-          [ ((package, moduleName', dciName constructor), constructor)
-          | dataType <- tcInterfaceDataTypes interface,
-            constructor <- dtiConstructors dataType,
-            let (package, moduleName') = dciOrigin constructor
-          ]
       newtypes =
         Map.fromList
           [ ((package, moduleName', dciName constructor), dataType)
@@ -130,7 +121,6 @@ desugarValues convertEnv bindings interface moduleOrigin checked = do
             vsLocals = Map.empty,
             vsDictionaries = Map.empty,
             vsConstructors = constructors,
-            vsDataConstructors = dataConstructors,
             vsNewtypeConstructors = newtypes
           }
   fst <$> runStateT (desugarModuleValues checked) initialState
@@ -303,7 +293,7 @@ desugarSelector classTyCon classTyVars fieldTypes superClassCount method = do
           (ExVar (binderName classDictionary))
           caseBinder
           resultType'
-          [Alt (AltData (classDictConName classTyCon) []) fields selectedExpr]
+          [Alt (AltData (classDictConName classTyCon)) [] fields selectedExpr]
   typeBinders <- mapM convertTypeBinder typeVariables
   methodType' <- convertCheckedType (tcClassMethodType method)
   moduleOrigin <- gets vsModuleOrigin
@@ -611,8 +601,8 @@ desugarOverloadedIntegerMatch resultType arguments match failure =
                 test
                 testBinder
                 resultType'
-                [ Alt (AltData trueName []) [] success,
-                  Alt (AltData falseName []) [] failure
+                [ Alt (AltData trueName) [] [] success,
+                  Alt (AltData falseName) [] [] failure
                 ]
             )
       | otherwise =
@@ -726,7 +716,7 @@ desugarDataPatterns resultType argument arguments matches = do
         [] -> pure []
         _ -> do
           body <- desugarMatchArguments resultType arguments (map dropFirstPattern defaultMatches)
-          pure [Alt AltDefault [] body]
+          pure [Alt AltDefault [] [] body]
     pure (ExCase (ExVar (binderName argument)) caseBinder resultType' (constructorAlternatives <> defaultAlternatives))
 
 firstNewtypePattern :: [Syn.Match] -> ValueM (Maybe (Syn.Pattern, DataTypeInfo))
@@ -795,8 +785,8 @@ desugarPatternGroup resultType remaining matches key = do
   constructor <- patternConstructor pattern'
   let subpatterns = patternChildren pattern'
       predicates = patternGivenPredicates pattern'
-  existentialVariables <- patternConstructorExistentials pattern'
-  typeBinders <- mapM convertTypeBinder existentialVariables
+      typeVariables = patternTypeVariables pattern'
+  typeBinders <- mapM convertTypeBinder typeVariables
   fieldTypes <- patternFieldTypes pattern' subpatterns
   fields <- zipWithM freshPatternBinder subpatterns fieldTypes
   dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
@@ -815,7 +805,7 @@ desugarPatternGroup resultType remaining matches key = do
     withDictionaries
       (zipWith predicateDictionary predicates dictionaries)
       (withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded))
-  pure (Alt (constructorWithTypeBinders typeBinders constructor) (dictionaries <> fields) body)
+  pure (Alt constructor typeBinders (dictionaries <> fields) body)
 
 patternGivenPredicates :: Syn.Pattern -> [Pred]
 patternGivenPredicates = go
@@ -841,46 +831,20 @@ patternGivenPredicates = go
         ]
     evidencePredicates checked = [predicate | Ev.EvGiven predicate <- tcAnnEvidenceTerms checked]
 
-patternConstructorExistentials :: Syn.Pattern -> ValueM [TyVarId]
-patternConstructorExistentials pattern' = do
-  constructors <- gets vsDataConstructors
-  case patternConstructorSourceName pattern' >>= resolvedTermKey >>= (`Map.lookup` constructors) of
-    Nothing -> pure []
-    Just constructor ->
-      case dciExTyVars constructor of
-        [] -> pure []
-        existentials -> do
-          annotation <- maybe (failValue "existential constructor pattern has no checked annotation") pure (patternConstructorAnnotation pattern')
-          let declaredTypes = constructorBodyType constructor : concatMap predicateTypes (dciTheta constructor)
-              actualTypes = tcAnnType annotation : concatMap predicateTypes (patternGivenPredicates pattern')
-          instantiation <- maybe (failValue "existential constructor pattern types do not match its declaration") pure (matchTypes declaredTypes actualTypes)
-          mapM (existentialVariable instantiation) existentials
+patternTypeVariables :: Syn.Pattern -> [TyVarId]
+patternTypeVariables = go
   where
-    constructorBodyType constructor = foldr TcFunTy (dciResTy constructor) (dataConArgTypes constructor)
-    predicateTypes predicate =
-      case predicate of
-        ClassPred _ arguments -> arguments
-        EqPred left right -> [left, right]
-    existentialVariable instantiation existential =
-      case Map.lookup (tvUnique existential) instantiation of
-        Just (TcTyVar skolem) -> pure skolem
-        Just ty -> failValue ("existential constructor pattern has a non-variable type: " <> show ty)
-        Nothing -> failValue "existential constructor pattern does not instantiate all existential types"
-
-patternConstructorAnnotation :: Syn.Pattern -> Maybe TcAnnotation
-patternConstructorAnnotation pattern' =
-  case pattern' of
-    Syn.PAnn annotation inner ->
-      case Syn.fromAnnotation annotation of
-        Just checked
-          | not (null (tcAnnTypeArgs checked)) -> Just checked
-        _ -> patternConstructorAnnotation inner
-    Syn.PParen inner -> patternConstructorAnnotation inner
-    Syn.PStrict inner -> patternConstructorAnnotation inner
-    Syn.PIrrefutable inner -> patternConstructorAnnotation inner
-    Syn.PAs _ inner -> patternConstructorAnnotation inner
-    Syn.PTypeSig inner _ -> patternConstructorAnnotation inner
-    _ -> Nothing
+    go pattern' =
+      case pattern' of
+        Syn.PAnn annotation inner -> annotationTypeVariables annotation <> go inner
+        Syn.PParen inner -> go inner
+        Syn.PStrict inner -> go inner
+        Syn.PIrrefutable inner -> go inner
+        Syn.PAs _ inner -> go inner
+        Syn.PTypeSig inner _ -> go inner
+        _ -> []
+    annotationTypeVariables annotation =
+      maybe [] tcAnnTypeBinders (Syn.fromAnnotation annotation :: Maybe TcAnnotation)
 
 patternKeys :: [Syn.Match] -> [Text]
 patternKeys matches =
@@ -989,10 +953,10 @@ patternChildren pattern' =
 patternConstructor :: Syn.Pattern -> ValueM AltCon
 patternConstructor pattern' =
   case peelPattern pattern' of
-    Syn.PCon name _ _ -> (`AltData` []) <$> resolvedTermName name
-    Syn.PInfix _ name _ -> (`AltData` []) <$> resolvedTermName name
-    Syn.PList [] -> (`AltData` []) <$> primitiveName "GHC.Types" "[]" SortDataConstructor
-    Syn.PList (_ : _) -> (`AltData` []) <$> primitiveName "GHC.Types" ":" SortDataConstructor
+    Syn.PCon name _ _ -> AltData <$> resolvedTermName name
+    Syn.PInfix _ name _ -> AltData <$> resolvedTermName name
+    Syn.PList [] -> AltData <$> primitiveName "GHC.Types" "[]" SortDataConstructor
+    Syn.PList (_ : _) -> AltData <$> primitiveName "GHC.Types" ":" SortDataConstructor
     Syn.PTuple flavor fields ->
       let arity = length fields
           constructor =
@@ -1003,19 +967,13 @@ patternConstructor pattern' =
             case flavor of
               Syn.Boxed -> "GHC.Tuple"
               Syn.Unboxed -> "GHC.Types"
-       in (`AltData` []) <$> primitiveName moduleName' constructor SortDataConstructor
+       in AltData <$> primitiveName moduleName' constructor SortDataConstructor
     Syn.PLit literal
-      | isBoxedCharacterLiteral literal -> (`AltData` []) <$> uniqueConstructorName "C#"
+      | isBoxedCharacterLiteral literal -> AltData <$> uniqueConstructorName "C#"
       | otherwise -> AltLit <$> patternLiteral literal
     Syn.PWildcard -> pure AltDefault
     Syn.PVar {} -> pure AltDefault
     unsupported -> failValue ("unsupported System FC 2 pattern: " <> take 80 (show unsupported))
-
-constructorWithTypeBinders :: [Binder] -> AltCon -> AltCon
-constructorWithTypeBinders binders constructor =
-  case constructor of
-    AltData name _ -> AltData name binders
-    other -> other
 
 patternLiteral :: Syn.Literal -> ValueM Literal
 patternLiteral literal =
@@ -1194,8 +1152,8 @@ desugarIf resultType condition thenExpression elseExpression = do
         condition'
         binder
         resultType'
-        [ Alt (AltData trueName []) [] thenExpression',
-          Alt (AltData falseName []) [] elseExpression'
+        [ Alt (AltData trueName) [] [] thenExpression',
+          Alt (AltData falseName) [] [] elseExpression'
         ]
     )
 
@@ -1418,8 +1376,8 @@ desugarDoConstructorPattern resultType binder pattern' success = do
     Nothing -> do
       let children = patternChildren pattern'
           predicates = patternGivenPredicates pattern'
-      existentialVariables <- patternConstructorExistentials pattern'
-      typeBinders <- mapM convertTypeBinder existentialVariables
+      let typeVariables = patternTypeVariables pattern'
+      typeBinders <- mapM convertTypeBinder typeVariables
       fieldTypes <- patternFieldTypes pattern' children
       fields <- zipWithM freshPatternBinder children fieldTypes
       dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
@@ -1430,7 +1388,7 @@ desugarDoConstructorPattern resultType binder pattern' success = do
         withDictionaries
           (zipWith predicateDictionary predicates dictionaries)
           (desugarDoChildPatterns resultType (zip3 fields fieldTypes children) success)
-      pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt (constructorWithTypeBinders typeBinders constructor) (dictionaries <> fields) body])
+      pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt constructor typeBinders (dictionaries <> fields) body])
 
 desugarDoChildPatterns :: TcType -> [(Binder, TcType, Syn.Pattern)] -> ValueM Expr -> ValueM Expr
 desugarDoChildPatterns resultType children success =
@@ -1600,7 +1558,7 @@ desugarEvidence evidence =
             sourceExpression
             sourceBinder
             resultType
-            [Alt (AltData (classDictConName classTyCon) []) fieldBinders (ExVar (binderName selected))]
+            [Alt (AltData (classDictConName classTyCon)) [] fieldBinders (ExVar (binderName selected))]
         )
     Ev.EvCast inner coercion -> ExCast <$> desugarEvidence inner <*> convertCoercion coercion
     Ev.EvTypeable origin ty arguments -> desugarTypeableEvidence origin ty arguments

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -23,6 +23,7 @@ import Aihc.Tc
     TcBindingResult (..),
     TcInterface (..),
     TyConFlavor (..),
+    dataConArgTypes,
   )
 import Aihc.Tc.Annotations
   ( TcAnnotation (..),
@@ -73,6 +74,8 @@ data ValueState = ValueState
     vsLocals :: !(Map Text (Binder, TcType)),
     vsDictionaries :: !(Map Text Binder),
     vsConstructors :: !(Map Text [Name]),
+    vsDataConstructors :: !(Map (PackageId, Text, Text) DataConInfo),
+    vsTypeSubstitution :: !(Map Unique TcType),
     vsNewtypeConstructors :: !(Map (PackageId, Text, Text) DataTypeInfo)
   }
 
@@ -104,6 +107,13 @@ desugarValues convertEnv bindings interface moduleOrigin checked = do
             constructor <- dtiConstructors dataType,
             let (package, moduleName') = dciOrigin constructor
           ]
+      dataConstructors =
+        Map.fromList
+          [ ((package, moduleName', dciName constructor), constructor)
+          | dataType <- tcInterfaceDataTypes interface,
+            constructor <- dtiConstructors dataType,
+            let (package, moduleName') = dciOrigin constructor
+          ]
       newtypes =
         Map.fromList
           [ ((package, moduleName', dciName constructor), dataType)
@@ -121,6 +131,8 @@ desugarValues convertEnv bindings interface moduleOrigin checked = do
             vsLocals = Map.empty,
             vsDictionaries = Map.empty,
             vsConstructors = constructors,
+            vsDataConstructors = dataConstructors,
+            vsTypeSubstitution = Map.empty,
             vsNewtypeConstructors = newtypes
           }
   fst <$> runStateT (desugarModuleValues checked) initialState
@@ -293,7 +305,7 @@ desugarSelector classTyCon classTyVars fieldTypes superClassCount method = do
           (ExVar (binderName classDictionary))
           caseBinder
           resultType'
-          [Alt (AltData (classDictConName classTyCon)) [] fields selectedExpr]
+          [Alt (AltData (classDictConName classTyCon)) fields selectedExpr]
   typeBinders <- mapM convertTypeBinder typeVariables
   methodType' <- convertCheckedType (tcClassMethodType method)
   moduleOrigin <- gets vsModuleOrigin
@@ -601,8 +613,8 @@ desugarOverloadedIntegerMatch resultType arguments match failure =
                 test
                 testBinder
                 resultType'
-                [ Alt (AltData trueName) [] [] success,
-                  Alt (AltData falseName) [] [] failure
+                [ Alt (AltData trueName) [] success,
+                  Alt (AltData falseName) [] failure
                 ]
             )
       | otherwise =
@@ -716,7 +728,7 @@ desugarDataPatterns resultType argument arguments matches = do
         [] -> pure []
         _ -> do
           body <- desugarMatchArguments resultType arguments (map dropFirstPattern defaultMatches)
-          pure [Alt AltDefault [] [] body]
+          pure [Alt AltDefault [] body]
     pure (ExCase (ExVar (binderName argument)) caseBinder resultType' (constructorAlternatives <> defaultAlternatives))
 
 firstNewtypePattern :: [Syn.Match] -> ValueM (Maybe (Syn.Pattern, DataTypeInfo))
@@ -785,27 +797,27 @@ desugarPatternGroup resultType remaining matches key = do
   constructor <- patternConstructor pattern'
   let subpatterns = patternChildren pattern'
       predicates = patternGivenPredicates pattern'
-      typeVariables = patternTypeVariables pattern'
-  typeBinders <- mapM convertTypeBinder typeVariables
-  fieldTypes <- patternFieldTypes pattern' subpatterns
-  fields <- zipWithM freshPatternBinder subpatterns fieldTypes
-  dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
-  let arity = length fields
-      expanded = mapMaybe (specializeMatch key arity) matches
-      localBindings =
-        concat
-          [ concat (zipWith3 patternMatchBindings children fields fieldTypes)
-          | match <- matches,
-            candidate : _ <- [Syn.matchPats match],
-            not (patternIsDefault candidate),
-            patternKey candidate == key,
-            let children = patternChildren candidate
-          ]
-  body <-
-    withDictionaries
-      (zipWith predicateDictionary predicates dictionaries)
-      (withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded))
-  pure (Alt constructor typeBinders (dictionaries <> fields) body)
+  substitution <- patternConstructorSubstitution pattern'
+  withTypeSubstitution substitution $ do
+    fieldTypes <- patternFieldTypes pattern' subpatterns
+    fields <- zipWithM freshPatternBinder subpatterns fieldTypes
+    dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
+    let arity = length fields
+        expanded = mapMaybe (specializeMatch key arity) matches
+        localBindings =
+          concat
+            [ concat (zipWith3 patternMatchBindings children fields fieldTypes)
+            | match <- matches,
+              candidate : _ <- [Syn.matchPats match],
+              not (patternIsDefault candidate),
+              patternKey candidate == key,
+              let children = patternChildren candidate
+            ]
+    body <-
+      withDictionaries
+        (zipWith predicateDictionary predicates dictionaries)
+        (withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded))
+    pure (Alt constructor (dictionaries <> fields) body)
 
 patternGivenPredicates :: Syn.Pattern -> [Pred]
 patternGivenPredicates = go
@@ -831,20 +843,46 @@ patternGivenPredicates = go
         ]
     evidencePredicates checked = [predicate | Ev.EvGiven predicate <- tcAnnEvidenceTerms checked]
 
-patternTypeVariables :: Syn.Pattern -> [TyVarId]
-patternTypeVariables = go
+patternConstructorSubstitution :: Syn.Pattern -> ValueM (Map Unique TcType)
+patternConstructorSubstitution pattern' = do
+  constructors <- gets vsDataConstructors
+  case patternConstructorSourceName pattern' >>= resolvedTermKey >>= (`Map.lookup` constructors) of
+    Nothing -> pure Map.empty
+    Just constructor ->
+      case dciExTyVars constructor of
+        [] -> pure Map.empty
+        existentials -> do
+          annotation <- maybe (failValue "existential constructor pattern has no checked annotation") pure (patternConstructorAnnotation pattern')
+          let declaredTypes = constructorBodyType constructor : concatMap predicateTypes (dciTheta constructor)
+              actualTypes = tcAnnType annotation : concatMap predicateTypes (patternGivenPredicates pattern')
+          instantiation <- maybe (failValue "existential constructor pattern types do not match its declaration") pure (matchTypes declaredTypes actualTypes)
+          Map.fromList <$> mapM (existentialSubstitution instantiation) existentials
   where
-    go pattern' =
-      case pattern' of
-        Syn.PAnn annotation inner -> annotationTypeVariables annotation <> go inner
-        Syn.PParen inner -> go inner
-        Syn.PStrict inner -> go inner
-        Syn.PIrrefutable inner -> go inner
-        Syn.PAs _ inner -> go inner
-        Syn.PTypeSig inner _ -> go inner
-        _ -> []
-    annotationTypeVariables annotation =
-      maybe [] tcAnnTypeBinders (Syn.fromAnnotation annotation :: Maybe TcAnnotation)
+    constructorBodyType constructor = foldr TcFunTy (dciResTy constructor) (dataConArgTypes constructor)
+    predicateTypes predicate =
+      case predicate of
+        ClassPred _ arguments -> arguments
+        EqPred left right -> [left, right]
+    existentialSubstitution instantiation existential =
+      case Map.lookup (tvUnique existential) instantiation of
+        Just (TcTyVar skolem) -> pure (tvUnique skolem, TcTyVar existential)
+        Just ty -> failValue ("existential constructor pattern has a non-variable type: " <> show ty)
+        Nothing -> failValue "existential constructor pattern does not instantiate all existential types"
+
+patternConstructorAnnotation :: Syn.Pattern -> Maybe TcAnnotation
+patternConstructorAnnotation pattern' =
+  case pattern' of
+    Syn.PAnn annotation inner ->
+      case Syn.fromAnnotation annotation of
+        Just checked
+          | not (null (tcAnnTypeArgs checked)) -> Just checked
+        _ -> patternConstructorAnnotation inner
+    Syn.PParen inner -> patternConstructorAnnotation inner
+    Syn.PStrict inner -> patternConstructorAnnotation inner
+    Syn.PIrrefutable inner -> patternConstructorAnnotation inner
+    Syn.PAs _ inner -> patternConstructorAnnotation inner
+    Syn.PTypeSig inner _ -> patternConstructorAnnotation inner
+    _ -> Nothing
 
 patternKeys :: [Syn.Match] -> [Text]
 patternKeys matches =
@@ -1152,8 +1190,8 @@ desugarIf resultType condition thenExpression elseExpression = do
         condition'
         binder
         resultType'
-        [ Alt (AltData trueName) [] [] thenExpression',
-          Alt (AltData falseName) [] [] elseExpression'
+        [ Alt (AltData trueName) [] thenExpression',
+          Alt (AltData falseName) [] elseExpression'
         ]
     )
 
@@ -1376,19 +1414,19 @@ desugarDoConstructorPattern resultType binder pattern' success = do
     Nothing -> do
       let children = patternChildren pattern'
           predicates = patternGivenPredicates pattern'
-          typeVariables = patternTypeVariables pattern'
-      typeBinders <- mapM convertTypeBinder typeVariables
-      fieldTypes <- patternFieldTypes pattern' children
-      fields <- zipWithM freshPatternBinder children fieldTypes
-      dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
-      constructor <- patternConstructor pattern'
-      resultType' <- convertCheckedType resultType
-      caseBinder <- freshBinderFromType "_do_scrut" (binderType binder)
-      body <-
-        withDictionaries
-          (zipWith predicateDictionary predicates dictionaries)
-          (desugarDoChildPatterns resultType (zip3 fields fieldTypes children) success)
-      pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt constructor typeBinders (dictionaries <> fields) body])
+      substitution <- patternConstructorSubstitution pattern'
+      withTypeSubstitution substitution $ do
+        fieldTypes <- patternFieldTypes pattern' children
+        fields <- zipWithM freshPatternBinder children fieldTypes
+        dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
+        constructor <- patternConstructor pattern'
+        resultType' <- convertCheckedType resultType
+        caseBinder <- freshBinderFromType "_do_scrut" (binderType binder)
+        body <-
+          withDictionaries
+            (zipWith predicateDictionary predicates dictionaries)
+            (desugarDoChildPatterns resultType (zip3 fields fieldTypes children) success)
+        pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt constructor (dictionaries <> fields) body])
 
 desugarDoChildPatterns :: TcType -> [(Binder, TcType, Syn.Pattern)] -> ValueM Expr -> ValueM Expr
 desugarDoChildPatterns resultType children success =
@@ -1558,7 +1596,7 @@ desugarEvidence evidence =
             sourceExpression
             sourceBinder
             resultType
-            [Alt (AltData (classDictConName classTyCon)) [] fieldBinders (ExVar (binderName selected))]
+            [Alt (AltData (classDictConName classTyCon)) fieldBinders (ExVar (binderName selected))]
         )
     Ev.EvCast inner coercion -> ExCast <$> desugarEvidence inner <*> convertCoercion coercion
     Ev.EvTypeable origin ty arguments -> desugarTypeableEvidence origin ty arguments
@@ -1768,7 +1806,8 @@ freshDictionaryBinder :: Text -> Int -> Pred -> ValueM Binder
 freshDictionaryBinder prefix index predicate = do
   unique <- freshUnique
   env <- gets vsConvertEnv
-  ty <- liftEither (convertPred env predicate)
+  substitution <- gets vsTypeSubstitution
+  ty <- liftEither (convertPred env (substitutePredicate substitution predicate))
   pure (Binder (Name (prefix <> T.pack (show index)) SortValue (OriginLocal unique)) ty)
 
 freshBinder :: Text -> TcType -> ValueM Binder
@@ -1850,7 +1889,8 @@ applicationResultType ty =
 convertCheckedType :: TcType -> ValueM Type
 convertCheckedType ty = do
   env <- gets vsConvertEnv
-  liftEither (convertType env ty)
+  substitution <- gets vsTypeSubstitution
+  liftEither (convertType env (TcInstantiate.applySubst substitution ty))
 
 convertTypeBinder :: TyVarId -> ValueM Binder
 convertTypeBinder tyVar = do
@@ -1879,6 +1919,14 @@ numericRepresentation numericType =
 
 predicateDictionary :: Pred -> Binder -> Dictionary
 predicateDictionary = Dictionary
+
+withTypeSubstitution :: Map Unique TcType -> ValueM a -> ValueM a
+withTypeSubstitution additions action = do
+  previous <- gets vsTypeSubstitution
+  modify' (\state -> state {vsTypeSubstitution = Map.union additions previous})
+  result <- action
+  modify' (\state -> state {vsTypeSubstitution = previous})
+  pure result
 
 withLocals :: [(Text, (Binder, TcType))] -> ValueM a -> ValueM a
 withLocals additions action = do

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -293,7 +293,7 @@ desugarSelector classTyCon classTyVars fieldTypes superClassCount method = do
           (ExVar (binderName classDictionary))
           caseBinder
           resultType'
-          [Alt (AltData (classDictConName classTyCon)) fields selectedExpr]
+          [Alt (AltData (classDictConName classTyCon)) [] fields selectedExpr]
   typeBinders <- mapM convertTypeBinder typeVariables
   methodType' <- convertCheckedType (tcClassMethodType method)
   moduleOrigin <- gets vsModuleOrigin
@@ -601,8 +601,8 @@ desugarOverloadedIntegerMatch resultType arguments match failure =
                 test
                 testBinder
                 resultType'
-                [ Alt (AltData trueName) [] success,
-                  Alt (AltData falseName) [] failure
+                [ Alt (AltData trueName) [] [] success,
+                  Alt (AltData falseName) [] [] failure
                 ]
             )
       | otherwise =
@@ -716,7 +716,7 @@ desugarDataPatterns resultType argument arguments matches = do
         [] -> pure []
         _ -> do
           body <- desugarMatchArguments resultType arguments (map dropFirstPattern defaultMatches)
-          pure [Alt AltDefault [] body]
+          pure [Alt AltDefault [] [] body]
     pure (ExCase (ExVar (binderName argument)) caseBinder resultType' (constructorAlternatives <> defaultAlternatives))
 
 firstNewtypePattern :: [Syn.Match] -> ValueM (Maybe (Syn.Pattern, DataTypeInfo))
@@ -785,6 +785,8 @@ desugarPatternGroup resultType remaining matches key = do
   constructor <- patternConstructor pattern'
   let subpatterns = patternChildren pattern'
       predicates = patternGivenPredicates pattern'
+      typeVariables = patternTypeVariables pattern'
+  typeBinders <- mapM convertTypeBinder typeVariables
   fieldTypes <- patternFieldTypes pattern' subpatterns
   fields <- zipWithM freshPatternBinder subpatterns fieldTypes
   dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
@@ -803,7 +805,7 @@ desugarPatternGroup resultType remaining matches key = do
     withDictionaries
       (zipWith predicateDictionary predicates dictionaries)
       (withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded))
-  pure (Alt constructor (dictionaries <> fields) body)
+  pure (Alt constructor typeBinders (dictionaries <> fields) body)
 
 patternGivenPredicates :: Syn.Pattern -> [Pred]
 patternGivenPredicates = go
@@ -828,6 +830,21 @@ patternGivenPredicates = go
           Just checked <- [Syn.fromAnnotation annotation :: Maybe TcAnnotation]
         ]
     evidencePredicates checked = [predicate | Ev.EvGiven predicate <- tcAnnEvidenceTerms checked]
+
+patternTypeVariables :: Syn.Pattern -> [TyVarId]
+patternTypeVariables = go
+  where
+    go pattern' =
+      case pattern' of
+        Syn.PAnn annotation inner -> annotationTypeVariables annotation <> go inner
+        Syn.PParen inner -> go inner
+        Syn.PStrict inner -> go inner
+        Syn.PIrrefutable inner -> go inner
+        Syn.PAs _ inner -> go inner
+        Syn.PTypeSig inner _ -> go inner
+        _ -> []
+    annotationTypeVariables annotation =
+      maybe [] tcAnnTypeBinders (Syn.fromAnnotation annotation :: Maybe TcAnnotation)
 
 patternKeys :: [Syn.Match] -> [Text]
 patternKeys matches =
@@ -1135,8 +1152,8 @@ desugarIf resultType condition thenExpression elseExpression = do
         condition'
         binder
         resultType'
-        [ Alt (AltData trueName) [] thenExpression',
-          Alt (AltData falseName) [] elseExpression'
+        [ Alt (AltData trueName) [] [] thenExpression',
+          Alt (AltData falseName) [] [] elseExpression'
         ]
     )
 
@@ -1359,6 +1376,8 @@ desugarDoConstructorPattern resultType binder pattern' success = do
     Nothing -> do
       let children = patternChildren pattern'
           predicates = patternGivenPredicates pattern'
+          typeVariables = patternTypeVariables pattern'
+      typeBinders <- mapM convertTypeBinder typeVariables
       fieldTypes <- patternFieldTypes pattern' children
       fields <- zipWithM freshPatternBinder children fieldTypes
       dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
@@ -1369,7 +1388,7 @@ desugarDoConstructorPattern resultType binder pattern' success = do
         withDictionaries
           (zipWith predicateDictionary predicates dictionaries)
           (desugarDoChildPatterns resultType (zip3 fields fieldTypes children) success)
-      pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt constructor (dictionaries <> fields) body])
+      pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt constructor typeBinders (dictionaries <> fields) body])
 
 desugarDoChildPatterns :: TcType -> [(Binder, TcType, Syn.Pattern)] -> ValueM Expr -> ValueM Expr
 desugarDoChildPatterns resultType children success =
@@ -1539,7 +1558,7 @@ desugarEvidence evidence =
             sourceExpression
             sourceBinder
             resultType
-            [Alt (AltData (classDictConName classTyCon)) fieldBinders (ExVar (binderName selected))]
+            [Alt (AltData (classDictConName classTyCon)) [] fieldBinders (ExVar (binderName selected))]
         )
     Ev.EvCast inner coercion -> ExCast <$> desugarEvidence inner <*> convertCoercion coercion
     Ev.EvTypeable origin ty arguments -> desugarTypeableEvidence origin ty arguments

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -75,7 +75,6 @@ data ValueState = ValueState
     vsDictionaries :: !(Map Text Binder),
     vsConstructors :: !(Map Text [Name]),
     vsDataConstructors :: !(Map (PackageId, Text, Text) DataConInfo),
-    vsTypeSubstitution :: !(Map Unique TcType),
     vsNewtypeConstructors :: !(Map (PackageId, Text, Text) DataTypeInfo)
   }
 
@@ -132,7 +131,6 @@ desugarValues convertEnv bindings interface moduleOrigin checked = do
             vsDictionaries = Map.empty,
             vsConstructors = constructors,
             vsDataConstructors = dataConstructors,
-            vsTypeSubstitution = Map.empty,
             vsNewtypeConstructors = newtypes
           }
   fst <$> runStateT (desugarModuleValues checked) initialState
@@ -305,7 +303,7 @@ desugarSelector classTyCon classTyVars fieldTypes superClassCount method = do
           (ExVar (binderName classDictionary))
           caseBinder
           resultType'
-          [Alt (AltData (classDictConName classTyCon)) fields selectedExpr]
+          [Alt (AltData (classDictConName classTyCon) []) fields selectedExpr]
   typeBinders <- mapM convertTypeBinder typeVariables
   methodType' <- convertCheckedType (tcClassMethodType method)
   moduleOrigin <- gets vsModuleOrigin
@@ -613,8 +611,8 @@ desugarOverloadedIntegerMatch resultType arguments match failure =
                 test
                 testBinder
                 resultType'
-                [ Alt (AltData trueName) [] success,
-                  Alt (AltData falseName) [] failure
+                [ Alt (AltData trueName []) [] success,
+                  Alt (AltData falseName []) [] failure
                 ]
             )
       | otherwise =
@@ -797,27 +795,27 @@ desugarPatternGroup resultType remaining matches key = do
   constructor <- patternConstructor pattern'
   let subpatterns = patternChildren pattern'
       predicates = patternGivenPredicates pattern'
-  substitution <- patternConstructorSubstitution pattern'
-  withTypeSubstitution substitution $ do
-    fieldTypes <- patternFieldTypes pattern' subpatterns
-    fields <- zipWithM freshPatternBinder subpatterns fieldTypes
-    dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
-    let arity = length fields
-        expanded = mapMaybe (specializeMatch key arity) matches
-        localBindings =
-          concat
-            [ concat (zipWith3 patternMatchBindings children fields fieldTypes)
-            | match <- matches,
-              candidate : _ <- [Syn.matchPats match],
-              not (patternIsDefault candidate),
-              patternKey candidate == key,
-              let children = patternChildren candidate
-            ]
-    body <-
-      withDictionaries
-        (zipWith predicateDictionary predicates dictionaries)
-        (withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded))
-    pure (Alt constructor (dictionaries <> fields) body)
+  existentialVariables <- patternConstructorExistentials pattern'
+  typeBinders <- mapM convertTypeBinder existentialVariables
+  fieldTypes <- patternFieldTypes pattern' subpatterns
+  fields <- zipWithM freshPatternBinder subpatterns fieldTypes
+  dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
+  let arity = length fields
+      expanded = mapMaybe (specializeMatch key arity) matches
+      localBindings =
+        concat
+          [ concat (zipWith3 patternMatchBindings children fields fieldTypes)
+          | match <- matches,
+            candidate : _ <- [Syn.matchPats match],
+            not (patternIsDefault candidate),
+            patternKey candidate == key,
+            let children = patternChildren candidate
+          ]
+  body <-
+    withDictionaries
+      (zipWith predicateDictionary predicates dictionaries)
+      (withLocals localBindings (desugarMatchArguments resultType (fields <> remaining) expanded))
+  pure (Alt (constructorWithTypeBinders typeBinders constructor) (dictionaries <> fields) body)
 
 patternGivenPredicates :: Syn.Pattern -> [Pred]
 patternGivenPredicates = go
@@ -843,29 +841,29 @@ patternGivenPredicates = go
         ]
     evidencePredicates checked = [predicate | Ev.EvGiven predicate <- tcAnnEvidenceTerms checked]
 
-patternConstructorSubstitution :: Syn.Pattern -> ValueM (Map Unique TcType)
-patternConstructorSubstitution pattern' = do
+patternConstructorExistentials :: Syn.Pattern -> ValueM [TyVarId]
+patternConstructorExistentials pattern' = do
   constructors <- gets vsDataConstructors
   case patternConstructorSourceName pattern' >>= resolvedTermKey >>= (`Map.lookup` constructors) of
-    Nothing -> pure Map.empty
+    Nothing -> pure []
     Just constructor ->
       case dciExTyVars constructor of
-        [] -> pure Map.empty
+        [] -> pure []
         existentials -> do
           annotation <- maybe (failValue "existential constructor pattern has no checked annotation") pure (patternConstructorAnnotation pattern')
           let declaredTypes = constructorBodyType constructor : concatMap predicateTypes (dciTheta constructor)
               actualTypes = tcAnnType annotation : concatMap predicateTypes (patternGivenPredicates pattern')
           instantiation <- maybe (failValue "existential constructor pattern types do not match its declaration") pure (matchTypes declaredTypes actualTypes)
-          Map.fromList <$> mapM (existentialSubstitution instantiation) existentials
+          mapM (existentialVariable instantiation) existentials
   where
     constructorBodyType constructor = foldr TcFunTy (dciResTy constructor) (dataConArgTypes constructor)
     predicateTypes predicate =
       case predicate of
         ClassPred _ arguments -> arguments
         EqPred left right -> [left, right]
-    existentialSubstitution instantiation existential =
+    existentialVariable instantiation existential =
       case Map.lookup (tvUnique existential) instantiation of
-        Just (TcTyVar skolem) -> pure (tvUnique skolem, TcTyVar existential)
+        Just (TcTyVar skolem) -> pure skolem
         Just ty -> failValue ("existential constructor pattern has a non-variable type: " <> show ty)
         Nothing -> failValue "existential constructor pattern does not instantiate all existential types"
 
@@ -991,10 +989,10 @@ patternChildren pattern' =
 patternConstructor :: Syn.Pattern -> ValueM AltCon
 patternConstructor pattern' =
   case peelPattern pattern' of
-    Syn.PCon name _ _ -> AltData <$> resolvedTermName name
-    Syn.PInfix _ name _ -> AltData <$> resolvedTermName name
-    Syn.PList [] -> AltData <$> primitiveName "GHC.Types" "[]" SortDataConstructor
-    Syn.PList (_ : _) -> AltData <$> primitiveName "GHC.Types" ":" SortDataConstructor
+    Syn.PCon name _ _ -> (`AltData` []) <$> resolvedTermName name
+    Syn.PInfix _ name _ -> (`AltData` []) <$> resolvedTermName name
+    Syn.PList [] -> (`AltData` []) <$> primitiveName "GHC.Types" "[]" SortDataConstructor
+    Syn.PList (_ : _) -> (`AltData` []) <$> primitiveName "GHC.Types" ":" SortDataConstructor
     Syn.PTuple flavor fields ->
       let arity = length fields
           constructor =
@@ -1005,13 +1003,19 @@ patternConstructor pattern' =
             case flavor of
               Syn.Boxed -> "GHC.Tuple"
               Syn.Unboxed -> "GHC.Types"
-       in AltData <$> primitiveName moduleName' constructor SortDataConstructor
+       in (`AltData` []) <$> primitiveName moduleName' constructor SortDataConstructor
     Syn.PLit literal
-      | isBoxedCharacterLiteral literal -> AltData <$> uniqueConstructorName "C#"
+      | isBoxedCharacterLiteral literal -> (`AltData` []) <$> uniqueConstructorName "C#"
       | otherwise -> AltLit <$> patternLiteral literal
     Syn.PWildcard -> pure AltDefault
     Syn.PVar {} -> pure AltDefault
     unsupported -> failValue ("unsupported System FC 2 pattern: " <> take 80 (show unsupported))
+
+constructorWithTypeBinders :: [Binder] -> AltCon -> AltCon
+constructorWithTypeBinders binders constructor =
+  case constructor of
+    AltData name _ -> AltData name binders
+    other -> other
 
 patternLiteral :: Syn.Literal -> ValueM Literal
 patternLiteral literal =
@@ -1190,8 +1194,8 @@ desugarIf resultType condition thenExpression elseExpression = do
         condition'
         binder
         resultType'
-        [ Alt (AltData trueName) [] thenExpression',
-          Alt (AltData falseName) [] elseExpression'
+        [ Alt (AltData trueName []) [] thenExpression',
+          Alt (AltData falseName []) [] elseExpression'
         ]
     )
 
@@ -1414,19 +1418,19 @@ desugarDoConstructorPattern resultType binder pattern' success = do
     Nothing -> do
       let children = patternChildren pattern'
           predicates = patternGivenPredicates pattern'
-      substitution <- patternConstructorSubstitution pattern'
-      withTypeSubstitution substitution $ do
-        fieldTypes <- patternFieldTypes pattern' children
-        fields <- zipWithM freshPatternBinder children fieldTypes
-        dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
-        constructor <- patternConstructor pattern'
-        resultType' <- convertCheckedType resultType
-        caseBinder <- freshBinderFromType "_do_scrut" (binderType binder)
-        body <-
-          withDictionaries
-            (zipWith predicateDictionary predicates dictionaries)
-            (desugarDoChildPatterns resultType (zip3 fields fieldTypes children) success)
-        pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt constructor (dictionaries <> fields) body])
+      existentialVariables <- patternConstructorExistentials pattern'
+      typeBinders <- mapM convertTypeBinder existentialVariables
+      fieldTypes <- patternFieldTypes pattern' children
+      fields <- zipWithM freshPatternBinder children fieldTypes
+      dictionaries <- zipWithM (freshDictionaryBinder "$pattern_d") [0 :: Int ..] predicates
+      constructor <- patternConstructor pattern'
+      resultType' <- convertCheckedType resultType
+      caseBinder <- freshBinderFromType "_do_scrut" (binderType binder)
+      body <-
+        withDictionaries
+          (zipWith predicateDictionary predicates dictionaries)
+          (desugarDoChildPatterns resultType (zip3 fields fieldTypes children) success)
+      pure (ExCase (ExVar (binderName binder)) caseBinder resultType' [Alt (constructorWithTypeBinders typeBinders constructor) (dictionaries <> fields) body])
 
 desugarDoChildPatterns :: TcType -> [(Binder, TcType, Syn.Pattern)] -> ValueM Expr -> ValueM Expr
 desugarDoChildPatterns resultType children success =
@@ -1596,7 +1600,7 @@ desugarEvidence evidence =
             sourceExpression
             sourceBinder
             resultType
-            [Alt (AltData (classDictConName classTyCon)) fieldBinders (ExVar (binderName selected))]
+            [Alt (AltData (classDictConName classTyCon) []) fieldBinders (ExVar (binderName selected))]
         )
     Ev.EvCast inner coercion -> ExCast <$> desugarEvidence inner <*> convertCoercion coercion
     Ev.EvTypeable origin ty arguments -> desugarTypeableEvidence origin ty arguments
@@ -1806,8 +1810,7 @@ freshDictionaryBinder :: Text -> Int -> Pred -> ValueM Binder
 freshDictionaryBinder prefix index predicate = do
   unique <- freshUnique
   env <- gets vsConvertEnv
-  substitution <- gets vsTypeSubstitution
-  ty <- liftEither (convertPred env (substitutePredicate substitution predicate))
+  ty <- liftEither (convertPred env predicate)
   pure (Binder (Name (prefix <> T.pack (show index)) SortValue (OriginLocal unique)) ty)
 
 freshBinder :: Text -> TcType -> ValueM Binder
@@ -1889,8 +1892,7 @@ applicationResultType ty =
 convertCheckedType :: TcType -> ValueM Type
 convertCheckedType ty = do
   env <- gets vsConvertEnv
-  substitution <- gets vsTypeSubstitution
-  liftEither (convertType env (TcInstantiate.applySubst substitution ty))
+  liftEither (convertType env ty)
 
 convertTypeBinder :: TyVarId -> ValueM Binder
 convertTypeBinder tyVar = do
@@ -1919,14 +1921,6 @@ numericRepresentation numericType =
 
 predicateDictionary :: Pred -> Binder -> Dictionary
 predicateDictionary = Dictionary
-
-withTypeSubstitution :: Map Unique TcType -> ValueM a -> ValueM a
-withTypeSubstitution additions action = do
-  previous <- gets vsTypeSubstitution
-  modify' (\state -> state {vsTypeSubstitution = Map.union additions previous})
-  result <- action
-  modify' (\state -> state {vsTypeSubstitution = previous})
-  pure result
 
 withLocals :: [(Text, (Binder, TcType))] -> ValueM a -> ValueM a
 withLocals additions action = do

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -471,11 +471,9 @@ lintAlt :: LintEnv -> Type -> Alt -> Either LintError Type
 lintAlt env scrutType alt =
   case altCon alt of
     AltDefault -> do
-      unless (null (altTypeBinders alt)) (Left (LintFailure "default alternative has type binders"))
       unless (null (altBinders alt)) (Left (LintFailure "default alternative has field binders"))
       lintExpr env (altRhs alt)
     AltLit literal -> do
-      unless (null (altTypeBinders alt)) (Left (LintFailure "literal alternative has type binders"))
       unless (null (altBinders alt)) (Left (LintFailure "literal alternative has field binders"))
       matchLiteralAlternative env scrutType literal
       lintExpr env (altRhs alt)
@@ -484,23 +482,10 @@ lintAlt env scrutType alt =
         Nothing -> Left (UnboundName name)
         Just constructorType -> do
           (existentials, fields) <- matchConstructor env constructorType scrutType
-          scopeEnv <- foldM bindLocal env (altTypeBinders alt)
-          mapM_ (lintType scopeEnv . binderType) (altBinders alt)
-          unless (length existentials == length (altTypeBinders alt)) (Left (LintFailure ("case alternative type binder count does not match constructor: " <> show name)))
           unless (length fields == length (altBinders alt)) (Left (LintFailure ("case alternative binder count does not match constructor: " <> show name)))
-          (envEx, existentialSubst) <- foldM (bindExistential name) (env, Map.empty) (zip existentials (altTypeBinders alt))
-          let matchedFields = map (applySubst existentialSubst) fields
-          envFields <- foldM (bindField name) envEx (zip matchedFields (altBinders alt))
+          envEx <- foldM bindLocal env existentials
+          envFields <- foldM (bindField name) envEx (zip fields (altBinders alt))
           lintExpr envFields (altRhs alt)
-
-bindExistential :: Name -> (LintEnv, Map Name Type) -> (Binder, Binder) -> Either LintError (LintEnv, Map Name Type)
-bindExistential constructorName (env, subst) (expected, actual) = do
-  let expectedKind = applySubst subst (binderType expected)
-  env' <- bindLocal env actual
-  unless
-    (typesEqual (leTypes env) expectedKind (binderType actual))
-    (Left (KindMismatch ("case alternative type binder for " <> show constructorName) expectedKind (binderType actual)))
-  pure (env', Map.insert (binderName expected) (TyVar (binderName actual)) subst)
 
 matchLiteralAlternative :: LintEnv -> Type -> Literal -> Either LintError ()
 matchLiteralAlternative env scrutType literal = do
@@ -517,7 +502,7 @@ matchConstructor :: LintEnv -> Type -> Type -> Either LintError ([Binder], [Type
 matchConstructor env constructorType scrutType = do
   let (foralls, fields, result) = splitConType env constructorType
   subst <- matchExpected env (map binderName foralls) Map.empty result scrutType
-  let existentials = [binder | binder <- foralls, binderName binder `Map.notMember` subst]
+  let existentials = [binder {binderType = applySubst subst (binderType binder)} | binder <- foralls, binderName binder `Map.notMember` subst]
       substituted = map (applySubst subst) fields
   Right (existentials, substituted)
 

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -477,14 +477,15 @@ lintAlt env scrutType alt =
       unless (null (altBinders alt)) (Left (LintFailure "literal alternative has field binders"))
       matchLiteralAlternative env scrutType literal
       lintExpr env (altRhs alt)
-    AltData name ->
+    AltData name typeBinders ->
       case lookupHeaderType (leTypes env) name of
         Nothing -> Left (UnboundName name)
         Just constructorType -> do
           (existentials, fields) <- matchConstructor env constructorType scrutType
+          unless (length existentials == length typeBinders) (Left (LintFailure ("case alternative type binder count does not match constructor: " <> show name)))
+          (envEx, substitution) <- foldM (bindExistential name) (env, Map.empty) (zip existentials typeBinders)
           unless (length fields == length (altBinders alt)) (Left (LintFailure ("case alternative binder count does not match constructor: " <> show name)))
-          envEx <- foldM bindLocal env existentials
-          envFields <- foldM (bindField name) envEx (zip fields (altBinders alt))
+          envFields <- foldM (bindField name) envEx (zip (map (applySubst substitution) fields) (altBinders alt))
           lintExpr envFields (altRhs alt)
 
 matchLiteralAlternative :: LintEnv -> Type -> Literal -> Either LintError ()
@@ -497,6 +498,14 @@ bindField constructorName env (expected, binder) = do
   env' <- bindLocal env binder
   unless (typesEqual (leTypes env) expected (binderType binder)) (Left (TypeMismatch ("case alternative binder for " <> show constructorName) expected (binderType binder)))
   Right env'
+
+bindExistential :: Name -> (LintEnv, Map Name Type) -> (Binder, Binder) -> Either LintError (LintEnv, Map Name Type)
+bindExistential constructorName (env, substitution) (expected, actual) = do
+  unless (nameSort (binderName actual) == SortTypeVariable) (Left (LintFailure ("case alternative type binder has an invalid name sort: " <> show constructorName)))
+  env' <- bindLocal env actual
+  let expectedKind = applySubst substitution (binderType expected)
+  unless (typesEqual (leTypes env') expectedKind (binderType actual)) (Left (KindMismatch ("case alternative type binder for " <> show constructorName) expectedKind (binderType actual)))
+  Right (env', Map.insert (binderName expected) (TyVar (binderName actual)) substitution)
 
 matchConstructor :: LintEnv -> Type -> Type -> Either LintError ([Binder], [Type])
 matchConstructor env constructorType scrutType = do

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -471,20 +471,24 @@ lintAlt :: LintEnv -> Type -> Alt -> Either LintError Type
 lintAlt env scrutType alt =
   case altCon alt of
     AltDefault -> do
+      unless (null (altTypeBinders alt)) (Left (LintFailure "default alternative has type binders"))
       unless (null (altBinders alt)) (Left (LintFailure "default alternative has field binders"))
       lintExpr env (altRhs alt)
     AltLit literal -> do
+      unless (null (altTypeBinders alt)) (Left (LintFailure "literal alternative has type binders"))
       unless (null (altBinders alt)) (Left (LintFailure "literal alternative has field binders"))
       matchLiteralAlternative env scrutType literal
       lintExpr env (altRhs alt)
-    AltData name typeBinders ->
+    AltData name ->
       case lookupHeaderType (leTypes env) name of
         Nothing -> Left (UnboundName name)
         Just constructorType -> do
           (existentials, fields) <- matchConstructor env constructorType scrutType
-          unless (length existentials == length typeBinders) (Left (LintFailure ("case alternative type binder count does not match constructor: " <> show name)))
-          (envEx, substitution) <- foldM (bindExistential name) (env, Map.empty) (zip existentials typeBinders)
+          scopeEnv <- foldM bindLocal env (altTypeBinders alt)
+          mapM_ (lintType scopeEnv . binderType) (altBinders alt)
+          unless (length existentials == length (altTypeBinders alt)) (Left (LintFailure ("case alternative type binder count does not match constructor: " <> show name)))
           unless (length fields == length (altBinders alt)) (Left (LintFailure ("case alternative binder count does not match constructor: " <> show name)))
+          (envEx, substitution) <- foldM (bindExistential name) (env, Map.empty) (zip existentials (altTypeBinders alt))
           envFields <- foldM (bindField name) envEx (zip (map (applySubst substitution) fields) (altBinders alt))
           lintExpr envFields (altRhs alt)
 

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -20,7 +20,7 @@ import Control.Monad (foldM, unless, when)
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
-import Data.Maybe (catMaybes, isNothing, listToMaybe)
+import Data.Maybe (catMaybes, listToMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
@@ -471,9 +471,11 @@ lintAlt :: LintEnv -> Type -> Alt -> Either LintError Type
 lintAlt env scrutType alt =
   case altCon alt of
     AltDefault -> do
+      unless (null (altTypeBinders alt)) (Left (LintFailure "default alternative has type binders"))
       unless (null (altBinders alt)) (Left (LintFailure "default alternative has field binders"))
       lintExpr env (altRhs alt)
     AltLit literal -> do
+      unless (null (altTypeBinders alt)) (Left (LintFailure "literal alternative has type binders"))
       unless (null (altBinders alt)) (Left (LintFailure "literal alternative has field binders"))
       matchLiteralAlternative env scrutType literal
       lintExpr env (altRhs alt)
@@ -482,27 +484,23 @@ lintAlt env scrutType alt =
         Nothing -> Left (UnboundName name)
         Just constructorType -> do
           (existentials, fields) <- matchConstructor env constructorType scrutType
+          scopeEnv <- foldM bindLocal env (altTypeBinders alt)
+          mapM_ (lintType scopeEnv . binderType) (altBinders alt)
+          unless (length existentials == length (altTypeBinders alt)) (Left (LintFailure ("case alternative type binder count does not match constructor: " <> show name)))
           unless (length fields == length (altBinders alt)) (Left (LintFailure ("case alternative binder count does not match constructor: " <> show name)))
-          existentialSubst <- matchExistentialFields env existentials fields (map binderType (altBinders alt))
-          envEx <- foldM (bindMatchedExistential existentialSubst) env existentials
+          (envEx, existentialSubst) <- foldM (bindExistential name) (env, Map.empty) (zip existentials (altTypeBinders alt))
           let matchedFields = map (applySubst existentialSubst) fields
           envFields <- foldM (bindField name) envEx (zip matchedFields (altBinders alt))
           lintExpr envFields (altRhs alt)
 
-matchExistentialFields :: LintEnv -> [Binder] -> [Type] -> [Type] -> Either LintError (Map Name Type)
-matchExistentialFields env existentials expected actual =
-  foldM matchOne Map.empty (zip expected actual)
-  where
-    names = map binderName existentials
-    matchOne subst (expectedType, actualType) = matchExpected env names subst expectedType actualType
-
-bindMatchedExistential :: Map Name Type -> LintEnv -> Binder -> Either LintError LintEnv
-bindMatchedExistential subst env binder =
-  case Map.lookup (binderName binder) subst of
-    Just (TyVar actualName)
-      | isNothing (lookupBinderType (leTypes env) actualName) ->
-          bindLocal env (Binder actualName (applySubst subst (binderType binder)))
-    _ -> Right env
+bindExistential :: Name -> (LintEnv, Map Name Type) -> (Binder, Binder) -> Either LintError (LintEnv, Map Name Type)
+bindExistential constructorName (env, subst) (expected, actual) = do
+  let expectedKind = applySubst subst (binderType expected)
+  env' <- bindLocal env actual
+  unless
+    (typesEqual (leTypes env) expectedKind (binderType actual))
+    (Left (KindMismatch ("case alternative type binder for " <> show constructorName) expectedKind (binderType actual)))
+  pure (env', Map.insert (binderName expected) (TyVar (binderName actual)) subst)
 
 matchLiteralAlternative :: LintEnv -> Type -> Literal -> Either LintError ()
 matchLiteralAlternative env scrutType literal = do

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -108,7 +108,7 @@ data OpenExpr
 data OpenBind = OpenBind OpenBinder OpenExpr
   deriving (Eq, Show)
 
-data OpenAlt = OpenAlt AltCon [OpenBinder] [OpenBinder] OpenExpr
+data OpenAlt = OpenAlt AltCon [OpenBinder] OpenExpr
   deriving (Eq, Show)
 
 data OpenCoercion
@@ -414,13 +414,12 @@ caseAlt =
     [ do
         _ <- symbol "_"
         _ <- symbol "→" <|> symbol "->"
-        OpenAlt AltDefault [] [] <$> expression,
+        OpenAlt AltDefault [] <$> expression,
       do
         constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort)
-        typeBinders <- MP.many (symbol "@" *> openTermBinder SortTypeVariable)
         binders <- MP.many (openTermBinder SortValue)
         _ <- symbol "→" <|> symbol "->"
-        OpenAlt constructor typeBinders binders <$> expression
+        OpenAlt constructor binders <$> expression
     ]
 
 castOrApp :: Parser OpenExpr
@@ -733,20 +732,10 @@ fillExpr env expr =
     OCast body coercionValue -> ExCast <$> fillExpr env body <*> fillCoercion env coercionValue
 
 fillAlt :: TypeEnv -> OpenAlt -> Either String Alt
-fillAlt env (OpenAlt con typeBinders binders rhs) = do
-  (closedTypeBinders, typeEnv) <- closeScopedBinders env typeBinders
-  closedBinders <- mapM (closeBinder typeEnv) binders
-  closed <- fillExpr (extendBinders typeEnv closedBinders) rhs
-  pure (Alt con closedTypeBinders closedBinders closed)
-
-closeScopedBinders :: TypeEnv -> [OpenBinder] -> Either String ([Binder], TypeEnv)
-closeScopedBinders env binders =
-  case binders of
-    [] -> Right ([], env)
-    binder : rest -> do
-      closed <- closeBinder env binder
-      (closedRest, finalEnv) <- closeScopedBinders (extend env closed) rest
-      pure (closed : closedRest, finalEnv)
+fillAlt env (OpenAlt con binders rhs) = do
+  closedBinders <- mapM (closeBinder env) binders
+  closed <- fillExpr (extendBinders env closedBinders) rhs
+  pure (Alt con closedBinders closed)
 
 fillCoercion :: TypeEnv -> OpenCoercion -> Either String Coercion
 fillCoercion env coercionValue =
@@ -894,7 +883,6 @@ normalizeAlt :: Map.Map Name Sort -> Alt -> Alt
 normalizeAlt table alternative =
   alternative
     { altCon = normalizeAltCon table (altCon alternative),
-      altTypeBinders = map (normalizeBinder table) (altTypeBinders alternative),
       altBinders = map (normalizeBinder table) (altBinders alternative),
       altRhs = normalizeExpr table (altRhs alternative)
     }

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -108,7 +108,7 @@ data OpenExpr
 data OpenBind = OpenBind OpenBinder OpenExpr
   deriving (Eq, Show)
 
-data OpenAlt = OpenAlt AltCon [OpenBinder] OpenExpr
+data OpenAlt = OpenAlt AltCon [OpenBinder] [OpenBinder] OpenExpr
   deriving (Eq, Show)
 
 data OpenCoercion
@@ -414,12 +414,13 @@ caseAlt =
     [ do
         _ <- symbol "_"
         _ <- symbol "→" <|> symbol "->"
-        OpenAlt AltDefault [] <$> expression,
+        OpenAlt AltDefault [] [] <$> expression,
       do
         constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort)
+        typeBinders <- MP.many (symbol "@" *> openTermBinder SortTypeVariable)
         binders <- MP.many (openTermBinder SortValue)
         _ <- symbol "→" <|> symbol "->"
-        OpenAlt constructor binders <$> expression
+        OpenAlt constructor typeBinders binders <$> expression
     ]
 
 castOrApp :: Parser OpenExpr
@@ -732,10 +733,20 @@ fillExpr env expr =
     OCast body coercionValue -> ExCast <$> fillExpr env body <*> fillCoercion env coercionValue
 
 fillAlt :: TypeEnv -> OpenAlt -> Either String Alt
-fillAlt env (OpenAlt con binders rhs) = do
-  closedBinders <- mapM (closeBinder env) binders
-  closed <- fillExpr (extendBinders env closedBinders) rhs
-  pure (Alt con closedBinders closed)
+fillAlt env (OpenAlt con typeBinders binders rhs) = do
+  (closedTypeBinders, typeEnv) <- closeScopedBinders env typeBinders
+  closedBinders <- mapM (closeBinder typeEnv) binders
+  closed <- fillExpr (extendBinders typeEnv closedBinders) rhs
+  pure (Alt con closedTypeBinders closedBinders closed)
+
+closeScopedBinders :: TypeEnv -> [OpenBinder] -> Either String ([Binder], TypeEnv)
+closeScopedBinders env binders =
+  case binders of
+    [] -> Right ([], env)
+    binder : rest -> do
+      closed <- closeBinder env binder
+      (closedRest, finalEnv) <- closeScopedBinders (extend env closed) rest
+      pure (closed : closedRest, finalEnv)
 
 fillCoercion :: TypeEnv -> OpenCoercion -> Either String Coercion
 fillCoercion env coercionValue =
@@ -883,6 +894,7 @@ normalizeAlt :: Map.Map Name Sort -> Alt -> Alt
 normalizeAlt table alternative =
   alternative
     { altCon = normalizeAltCon table (altCon alternative),
+      altTypeBinders = map (normalizeBinder table) (altTypeBinders alternative),
       altBinders = map (normalizeBinder table) (altBinders alternative),
       altRhs = normalizeExpr table (altRhs alternative)
     }

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -108,7 +108,7 @@ data OpenExpr
 data OpenBind = OpenBind OpenBinder OpenExpr
   deriving (Eq, Show)
 
-data OpenAlt = OpenAlt AltCon [OpenBinder] OpenExpr
+data OpenAlt = OpenAlt AltCon [OpenBinder] [OpenBinder] OpenExpr
   deriving (Eq, Show)
 
 data OpenCoercion
@@ -414,12 +414,13 @@ caseAlt =
     [ do
         _ <- symbol "_"
         _ <- symbol "→" <|> symbol "->"
-        OpenAlt AltDefault [] <$> expression,
+        OpenAlt AltDefault [] [] <$> expression,
       do
-        constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort <*> pure [])
+        constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort)
+        typeBinders <- MP.many (symbol "@" *> openTermBinder SortTypeVariable)
         binders <- MP.many (openTermBinder SortValue)
         _ <- symbol "→" <|> symbol "->"
-        OpenAlt constructor binders <$> expression
+        OpenAlt constructor typeBinders binders <$> expression
     ]
 
 castOrApp :: Parser OpenExpr
@@ -647,18 +648,10 @@ collectHeaders scopes =
     empty = emptyTypeEnv
     add env decl =
       case decl of
-        OpenTypeDecl _ name binders result _ constructors
+        OpenTypeDecl _ name binders result _ _
           | Right closedBinders <- mapM (closeBinder env) binders,
-            let binderEnv = extendBinders env closedBinders,
-            Right closed <- closeType binderEnv result,
-            Right closedConstructors <- mapM (fillCon binderEnv) constructors ->
-              env
-                { teHeaders =
-                    foldl
-                      (\headers constructor -> Map.insert (conName constructor) (conType constructor) headers)
-                      (Map.insert name (headerType closedBinders closed) (teHeaders env))
-                      closedConstructors
-                }
+            Right closed <- closeType (extendBinders env closedBinders) result ->
+              env {teHeaders = Map.insert name (headerType closedBinders closed) (teHeaders env)}
         OpenSynonymDecl _ name binders result body
           | Right closedBinders <- mapM (closeBinder env) binders,
             Right closedResult <- closeType (extendBinders env closedBinders) result,
@@ -740,57 +733,20 @@ fillExpr env expr =
     OCast body coercionValue -> ExCast <$> fillExpr env body <*> fillCoercion env coercionValue
 
 fillAlt :: TypeEnv -> OpenAlt -> Either String Alt
-fillAlt env (OpenAlt con binders rhs) =
-  case con of
-    AltData name _ -> do
-      existentialCount <- constructorExistentialCount env name
-      let (openTypeBinders, openFieldBinders) = splitAt existentialCount binders
-      (typeBinders, fieldEnv) <- closeAltTypeBinders env openTypeBinders
-      fieldBinders <- mapM (closeBinder fieldEnv) openFieldBinders
-      closed <- fillExpr (extendBinders fieldEnv fieldBinders) rhs
-      pure (Alt (AltData name typeBinders) fieldBinders closed)
-    _ -> do
-      closedBinders <- mapM (closeBinder env) binders
-      closed <- fillExpr (extendBinders env closedBinders) rhs
-      pure (Alt con closedBinders closed)
+fillAlt env (OpenAlt con typeBinders binders rhs) = do
+  (closedTypeBinders, typeEnv) <- closeScopedBinders env typeBinders
+  closedBinders <- mapM (closeBinder typeEnv) binders
+  closed <- fillExpr (extendBinders typeEnv closedBinders) rhs
+  pure (Alt con closedTypeBinders closedBinders closed)
 
-closeAltTypeBinders :: TypeEnv -> [OpenBinder] -> Either String ([Binder], TypeEnv)
-closeAltTypeBinders env binders =
+closeScopedBinders :: TypeEnv -> [OpenBinder] -> Either String ([Binder], TypeEnv)
+closeScopedBinders env binders =
   case binders of
     [] -> Right ([], env)
-    OpenBinder name kind : rest -> do
-      binder <- closeBinder env (OpenBinder name {nameSort = SortTypeVariable} kind)
-      (closed, finalEnv) <- closeAltTypeBinders (extend env binder) rest
-      Right (binder : closed, finalEnv)
-
-constructorExistentialCount :: TypeEnv -> Name -> Either String Int
-constructorExistentialCount env name =
-  case lookupHeaderType env name of
-    Nothing -> Right 0
-    Just constructorType ->
-      let (binders, result) = constructorBindersAndResult env constructorType
-       in Right (length [binder | binder <- binders, not (typeContainsName (binderName binder) result)])
-
-constructorBindersAndResult :: TypeEnv -> Type -> ([Binder], Type)
-constructorBindersAndResult env ty =
-  case ty of
-    TyForAll binder body ->
-      let (binders, result) = constructorBindersAndResult env body
-       in (binder : binders, result)
-    TyFun _ _ _ body -> constructorBindersAndResult env body
-    other ->
-      let reduced = reduceType env other
-       in if reduced == other then ([], other) else constructorBindersAndResult env reduced
-
-typeContainsName :: Name -> Type -> Bool
-typeContainsName target ty =
-  case ty of
-    TyVar name -> name == target
-    TyCon {} -> False
-    TyApp function argument -> typeContainsName target function || typeContainsName target argument
-    TyFun r1 r2 argument result -> any (typeContainsName target) [r1, r2, argument, result]
-    TyForAll binder body -> typeContainsName target (binderType binder) || (binderName binder /= target && typeContainsName target body)
-    TyEq left right -> typeContainsName target left || typeContainsName target right
+    binder : rest -> do
+      closed <- closeBinder env binder
+      (closedRest, finalEnv) <- closeScopedBinders (extend env closed) rest
+      pure (closed : closedRest, finalEnv)
 
 fillCoercion :: TypeEnv -> OpenCoercion -> Either String Coercion
 fillCoercion env coercionValue =
@@ -938,6 +894,7 @@ normalizeAlt :: Map.Map Name Sort -> Alt -> Alt
 normalizeAlt table alternative =
   alternative
     { altCon = normalizeAltCon table (altCon alternative),
+      altTypeBinders = map (normalizeBinder table) (altTypeBinders alternative),
       altBinders = map (normalizeBinder table) (altBinders alternative),
       altRhs = normalizeExpr table (altRhs alternative)
     }
@@ -945,7 +902,7 @@ normalizeAlt table alternative =
 normalizeAltCon :: Map.Map Name Sort -> AltCon -> AltCon
 normalizeAltCon table alt =
   case alt of
-    AltData name binders -> AltData (rewriteName table name) (map (normalizeBinder table) binders)
+    AltData name -> AltData (rewriteName table name)
     AltLit literalValue -> AltLit (normalizeLiteral table literalValue)
     AltDefault -> AltDefault
 

--- a/components/aihc-fc/src/Aihc/Fc2/Parser.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Parser.hs
@@ -416,7 +416,7 @@ caseAlt =
         _ <- symbol "→" <|> symbol "->"
         OpenAlt AltDefault [] <$> expression,
       do
-        constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort)
+        constructor <- MP.try (AltLit <$> literal) <|> (AltData <$> topNameWithSort <*> pure [])
         binders <- MP.many (openTermBinder SortValue)
         _ <- symbol "→" <|> symbol "->"
         OpenAlt constructor binders <$> expression
@@ -647,10 +647,18 @@ collectHeaders scopes =
     empty = emptyTypeEnv
     add env decl =
       case decl of
-        OpenTypeDecl _ name binders result _ _
+        OpenTypeDecl _ name binders result _ constructors
           | Right closedBinders <- mapM (closeBinder env) binders,
-            Right closed <- closeType (extendBinders env closedBinders) result ->
-              env {teHeaders = Map.insert name (headerType closedBinders closed) (teHeaders env)}
+            let binderEnv = extendBinders env closedBinders,
+            Right closed <- closeType binderEnv result,
+            Right closedConstructors <- mapM (fillCon binderEnv) constructors ->
+              env
+                { teHeaders =
+                    foldl
+                      (\headers constructor -> Map.insert (conName constructor) (conType constructor) headers)
+                      (Map.insert name (headerType closedBinders closed) (teHeaders env))
+                      closedConstructors
+                }
         OpenSynonymDecl _ name binders result body
           | Right closedBinders <- mapM (closeBinder env) binders,
             Right closedResult <- closeType (extendBinders env closedBinders) result,
@@ -732,10 +740,57 @@ fillExpr env expr =
     OCast body coercionValue -> ExCast <$> fillExpr env body <*> fillCoercion env coercionValue
 
 fillAlt :: TypeEnv -> OpenAlt -> Either String Alt
-fillAlt env (OpenAlt con binders rhs) = do
-  closedBinders <- mapM (closeBinder env) binders
-  closed <- fillExpr (extendBinders env closedBinders) rhs
-  pure (Alt con closedBinders closed)
+fillAlt env (OpenAlt con binders rhs) =
+  case con of
+    AltData name _ -> do
+      existentialCount <- constructorExistentialCount env name
+      let (openTypeBinders, openFieldBinders) = splitAt existentialCount binders
+      (typeBinders, fieldEnv) <- closeAltTypeBinders env openTypeBinders
+      fieldBinders <- mapM (closeBinder fieldEnv) openFieldBinders
+      closed <- fillExpr (extendBinders fieldEnv fieldBinders) rhs
+      pure (Alt (AltData name typeBinders) fieldBinders closed)
+    _ -> do
+      closedBinders <- mapM (closeBinder env) binders
+      closed <- fillExpr (extendBinders env closedBinders) rhs
+      pure (Alt con closedBinders closed)
+
+closeAltTypeBinders :: TypeEnv -> [OpenBinder] -> Either String ([Binder], TypeEnv)
+closeAltTypeBinders env binders =
+  case binders of
+    [] -> Right ([], env)
+    OpenBinder name kind : rest -> do
+      binder <- closeBinder env (OpenBinder name {nameSort = SortTypeVariable} kind)
+      (closed, finalEnv) <- closeAltTypeBinders (extend env binder) rest
+      Right (binder : closed, finalEnv)
+
+constructorExistentialCount :: TypeEnv -> Name -> Either String Int
+constructorExistentialCount env name =
+  case lookupHeaderType env name of
+    Nothing -> Right 0
+    Just constructorType ->
+      let (binders, result) = constructorBindersAndResult env constructorType
+       in Right (length [binder | binder <- binders, not (typeContainsName (binderName binder) result)])
+
+constructorBindersAndResult :: TypeEnv -> Type -> ([Binder], Type)
+constructorBindersAndResult env ty =
+  case ty of
+    TyForAll binder body ->
+      let (binders, result) = constructorBindersAndResult env body
+       in (binder : binders, result)
+    TyFun _ _ _ body -> constructorBindersAndResult env body
+    other ->
+      let reduced = reduceType env other
+       in if reduced == other then ([], other) else constructorBindersAndResult env reduced
+
+typeContainsName :: Name -> Type -> Bool
+typeContainsName target ty =
+  case ty of
+    TyVar name -> name == target
+    TyCon {} -> False
+    TyApp function argument -> typeContainsName target function || typeContainsName target argument
+    TyFun r1 r2 argument result -> any (typeContainsName target) [r1, r2, argument, result]
+    TyForAll binder body -> typeContainsName target (binderType binder) || (binderName binder /= target && typeContainsName target body)
+    TyEq left right -> typeContainsName target left || typeContainsName target right
 
 fillCoercion :: TypeEnv -> OpenCoercion -> Either String Coercion
 fillCoercion env coercionValue =
@@ -890,7 +945,7 @@ normalizeAlt table alternative =
 normalizeAltCon :: Map.Map Name Sort -> AltCon -> AltCon
 normalizeAltCon table alt =
   case alt of
-    AltData name -> AltData (rewriteName table name)
+    AltData name binders -> AltData (rewriteName table name) (map (normalizeBinder table) binders)
     AltLit literalValue -> AltLit (normalizeLiteral table literalValue)
     AltDefault -> AltDefault
 

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -330,16 +330,33 @@ prettyAlt env scopes alternative =
   prettyAltHead env scopes alternative
     <> " →"
     <> hardline
-    <> indent 4 (prettyExprWith env scopes (altRhs alternative))
+    <> indent 4 (prettyExprWith rhsEnv scopes (altRhs alternative))
+  where
+    rhsEnv = foldl extendPrettyEnv env (altTypeBinders alternative <> altBinders alternative)
 
 prettyAltHead :: TypeEnv -> ScopeTable -> Alt -> Doc ann
 prettyAltHead env scopes alternative =
   case altCon alternative of
     AltDefault -> "_"
-    AltLit literal -> prettyLiteral scopes literal <> prettyAltBinders (altBinders alternative)
-    AltData name typeBinders -> prettyName scopes name <> prettyAltBinders (typeBinders <> altBinders alternative)
+    AltLit literal -> prettyLiteral scopes literal <> prettyTypeBinders env (altTypeBinders alternative) <> prettyTermBinders typeEnv (altBinders alternative)
+    AltData name -> prettyName scopes name <> prettyTypeBinders env (altTypeBinders alternative) <> prettyTermBinders typeEnv (altBinders alternative)
   where
-    prettyAltBinders = foldMap ((space <>) . prettyPiBinder env scopes)
+    typeEnv = foldl extendPrettyEnv env (altTypeBinders alternative)
+    prettyTypeBinders current binders =
+      case binders of
+        [] -> mempty
+        binder : rest ->
+          space
+            <> "@"
+            <> prettyPiBinder current scopes binder
+            <> prettyTypeBinders (extendPrettyEnv current binder) rest
+    prettyTermBinders current binders =
+      case binders of
+        [] -> mempty
+        binder : rest ->
+          space
+            <> prettyPiBinder current scopes binder
+            <> prettyTermBinders (extendPrettyEnv current binder) rest
 
 prettyIndentedItems :: Int -> [Doc ann] -> Doc ann
 prettyIndentedItems _ [] = mempty

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -336,10 +336,10 @@ prettyAltHead :: TypeEnv -> ScopeTable -> Alt -> Doc ann
 prettyAltHead env scopes alternative =
   case altCon alternative of
     AltDefault -> "_"
-    AltLit literal -> prettyLiteral scopes literal <> prettyAltBinders
-    AltData name -> prettyName scopes name <> prettyAltBinders
+    AltLit literal -> prettyLiteral scopes literal <> prettyAltBinders (altBinders alternative)
+    AltData name typeBinders -> prettyName scopes name <> prettyAltBinders (typeBinders <> altBinders alternative)
   where
-    prettyAltBinders = foldMap ((space <>) . prettyPiBinder env scopes) (altBinders alternative)
+    prettyAltBinders = foldMap ((space <>) . prettyPiBinder env scopes)
 
 prettyIndentedItems :: Int -> [Doc ann] -> Doc ann
 prettyIndentedItems _ [] = mempty

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -330,16 +330,33 @@ prettyAlt env scopes alternative =
   prettyAltHead env scopes alternative
     <> " →"
     <> hardline
-    <> indent 4 (prettyExprWith env scopes (altRhs alternative))
+    <> indent 4 (prettyExprWith rhsEnv scopes (altRhs alternative))
+  where
+    rhsEnv = foldl extendPrettyEnv env (altTypeBinders alternative <> altBinders alternative)
 
 prettyAltHead :: TypeEnv -> ScopeTable -> Alt -> Doc ann
 prettyAltHead env scopes alternative =
   case altCon alternative of
     AltDefault -> "_"
-    AltLit literal -> prettyLiteral scopes literal <> prettyAltBinders
-    AltData name -> prettyName scopes name <> prettyAltBinders
+    AltLit literal -> prettyLiteral scopes literal <> prettyTypeBinders env (altTypeBinders alternative) <> prettyTermBinders typeEnv (altBinders alternative)
+    AltData name -> prettyName scopes name <> prettyTypeBinders env (altTypeBinders alternative) <> prettyTermBinders typeEnv (altBinders alternative)
   where
-    prettyAltBinders = foldMap ((space <>) . prettyPiBinder env scopes) (altBinders alternative)
+    typeEnv = foldl extendPrettyEnv env (altTypeBinders alternative)
+    prettyTypeBinders current binders =
+      case binders of
+        [] -> mempty
+        binder : rest ->
+          space
+            <> "@"
+            <> prettyPiBinder current scopes binder
+            <> prettyTypeBinders (extendPrettyEnv current binder) rest
+    prettyTermBinders current binders =
+      case binders of
+        [] -> mempty
+        binder : rest ->
+          space
+            <> prettyPiBinder current scopes binder
+            <> prettyTermBinders (extendPrettyEnv current binder) rest
 
 prettyIndentedItems :: Int -> [Doc ann] -> Doc ann
 prettyIndentedItems _ [] = mempty

--- a/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Pretty.hs
@@ -330,33 +330,16 @@ prettyAlt env scopes alternative =
   prettyAltHead env scopes alternative
     <> " →"
     <> hardline
-    <> indent 4 (prettyExprWith rhsEnv scopes (altRhs alternative))
-  where
-    rhsEnv = foldl extendPrettyEnv env (altTypeBinders alternative <> altBinders alternative)
+    <> indent 4 (prettyExprWith env scopes (altRhs alternative))
 
 prettyAltHead :: TypeEnv -> ScopeTable -> Alt -> Doc ann
 prettyAltHead env scopes alternative =
   case altCon alternative of
     AltDefault -> "_"
-    AltLit literal -> prettyLiteral scopes literal <> prettyTypeBinders env (altTypeBinders alternative) <> prettyTermBinders typeEnv (altBinders alternative)
-    AltData name -> prettyName scopes name <> prettyTypeBinders env (altTypeBinders alternative) <> prettyTermBinders typeEnv (altBinders alternative)
+    AltLit literal -> prettyLiteral scopes literal <> prettyAltBinders
+    AltData name -> prettyName scopes name <> prettyAltBinders
   where
-    typeEnv = foldl extendPrettyEnv env (altTypeBinders alternative)
-    prettyTypeBinders current binders =
-      case binders of
-        [] -> mempty
-        binder : rest ->
-          space
-            <> "@"
-            <> prettyPiBinder current scopes binder
-            <> prettyTypeBinders (extendPrettyEnv current binder) rest
-    prettyTermBinders current binders =
-      case binders of
-        [] -> mempty
-        binder : rest ->
-          space
-            <> prettyPiBinder current scopes binder
-            <> prettyTermBinders (extendPrettyEnv current binder) rest
+    prettyAltBinders = foldMap ((space <>) . prettyPiBinder env scopes) (altBinders alternative)
 
 prettyIndentedItems :: Int -> [Doc ann] -> Doc ann
 prettyIndentedItems _ [] = mempty

--- a/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
@@ -66,7 +66,6 @@ data Bind = Bind
 
 data Alt = Alt
   { altCon :: AltCon,
-    altTypeBinders :: [Binder],
     altBinders :: [Binder],
     altRhs :: Expr
   }

--- a/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
@@ -66,13 +66,14 @@ data Bind = Bind
 
 data Alt = Alt
   { altCon :: AltCon,
+    altTypeBinders :: [Binder],
     altBinders :: [Binder],
     altRhs :: Expr
   }
   deriving (Eq, Ord, Show, Read)
 
 data AltCon
-  = AltData Name [Binder]
+  = AltData Name
   | AltLit Literal
   | AltDefault
   deriving (Eq, Ord, Show, Read)

--- a/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
@@ -72,7 +72,7 @@ data Alt = Alt
   deriving (Eq, Ord, Show, Read)
 
 data AltCon
-  = AltData Name
+  = AltData Name [Binder]
   | AltLit Literal
   | AltDefault
   deriving (Eq, Ord, Show, Read)

--- a/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Syntax.hs
@@ -66,6 +66,7 @@ data Bind = Bind
 
 data Alt = Alt
   { altCon :: AltCon,
+    altTypeBinders :: [Binder],
     altBinders :: [Binder],
     altRhs :: Expr
   }

--- a/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
@@ -117,14 +117,34 @@ tidyRecBind env binder bind =
 
 tidyAlt :: TidyEnv -> Alt -> Alt
 tidyAlt env alternative =
-  let (typeBinders, typeEnv) = tidyBinders env (altTypeBinders alternative)
-      (binders, rhsEnv) = tidyBinders typeEnv (altBinders alternative)
+  let implicitEnv = foldl tidyImplicitTypeName env (implicitTypeNames env (altBinders alternative))
+      (binders, rhsEnv) = tidyBinders implicitEnv (altBinders alternative)
    in alternative
         { altCon = tidyAltCon env (altCon alternative),
-          altTypeBinders = typeBinders,
           altBinders = binders,
           altRhs = tidyExpr rhsEnv (altRhs alternative)
         }
+
+implicitTypeNames :: TidyEnv -> [Binder] -> [Name]
+implicitTypeNames env binders =
+  filter (`Map.notMember` tidyNames env) (Set.toAscList (Set.unions (map (freeTypeNames Set.empty . binderType) binders)))
+
+freeTypeNames :: Set Name -> Type -> Set Name
+freeTypeNames bound ty =
+  case ty of
+    TyVar name
+      | name `Set.member` bound -> Set.empty
+      | otherwise -> Set.singleton name
+    TyCon {} -> Set.empty
+    TyApp function argument -> freeTypeNames bound function <> freeTypeNames bound argument
+    TyFun r1 r2 argument result -> Set.unions (map (freeTypeNames bound) [r1, r2, argument, result])
+    TyForAll binder body ->
+      freeTypeNames bound (binderType binder)
+        <> freeTypeNames (Set.insert (binderName binder) bound) body
+    TyEq left right -> freeTypeNames bound left <> freeTypeNames bound right
+
+tidyImplicitTypeName :: TidyEnv -> Name -> TidyEnv
+tidyImplicitTypeName env name = bindName env name (tidyBinderName env name)
 
 tidyAltCon :: TidyEnv -> AltCon -> AltCon
 tidyAltCon env alternative =

--- a/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
@@ -117,9 +117,11 @@ tidyRecBind env binder bind =
 
 tidyAlt :: TidyEnv -> Alt -> Alt
 tidyAlt env alternative =
-  let (binders, rhsEnv) = tidyBinders env (altBinders alternative)
+  let (typeBinders, typeEnv) = tidyBinders env (altTypeBinders alternative)
+      (binders, rhsEnv) = tidyBinders typeEnv (altBinders alternative)
    in alternative
         { altCon = tidyAltCon env (altCon alternative),
+          altTypeBinders = typeBinders,
           altBinders = binders,
           altRhs = tidyExpr rhsEnv (altRhs alternative)
         }

--- a/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
@@ -117,41 +117,22 @@ tidyRecBind env binder bind =
 
 tidyAlt :: TidyEnv -> Alt -> Alt
 tidyAlt env alternative =
-  let implicitEnv = foldl tidyImplicitTypeName env (implicitTypeNames env (altBinders alternative))
-      (binders, rhsEnv) = tidyBinders implicitEnv (altBinders alternative)
+  let (constructor, fieldEnv) = tidyAltCon env (altCon alternative)
+      (binders, rhsEnv) = tidyBinders fieldEnv (altBinders alternative)
    in alternative
-        { altCon = tidyAltCon env (altCon alternative),
+        { altCon = constructor,
           altBinders = binders,
           altRhs = tidyExpr rhsEnv (altRhs alternative)
         }
 
-implicitTypeNames :: TidyEnv -> [Binder] -> [Name]
-implicitTypeNames env binders =
-  filter (`Map.notMember` tidyNames env) (Set.toAscList (Set.unions (map (freeTypeNames Set.empty . binderType) binders)))
-
-freeTypeNames :: Set Name -> Type -> Set Name
-freeTypeNames bound ty =
-  case ty of
-    TyVar name
-      | name `Set.member` bound -> Set.empty
-      | otherwise -> Set.singleton name
-    TyCon {} -> Set.empty
-    TyApp function argument -> freeTypeNames bound function <> freeTypeNames bound argument
-    TyFun r1 r2 argument result -> Set.unions (map (freeTypeNames bound) [r1, r2, argument, result])
-    TyForAll binder body ->
-      freeTypeNames bound (binderType binder)
-        <> freeTypeNames (Set.insert (binderName binder) bound) body
-    TyEq left right -> freeTypeNames bound left <> freeTypeNames bound right
-
-tidyImplicitTypeName :: TidyEnv -> Name -> TidyEnv
-tidyImplicitTypeName env name = bindName env name (tidyBinderName env name)
-
-tidyAltCon :: TidyEnv -> AltCon -> AltCon
+tidyAltCon :: TidyEnv -> AltCon -> (AltCon, TidyEnv)
 tidyAltCon env alternative =
   case alternative of
-    AltData name -> AltData (tidyUse env name)
-    AltLit literal -> AltLit (tidyLiteral env literal)
-    AltDefault -> AltDefault
+    AltData name binders ->
+      let (binders', bodyEnv) = tidyBinders env binders
+       in (AltData (tidyUse env name) binders', bodyEnv)
+    AltLit literal -> (AltLit (tidyLiteral env literal), env)
+    AltDefault -> (AltDefault, env)
 
 tidyLiteral :: TidyEnv -> Literal -> Literal
 tidyLiteral env literal =

--- a/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Tidy.hs
@@ -117,22 +117,21 @@ tidyRecBind env binder bind =
 
 tidyAlt :: TidyEnv -> Alt -> Alt
 tidyAlt env alternative =
-  let (constructor, fieldEnv) = tidyAltCon env (altCon alternative)
-      (binders, rhsEnv) = tidyBinders fieldEnv (altBinders alternative)
+  let (typeBinders, typeEnv) = tidyBinders env (altTypeBinders alternative)
+      (binders, rhsEnv) = tidyBinders typeEnv (altBinders alternative)
    in alternative
-        { altCon = constructor,
+        { altCon = tidyAltCon env (altCon alternative),
+          altTypeBinders = typeBinders,
           altBinders = binders,
           altRhs = tidyExpr rhsEnv (altRhs alternative)
         }
 
-tidyAltCon :: TidyEnv -> AltCon -> (AltCon, TidyEnv)
+tidyAltCon :: TidyEnv -> AltCon -> AltCon
 tidyAltCon env alternative =
   case alternative of
-    AltData name binders ->
-      let (binders', bodyEnv) = tidyBinders env binders
-       in (AltData (tidyUse env name) binders', bodyEnv)
-    AltLit literal -> (AltLit (tidyLiteral env literal), env)
-    AltDefault -> (AltDefault, env)
+    AltData name -> AltData (tidyUse env name)
+    AltLit literal -> AltLit (tidyLiteral env literal)
+    AltDefault -> AltDefault
 
 tidyLiteral :: TidyEnv -> Literal -> Literal
 tidyLiteral env literal =

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/unbound-existential-pattern.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/unbound-existential-pattern.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+pub type 1.tBox :: 2.tType {
+    pub 1.vBox :: ∀(a : 2.tType). a → 1.tBox
+}
+
+val 1.vkeep :: 1.tBox → 1.tBox
+ = λ(x : 1.tBox).
+  case x as (w : 1.tBox) return (1.tBox) of {
+    1.vBox (value : a{1}) →
+      x
+  }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/existential-pattern.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/existential-pattern.fc2
@@ -8,6 +8,6 @@ pub type 1.tBox :: 2.tType {
 val 1.vkeep :: 1.tBox → 1.tBox
  = λ(x : 1.tBox).
   case x as (w : 1.tBox) return (1.tBox) of {
-    1.vBox (a : 2.tType) (value : a) →
+    1.vBox @(a : 2.tType) (value : a) →
       x
   }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/existential-pattern.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/existential-pattern.fc2
@@ -1,0 +1,13 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+pub type 1.tBox :: 2.tType {
+    pub 1.vBox :: ∀(a : 2.tType). a → 1.tBox
+}
+
+val 1.vkeep :: 1.tBox → 1.tBox
+ = λ(x : 1.tBox).
+  case x as (w : 1.tBox) return (1.tBox) of {
+    1.vBox (value : a) →
+      x
+  }

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/existential-pattern.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/existential-pattern.fc2
@@ -8,6 +8,6 @@ pub type 1.tBox :: 2.tType {
 val 1.vkeep :: 1.tBox → 1.tBox
  = λ(x : 1.tBox).
   case x as (w : 1.tBox) return (1.tBox) of {
-    1.vBox (value : a) →
+    1.vBox (a : 2.tType) (value : a) →
       x
   }

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
@@ -38,7 +38,7 @@ expected: |-
   pub val 1.vinspect :: 1.tBox → 1.tMark
    = λ(x : 1.tBox).
     case x as (_scrut : 1.tBox) return (1.tMark) of {
-        1.vBox (a : 2.tType) ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
+        1.vBox @(a : 2.tType) ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
             1.vmark @a $pattern_d0 value
     }
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
@@ -38,8 +38,8 @@ expected: |-
   pub val 1.vinspect :: 1.tBox → 1.tMark
    = λ(x : 1.tBox).
     case x as (_scrut : 1.tBox) return (1.tMark) of {
-        1.vBox ($pattern_d0 : 1.t$Dict$Markable a{4}) (value : a{4}) →
-            1.vmark @a{4} $pattern_d0 value
+        1.vBox @(a : 2.tType) ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
+            1.vmark @a $pattern_d0 value
     }
 status: pass
 reason: ''

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
@@ -38,7 +38,7 @@ expected: |-
   pub val 1.vinspect :: 1.tBox → 1.tMark
    = λ(x : 1.tBox).
     case x as (_scrut : 1.tBox) return (1.tMark) of {
-        1.vBox ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
+        1.vBox (a : 2.tType) ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
             1.vmark @a $pattern_d0 value
     }
 status: pass

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/constrained-existential-constructor.yaml
@@ -38,7 +38,7 @@ expected: |-
   pub val 1.vinspect :: 1.tBox → 1.tMark
    = λ(x : 1.tBox).
     case x as (_scrut : 1.tBox) return (1.tMark) of {
-        1.vBox @(a : 2.tType) ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
+        1.vBox ($pattern_d0 : 1.t$Dict$Markable a) (value : a) →
             1.vmark @a $pattern_d0 value
     }
 status: pass

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -29,7 +29,7 @@ import Aihc.Parser.Syntax
     peelPatternAnn,
   )
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
-import Aihc.Tc.Annotations (PendingTcAnnotation (..), pendingAnnotation)
+import Aihc.Tc.Annotations (PendingTcAnnotation, pendingAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (TyConInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
@@ -407,12 +407,7 @@ checkConPattern gadtHandling sp originalPat conSyntax subPats scrutTy = do
             | null predicateGivens && null skolems = rebuiltPattern
             | otherwise =
                 PAnn
-                  ( mkAnnotation
-                      ( (pendingAnnotation conTy typeArgs (map ctEvVar predicateGivens) [])
-                          { pendingTcAnnTypeBinders = skolems
-                          }
-                      )
-                  )
+                  (mkAnnotation (pendingAnnotation conTy typeArgs (map ctEvVar predicateGivens) []))
                   rebuiltPattern
       pure
         subCheck

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -29,7 +29,7 @@ import Aihc.Parser.Syntax
     peelPatternAnn,
   )
 import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
-import Aihc.Tc.Annotations (PendingTcAnnotation, pendingAnnotation)
+import Aihc.Tc.Annotations (PendingTcAnnotation (..), pendingAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (TyConInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
@@ -407,7 +407,12 @@ checkConPattern gadtHandling sp originalPat conSyntax subPats scrutTy = do
             | null predicateGivens && null skolems = rebuiltPattern
             | otherwise =
                 PAnn
-                  (mkAnnotation (pendingAnnotation conTy typeArgs (map ctEvVar predicateGivens) []))
+                  ( mkAnnotation
+                      ( (pendingAnnotation conTy typeArgs (map ctEvVar predicateGivens) [])
+                          { pendingTcAnnTypeBinders = skolems
+                          }
+                      )
+                  )
                   rebuiltPattern
       pure
         subCheck


### PR DESCRIPTION
## Summary

- Store explicit type binders in each System FC 2 alternative.
- Print constructor patterns as `Constructor @(a : Type) (value : a)`.
- Parse the explicit binders without inspection of the constructor declaration.
- Reject missing binders and all free type variables.

## Tests

- `just fmt`
- `just check`
- `cabal test -v0 aihc-fc:spec --test-options="--hide-successes"`

## Progress counts

- FC 2 lint rejection fixtures increase from 12 to 13.
- FC 2 lint acceptance fixtures increase from 10 to 11.
- FC 2 golden fixtures stay at 70.
- FC 2 tests increase from 109 to 111.
