### PR TITLE
fix(resolve): require import for Constraint

### DIFF
--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -516,7 +516,7 @@ emptyScope = Scope Map.empty Map.empty Map.empty Map.empty Map.empty Map.empty M
 --
 -- The term namespace is empty.
 -- Promoted constructors from @aihc-prim@ use ordinary name resolution.
--- The type namespace contains only the function arrow and @Constraint@.
+-- The type namespace contains only the function arrow.
 -- Types from @aihc-prim@ use ordinary name resolution.
 --
 -- This scope is merged into every module's scope unconditionally (lowest
@@ -546,9 +546,7 @@ builtinPromotedConstructorNames = []
 -- (not @"(->)"@).
 builtinTypeNames :: [T.Text]
 builtinTypeNames =
-  [ "->",
-    "Constraint"
-  ]
+  ["->"]
 
 unionScope :: Scope -> Scope -> Scope
 unionScope left right =

--- a/components/aihc-resolve/test/Test/Fixtures/golden/constraint-requires-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/constraint-requires-import.yaml
@@ -1,0 +1,13 @@
+---
+extensions: []
+modules:
+- |
+  module Main where
+  type Predicate = Constraint
+annotated:
+- |
+  module Main where
+  type Predicate = Constraint
+       └─ t Main   └─ t Error unbound
+status: pass
+reason: Constraint requires an ordinary import from GHC.Types


### PR DESCRIPTION
## Summary

- Remove `Constraint` from the built-in resolver type names.
- Add a resolver fixture that requires an ordinary `GHC.Types` import.

## Progress

- Increase resolver golden `PASS` cases from 51 to 52.
- Increase total resolver golden cases from 52 to 53.
- Keep resolver golden `XFAIL` cases at 1.
- Increase resolver golden completion from 98.07% to 98.11%.

## Tests

- `cabal test -v0 aihc-resolve:spec --test-options="--pattern resolver-golden --hide-successes"`
- `just check`