### PR TITLE
feat(resolve): preserve namespaces in type identities

### DIFF
--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -57,7 +57,7 @@ import Aihc.Tc
     tcModuleSuccess,
     typecheckModuleSccWithInterface,
   )
-import Aihc.Tc.Types (tyConModuleName, tyConPackageId)
+import Aihc.Tc.Types (tyConModuleName, tyConNamespace, tyConPackageId)
 import Control.Exception (IOException, try)
 import Control.Monad (foldM, unless, when)
 import Data.Bits (xor)
@@ -414,7 +414,7 @@ writeCoreV2Files verbose currentPackage primIdentity interface storeRoot coreV2P
 
 moduleTypeInterface :: ModuleExports -> Package -> TcInterface -> SourceModule -> TcInterface
 moduleTypeInterface exports package interface source =
-  addTermSupportTyCons
+  addReferencedTyCons
     interface
     interface
       { tcInterfaceTerms = filter visibleTerm (tcInterfaceTerms interface),
@@ -435,10 +435,16 @@ moduleTypeInterface exports package interface source =
     visibleTyCon info =
       let tyCon = tciTyCon info
           identity = (tyConPackageId tyCon, tyConModuleName tyCon, tciName info)
-       in Map.member (tciName info) (scopeTypes scope) || identity `Set.member` typeIdentities || identity == localIdentity (tciName info)
-    visibleTypeIdentity (packageId', moduleName', identifier) =
+          (namespaceScope, namespaceIdentities) =
+            case tyConNamespace tyCon of
+              ResolutionNamespaceTerm -> (scopeTerms scope, termIdentities)
+              ResolutionNamespaceType -> (scopeTypes scope, typeIdentities)
+              ResolutionNamespaceModule -> (Map.empty, Set.empty)
+       in Map.member (tciName info) namespaceScope || identity `Set.member` namespaceIdentities || identity == localIdentity (tciName info)
+    visibleTypeIdentity (packageId', moduleName', namespace, identifier) =
       let identity = (packageId', moduleName', identifier)
-       in Map.member identifier (scopeTypes scope) || identity `Set.member` typeIdentities || identity == localIdentity identifier
+       in namespace == ResolutionNamespaceType
+            && (Map.member identifier (scopeTypes scope) || identity `Set.member` typeIdentities || identity == localIdentity identifier)
     visibleClass info =
       case ciOrigin info of
         Just (packageIdText, moduleName') ->
@@ -449,20 +455,30 @@ moduleTypeInterface exports package interface source =
       ResolvedTopLevel packageId' resolvedName -> Just (packageId', fromMaybe name (nameQualifier resolvedName), nameText resolvedName)
       _ -> Nothing
 
-addTermSupportTyCons :: TcInterface -> TcInterface -> TcInterface
-addTermSupportTyCons complete interface =
+addReferencedTyCons :: TcInterface -> TcInterface -> TcInterface
+addReferencedTyCons complete interface =
   interface {tcInterfaceTyCons = Map.elems (existing <> support)}
   where
     existing = Map.fromList [(tciTyCon info, info) | info <- tcInterfaceTyCons interface]
     available = Map.fromList [(tciTyCon info, info) | info <- tcInterfaceTyCons complete]
-    referenced = concatMap (typeSchemeTyCons . snd) (tcInterfaceTerms interface)
-    support =
-      Map.fromList
-        [ (tyCon, info)
-        | tyCon <- referenced,
-          tyCon `Map.notMember` existing,
-          Just info <- [Map.lookup tyCon available]
-        ]
+    referenced =
+      Set.fromList
+        ( concatMap (typeSchemeTyCons . snd) (tcInterfaceTerms interface)
+            <> concatMap (typeSchemeTyCons . tciKindScheme) (tcInterfaceTyCons interface)
+        )
+    reachable = closeTyCons Set.empty referenced
+    support = Map.restrictKeys available (reachable `Set.difference` Map.keysSet existing)
+    closeTyCons found pending
+      | Set.null pending = found
+      | otherwise =
+          let (tyCon, pending') = Set.deleteFindMin pending
+              dependencies =
+                maybe
+                  Set.empty
+                  (Set.fromList . typeSchemeTyCons . tciKindScheme)
+                  (Map.lookup tyCon available)
+              found' = Set.insert tyCon found
+           in closeTyCons found' (pending' <> (dependencies `Set.difference` found'))
 
 typeSchemeTyCons :: TypeScheme -> [TyCon]
 typeSchemeTyCons (ForAll _ predicates body) = concatMap predTyCons predicates <> typeTyCons body

--- a/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
+++ b/bin/aihc/src/Aihc/Cli/TypeArtifact.hs
@@ -6,7 +6,7 @@ module Aihc.Cli.TypeArtifact
   )
 where
 
-import Aihc.Resolve (PackageId (..))
+import Aihc.Resolve (PackageId (..), ResolutionNamespace (..))
 import Aihc.Tc
   ( ClassInfo (..),
     DataConFieldInfo (..),
@@ -32,7 +32,7 @@ import Aihc.Tc
     tyConName,
   )
 import Aihc.Tc.Env (TypeSynonymInfo (..))
-import Aihc.Tc.Types (mkTyConWithOrigin, setTyVarKind, tyConModuleName, tyConPackageId)
+import Aihc.Tc.Types (mkTyConWithNamespace, setTyVarKind, tyConModuleName, tyConNamespace, tyConPackageId)
 import Control.Monad (replicateM, unless)
 import Data.Binary.Get qualified as Get
 import Data.Bits (shiftR)
@@ -55,7 +55,7 @@ encodeTypeArtifact artifact =
   Builder.toLazyByteString $
     cborArray 5
       <> cborText "aihc-type"
-      <> cborWord 5
+      <> cborWord 6
       <> cborText (typeArtifactModuleName artifact)
       <> encodeList encodeHash (typeArtifactInputHashes artifact)
       <> putInterface (typeArtifactInterface artifact)
@@ -77,7 +77,7 @@ getArtifact :: Get.Get TypeArtifact
 getArtifact = do
   expectArray 5
   expectText "aihc-type"
-  expectWord 5
+  expectWord 6
   typeArtifactModuleName <- getText
   typeArtifactInputHashes <- getList getHash
   typeArtifactInterface <- getInterface
@@ -157,16 +157,37 @@ getUnique = Unique <$> getInt
 
 putTyCon :: TyCon -> Builder.Builder
 putTyCon tyCon =
-  cborArray 4
+  cborArray 5
     <> putPackageId (tyConPackageId tyCon)
     <> cborText (tyConModuleName tyCon)
+    <> putResolutionNamespace (tyConNamespace tyCon)
     <> cborText (tyConName tyCon)
     <> cborInt (tyConArity tyCon)
 
 getTyCon :: Get.Get TyCon
 getTyCon = do
-  expectArray 4
-  mkTyConWithOrigin <$> getPackageId <*> getText <*> getText <*> getInt
+  expectArray 5
+  packageId <- getPackageId
+  moduleName <- getText
+  namespace <- getResolutionNamespace
+  mkTyConWithNamespace namespace packageId moduleName <$> getText <*> getInt
+
+putResolutionNamespace :: ResolutionNamespace -> Builder.Builder
+putResolutionNamespace namespace =
+  cborWord $
+    case namespace of
+      ResolutionNamespaceTerm -> 0
+      ResolutionNamespaceType -> 1
+      ResolutionNamespaceModule -> 2
+
+getResolutionNamespace :: Get.Get ResolutionNamespace
+getResolutionNamespace = do
+  tag <- getWord
+  case tag of
+    0 -> pure ResolutionNamespaceTerm
+    1 -> pure ResolutionNamespaceType
+    2 -> pure ResolutionNamespaceModule
+    _ -> fail "unsupported resolution namespace"
 
 putPackageId :: PackageId -> Builder.Builder
 putPackageId (PackageId identity) = cborText identity

--- a/components/aihc-fc/src/Aihc/Fc2/Convert.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Convert.hs
@@ -30,7 +30,7 @@ where
 import Aihc.Fc2.Name
 import Aihc.Fc2.Syntax
 import Aihc.Fc2.Wired
-import Aihc.Resolve (PackageId)
+import Aihc.Resolve (PackageId, ResolutionNamespace (..))
 import Aihc.Tc.Types
   ( Pred (..),
     TcKindEnv,
@@ -47,6 +47,7 @@ import Aihc.Tc.Types
     tyConKey,
     tyConModuleName,
     tyConName,
+    tyConNamespace,
     tyConPackageId,
     pattern AddrRep,
     pattern BoxedRep,
@@ -170,7 +171,7 @@ convertRep env runtimeRep =
     TupleRep fields -> convertTuple fields
     SumRep fields -> do
       converted <- mapM (convertRep env) fields
-      Right (TyApp (repCon env "SumRep") (promotedRuntimeRepList env converted))
+      Right (TyApp (repCon env "SumRep") (runtimeRepList env converted))
     VecRep count element ->
       Right
         ( TyApp
@@ -187,10 +188,10 @@ convertRep env runtimeRep =
   where
     convertTuple fields = do
       converted <- mapM (convertRep env) fields
-      Right (TyApp (repCon env "TupleRep") (promotedRuntimeRepList env converted))
+      Right (TyApp (repCon env "TupleRep") (runtimeRepList env converted))
 
-promotedRuntimeRepList :: ConvertEnv -> [Type] -> Type
-promotedRuntimeRepList env =
+runtimeRepList :: ConvertEnv -> [Type] -> Type
+runtimeRepList env =
   foldr cons nil
   where
     runtimeRep = TyCon (runtimeRepConstructor (cePrimPackage env))
@@ -274,25 +275,15 @@ tyConNameFc2 :: ConvertEnv -> TyCon -> Name
 tyConNameFc2 env tyCon =
   if Set.member (tyConKey tyCon) (ceClassTyCons env)
     then classDictTypeName tyCon
-    else case promotedNameFc2 tyCon of
-      Just name -> name
-      Nothing -> Name (tyConName tyCon) SortTypeConstructor (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
-
--- | Convert the type-checker promotion marker to an FC data-constructor name.
-promotedNameFc2 :: TyCon -> Maybe Name
-promotedNameFc2 tyCon =
-  if T.isPrefixOf "'" (tyConName tyCon)
-    then wiredBuiltinName tyCon
-    else Nothing
-
-wiredBuiltinName :: TyCon -> Maybe Name
-wiredBuiltinName tyCon =
-  case Map.lookup name builtinTable of
-    Just (sort, _) ->
-      Just (Name name sort (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon)))
-    Nothing -> Nothing
+    else
+      Name
+        (tyConName tyCon)
+        (namespaceSort (tyConNamespace tyCon))
+        (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
   where
-    name = T.dropWhile (== '\'') (tyConName tyCon)
+    namespaceSort ResolutionNamespaceTerm = SortDataConstructor
+    namespaceSort ResolutionNamespaceType = SortTypeConstructor
+    namespaceSort ResolutionNamespaceModule = SortTypeConstructor
 
 -- | Invisible kind parameters that the type constructor quantifies before visible arguments.
 extraKindVars :: ConvertEnv -> TyCon -> [TyVarId] -> Either String [TyVarId]
@@ -367,54 +358,3 @@ kindScheme env tyCon =
   case Map.lookup (tyConKey tyCon) (ceKindEnv env) of
     Just scheme -> Right scheme
     Nothing -> Left ("missing kind scheme for type constructor: " <> T.unpack (tyConName tyCon))
-
-builtinTable :: Map Text (Sort, Text)
-builtinTable =
-  Map.fromList
-    [ ("Type", (SortSynonym, "GHC.Types")),
-      ("TYPE", (SortTypeConstructor, "GHC.Types")),
-      ("Constraint", (SortTypeConstructor, "GHC.Types")),
-      ("RuntimeRep", (SortTypeConstructor, "GHC.Types")),
-      ("Levity", (SortTypeConstructor, "GHC.Types")),
-      ("VecCount", (SortTypeConstructor, "GHC.Types")),
-      ("VecElem", (SortTypeConstructor, "GHC.Types")),
-      ("LiftedRep", (SortSynonym, "GHC.Types")),
-      ("UnliftedRep", (SortSynonym, "GHC.Types")),
-      ("IntRep", (SortDataConstructor, "GHC.Types")),
-      ("Int8Rep", (SortDataConstructor, "GHC.Types")),
-      ("Int16Rep", (SortDataConstructor, "GHC.Types")),
-      ("Int32Rep", (SortDataConstructor, "GHC.Types")),
-      ("Int64Rep", (SortDataConstructor, "GHC.Types")),
-      ("WordRep", (SortDataConstructor, "GHC.Types")),
-      ("Word8Rep", (SortDataConstructor, "GHC.Types")),
-      ("Word16Rep", (SortDataConstructor, "GHC.Types")),
-      ("Word32Rep", (SortDataConstructor, "GHC.Types")),
-      ("Word64Rep", (SortDataConstructor, "GHC.Types")),
-      ("AddrRep", (SortDataConstructor, "GHC.Types")),
-      ("FloatRep", (SortDataConstructor, "GHC.Types")),
-      ("DoubleRep", (SortDataConstructor, "GHC.Types")),
-      ("BoxedRep", (SortDataConstructor, "GHC.Types")),
-      ("Lifted", (SortDataConstructor, "GHC.Types")),
-      ("Unlifted", (SortDataConstructor, "GHC.Types")),
-      ("TupleRep", (SortDataConstructor, "GHC.Types")),
-      ("SumRep", (SortDataConstructor, "GHC.Types")),
-      ("VecRep", (SortDataConstructor, "GHC.Types")),
-      ("[]", (SortDataConstructor, "GHC.Types")),
-      (":", (SortDataConstructor, "GHC.Types")),
-      ("Vec2", (SortDataConstructor, "GHC.Types")),
-      ("Vec4", (SortDataConstructor, "GHC.Types")),
-      ("Vec8", (SortDataConstructor, "GHC.Types")),
-      ("Vec16", (SortDataConstructor, "GHC.Types")),
-      ("Vec32", (SortDataConstructor, "GHC.Types")),
-      ("Vec64", (SortDataConstructor, "GHC.Types")),
-      ("Int8ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Int16ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Int32ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Int64ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Word8ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Word16ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Word32ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("Word64ElemRep", (SortDataConstructor, "GHC.Types")),
-      ("FloatElemRep", (SortDataConstructor, "GHC.Types")),
-      ("DoubleElemRep", (SortDataConstructor, "GHC.Types"))
-    ]

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -104,8 +104,8 @@ typeOf env ty =
     TyVar name ->
       Map.lookup name (teBinders env)
     TyCon name ->
-      case promotedListType env name of
-        Just promotedKind -> Just promotedKind
+      case listDataConstructorType env name of
+        Just constructorType -> Just constructorType
         Nothing -> lookupHeaderType env name
     TyApp function argument ->
       do
@@ -118,8 +118,8 @@ typeOf env ty =
     TyEq {} ->
       TyCon . constraintName <$> tePrimPackage env
 
-promotedListType :: TypeEnv -> Name -> Maybe Type
-promotedListType env name = do
+listDataConstructorType :: TypeEnv -> Name -> Maybe Type
+listDataConstructorType env name = do
   package <- tePrimPackage env
   let kindName = Name "k" SortTypeVariable (OriginLocal (Unique (-1000)))
       kindVariable = TyVar kindName

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/promoted-infix-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/promoted-infix-constructor.yaml
@@ -1,0 +1,25 @@
+extensions:
+  - DataKinds
+  - TypeOperators
+modules:
+  - |
+    module Test where
+    data Atom = A
+    data Pair = Atom :*: Atom
+    type AtomPair = 'A ':*: 'A
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  pub type 1.tAtom :: 2.tType {
+      pub 1.vA :: 1.tAtom
+  }
+
+  pub type 1.tPair :: 2.tType {
+      pub 1.v:*: :: 1.tAtom 2.→ 1.tAtom 2.→ 1.tPair
+  }
+
+  pub type 1.tAtomPair :: 1.tPair =
+   1.v:*: 1.vA 1.vA
+status: pass
+reason: promoted infix constructors use the resolved term namespace

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/promoted-tuple-namespace.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/promoted-tuple-namespace.yaml
@@ -1,0 +1,18 @@
+extensions:
+  - DataKinds
+modules:
+  - |
+    module Test where
+    data Atom
+    type AtomPair = '(Atom, Atom)
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Tuple
+  scope 3 = "aihc-prim" GHC.Types
+
+  pub type 1.tAtom :: 3.tType {}
+
+  pub type 1.tAtomPair :: 2.tTuple2 (3.tTYPE (3.vBoxedRep 3.vLifted)) (3.tTYPE (3.vBoxedRep 3.vLifted)) =
+   2.v(,) (3.tTYPE (3.vBoxedRep 3.vLifted)) (3.tTYPE (3.vBoxedRep 3.vLifted)) 1.tAtom 1.tAtom
+status: pass
+reason: promoted tuple syntax uses the resolved term namespace

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/user-promoted-constructor.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/user-promoted-constructor.yaml
@@ -1,0 +1,23 @@
+extensions:
+  - DataKinds
+modules:
+  - |
+    module Test where
+    data Same = Same
+    type TypeName = Same
+    type TermName = 'Same
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  pub type 1.tSame :: 2.tType {
+      pub 1.vSame :: 1.tSame
+  }
+
+  pub type 1.tTypeName :: 2.tType =
+   1.tSame
+
+  pub type 1.tTermName :: 1.tSame =
+   1.vSame
+status: pass
+reason: FC conversion keeps same-text type and term namespace identities separate

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -28,6 +28,7 @@ module Aihc.Resolve
     ResolutionForm (..),
     ResolvedName (..),
     ResolutionAnnotation (..),
+    TypeSyntaxResolution (..),
   )
 where
 
@@ -1381,15 +1382,38 @@ resolveType ty =
     TTypeApp left right ->
       TTypeApp <$> resolveType left <*> resolveType right
     TInfix left name promoted right ->
-      TInfix <$> resolveType left <*> pure name <*> pure promoted <*> resolveType right
+      TInfix <$> resolveType left <*> resolveTypeConstructorUse promoted name <*> pure promoted <*> resolveType right
     TFun arrowKind left right ->
       TFun <$> resolveArrowKind arrowKind <*> resolveType left <*> resolveType right
-    TTuple flavor promoted items ->
-      TTuple flavor promoted <$> mapM resolveType items
+    TTuple flavor promotion items -> do
+      items' <- mapM resolveType items
+      info <- currentModuleInfo
+      let constructorName = tupleConName flavor (length items)
+          renderedName = renderUnqualifiedName constructorName
+          tupleScope =
+            case flavor of
+              Boxed -> moduleInfoGhcTupleScope info
+              Unboxed -> moduleInfoGhcTypesScope info
+          (namespace, resolved) = resolveSyntaxName promotion renderedName tupleScope
+          syntaxResolution = TypeSyntaxResolution renderedName namespace resolved
+          tupleType = TTuple flavor promotion items'
+      pure $
+        case promotion of
+          Promoted -> TAnn (mkAnnotation syntaxResolution) tupleType
+          Unpromoted -> tupleType
     TUnboxedSum items ->
       TUnboxedSum <$> mapM resolveType items
-    TList promoted items ->
-      TList promoted <$> mapM resolveType items
+    TList promotion items -> do
+      items' <- mapM resolveType items
+      info <- currentModuleInfo
+      let renderedName = "[]"
+          (namespace, resolved) = resolveSyntaxName promotion renderedName (moduleInfoGhcTypesScope info)
+          syntaxResolution = TypeSyntaxResolution renderedName namespace resolved
+          listType = TList promotion items'
+      pure $
+        case promotion of
+          Promoted -> TAnn (mkAnnotation syntaxResolution) listType
+          Unpromoted -> listType
     TParen inner ->
       TParen <$> resolveType inner
     TKindSig inner kind ->
@@ -1648,7 +1672,20 @@ resolveTypeConstructorUse promotion name =
     Promoted -> do
       sp <- currentSpan
       scope <- currentScope
-      pure (resolveNameTo sp ResolutionNamespaceType (resolveTermName scope name) name)
+      pure (resolveNameTo sp ResolutionNamespaceTerm (resolveTermName scope name) name)
+
+resolveSyntaxName :: TypePromotion -> Text -> Scope -> (ResolutionNamespace, ResolvedName)
+resolveSyntaxName promotion renderedName scope =
+  case promotion of
+    Unpromoted ->
+      (ResolutionNamespaceType, fallbackBuiltin (lookupType renderedName scope))
+    Promoted ->
+      (ResolutionNamespaceTerm, fallbackBuiltin (lookupTerm renderedName scope))
+  where
+    fallbackBuiltin resolved =
+      case resolved of
+        ResolvedError {} -> ResolvedBuiltin renderedName
+        _ -> resolved
 
 resolveTypeUseAtName :: Name -> ResolveM Name
 resolveTypeUseAtName name = do

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -16,6 +16,7 @@ module Aihc.Resolve.Types
     modulesInPackage,
     ResolvedName (..),
     ResolutionAnnotation (..),
+    TypeSyntaxResolution (..),
     ResolveError (..),
     ResolveResult (..),
     resolvedModuleAsts,
@@ -72,7 +73,7 @@ data ResolutionNamespace
   = ResolutionNamespaceTerm
   | ResolutionNamespaceType
   | ResolutionNamespaceModule
-  deriving (Eq, Show)
+  deriving (Eq, Ord, Show, Read)
 
 -- | The syntax form that caused one resolution request.
 data ResolutionForm
@@ -86,6 +87,14 @@ data ResolutionAnnotation = ResolutionAnnotation
     resolutionNamespace :: !ResolutionNamespace,
     resolutionTarget :: !ResolvedName,
     resolutionForm :: !ResolutionForm
+  }
+  deriving (Eq, Show)
+
+-- | A resolved namespace and target for type syntax that has no identifier node.
+data TypeSyntaxResolution = TypeSyntaxResolution
+  { typeSyntaxResolutionName :: !Text,
+    typeSyntaxResolutionNamespace :: !ResolutionNamespace,
+    typeSyntaxResolutionTarget :: !ResolvedName
   }
   deriving (Eq, Show)
 

--- a/components/aihc-resolve/test/Test/Fixtures/golden/promoted-constructor-type.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/promoted-constructor-type.yaml
@@ -12,6 +12,6 @@ annotated:
          │        └─ v Main
          └─ t Main
     type LiftedRep = 'Lifted
-         └─ t Main    └─ t Main
+         └─ t Main    └─ v Main
 status: pass
 reason: promoted data constructors resolve in type expressions

--- a/components/aihc-resolve/test/Test/Fixtures/golden/promoted-prim-constructor-requires-import.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/promoted-prim-constructor-requires-import.yaml
@@ -8,7 +8,7 @@ annotated:
 - |-
   module Main where
   type Rep = 'IntRep
-       │      └─ t Error unbound
+       │      └─ v Error unbound
        └─ t Main
 status: pass
 reason: aihc-prim promoted constructors require ordinary name resolution

--- a/components/aihc-resolve/test/Test/Fixtures/golden/promotion-selects-namespace.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/promotion-selects-namespace.yaml
@@ -1,0 +1,20 @@
+extensions:
+  - DataKinds
+modules:
+  - |
+    module Main where
+    data Same = Same
+    type TypeName = Same
+    type TermName = 'Same
+annotated:
+  - |
+    module Main where
+    data Same = Same
+         │      └─ v Main
+         └─ t Main
+    type TypeName = Same
+         └─ t Main  └─ t Main
+    type TermName = 'Same
+         └─ t Main   └─ v Main
+status: pass
+reason: promotion selects the term namespace when type and term names have the same text

--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -54,9 +54,10 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
+import Aihc.Resolve (ResolutionNamespace (..))
 import Aihc.Tc.Env (DataTypeInfo)
 import Aihc.Tc.Evidence (EvTerm, EvVar)
-import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType, tyConModuleName, pattern KType)
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType, tyConModuleName, tyConNamespace, pattern KType)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -301,8 +302,9 @@ renderTcTypeInModule currentModule = go 0
     go _ KType = "Type"
     go _ (TcTyCon (TyCon name 1) [arg])
       | name == T.pack "[]" = "[" ++ go 0 arg ++ "]"
-    go _ (TcTyCon (TyCon name arity) args)
-      | isBoxedTupleCon name arity,
+    go _ (TcTyCon tc@(TyCon name arity) args)
+      | tyConNamespace tc == ResolutionNamespaceType,
+        isBoxedTupleCon name arity,
         arity == length args =
           "(" ++ commaSep (map (go 0) args) ++ ")"
     go _ tupleType@(TcTyCon _ args)
@@ -338,13 +340,18 @@ renderTcTypeInModule currentModule = go 0
     isBoxedTupleCon name arity =
       arity /= 1 && name == boxedTupleTyConName arity
 
-    renderTyConName tyCon
-      | definingModule `elem` map T.pack ["GHC.Prim", "GHC.Tuple", "GHC.Types"] = tyConName tyCon
-      | Nothing <- currentModule = tyConName tyCon
-      | Just definingModule == currentModule = tyConName tyCon
-      | otherwise = definingModule <> T.pack "." <> tyConName tyCon
+    renderTyConName tyCon =
+      namespacePrefix <> qualifiedName
       where
         definingModule = tyConModuleName tyCon
+        namespacePrefix
+          | tyConNamespace tyCon == ResolutionNamespaceTerm = T.pack "'"
+          | otherwise = T.empty
+        qualifiedName
+          | definingModule `elem` map T.pack ["GHC.Prim", "GHC.Tuple", "GHC.Types"] = tyConName tyCon
+          | Nothing <- currentModule = tyConName tyCon
+          | Just definingModule == currentModule = tyConName tyCon
+          | otherwise = definingModule <> T.pack "." <> tyConName tyCon
 
 -- | Collect nested forall binders into a list.
 collectForAlls :: TcType -> ([TyVarId], TcType)

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Decl.hs
@@ -77,7 +77,7 @@ import Aihc.Parser.Syntax
     peelTypeHead,
     unqualifiedNameAnns,
   )
-import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolvedName (..))
+import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
 import Aihc.Tc.Annotations
   ( TcAnnotation (..),
     TcClassAnnotation (..),
@@ -477,7 +477,7 @@ tcModuleScc modules = do
   let declarations = concatMap moduleDecls modules
       standaloneKindSignatures = collectStandaloneKindSignatures declarations
   mapM_ predeclareTypeConstructor declarations
-  mapM_ predeclarePromotedConstructors declarations
+  mapM_ predeclareTypeLevelDataConstructors declarations
   standaloneKindSchemes <- traverse standaloneKindSigToScheme standaloneKindSignatures
   mapM_ (registerTypeDeclHeader standaloneKindSchemes) declarations
   mapM_ registerTypeSynonymBody declarations
@@ -1932,9 +1932,9 @@ collectStandaloneKindSignatures = Map.fromList . mapMaybe collect
 
 resolvedTypeKey :: UnqualifiedName -> Maybe TcTypeKey
 resolvedTypeKey name = do
-  ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} <- nameResolution name
+  ResolutionAnnotation {resolutionNamespace = namespace, resolutionTarget = ResolvedTopLevel packageId resolvedName} <- nameResolution name
   moduleName' <- nameQualifier resolvedName
-  pure (packageId, moduleName', nameText resolvedName)
+  pure (packageId, moduleName', namespace, nameText resolvedName)
 
 registerTypeDeclHeader :: Map TcTypeKey TypeScheme -> Decl -> TcM [TcBindingResult]
 registerTypeDeclHeader kindSchemes (DeclData dataDecl) =
@@ -2009,10 +2009,10 @@ registerStructuralDecl origin (DeclInstance instanceDecl) = registerInstanceDecl
 registerStructuralDecl origin (DeclAnn _ inner) = registerStructuralDecl origin inner
 registerStructuralDecl _ _ = pure []
 
-predeclarePromotedConstructors :: Decl -> TcM ()
-predeclarePromotedConstructors declaration =
+predeclareTypeLevelDataConstructors :: Decl -> TcM ()
+predeclareTypeLevelDataConstructors declaration =
   case declaration of
-    DeclAnn _ inner -> predeclarePromotedConstructors inner
+    DeclAnn _ inner -> predeclareTypeLevelDataConstructors inner
     DeclData dataDeclaration -> do
       let parentBinder = binderHeadName (dataDeclHead dataDeclaration)
           parentName = unqualifiedNameText parentBinder
@@ -2032,21 +2032,26 @@ predeclarePromotedConstructors declaration =
           arity = length fields
       mapM_ (predeclareName parent arity) names
     predeclareName parent arity name = do
-      let promotedName = "'" <> name
-          isPromotedListConstructor =
+      let isListConstructor =
             tyConModuleName parent == "GHC.Types"
               && tyConName parent == "[]"
-              && promotedName `elem` ["'[]", "':"]
+              && name `elem` ["[]", ":"]
       kindScheme <-
-        if isPromotedListConstructor
-          then promotedListConstructorKind promotedName
+        if isListConstructor
+          then listDataConstructorKind name
           else ForAll [] [] <$> freshKindMeta
-      let promotedTyCon = mkTyConWithOrigin (tyConPackageId parent) (tyConModuleName parent) promotedName arity
+      let dataConTyCon =
+            mkTyConWithNamespace
+              ResolutionNamespaceTerm
+              (tyConPackageId parent)
+              (tyConModuleName parent)
+              name
+              arity
       storeTyConInfo
         TyConInfo
-          { tciName = promotedName,
+          { tciName = name,
             tciArity = arity,
-            tciTyCon = promotedTyCon,
+            tciTyCon = dataConTyCon,
             tciKindScheme = kindScheme,
             tciFlavor = DataTyCon,
             tciTypeSynonym = Nothing
@@ -2533,7 +2538,7 @@ registerDataConstructors dataDecl = do
       (kindParams, paramInfos) <- dataDeclParamInfos (quantifiedKindScheme info) dataDecl
       bindings <- mapM (registerDataCon (tciTyCon info) kindParams paramInfos) (dataDeclConstructors dataDecl)
       constructors <- concat <$> mapM (checkedDataConInfos (tciTyCon info)) (dataDeclConstructors dataDecl)
-      mapM_ registerPromotedDataCon constructors
+      mapM_ registerTypeLevelDataCon constructors
       selectorBindings <- registerRecordSelectors constructors
       let tyVars = map paramTyVar paramInfos
       resultKind <- tcTypeKind (TcTyCon (tciTyCon info) (map TcTyVar tyVars))
@@ -2585,7 +2590,7 @@ registerNewtypeConstructor newtypeDecl = do
       (kindParams, paramInfos) <- typeDeclParamInfos (quantifiedKindScheme info) (binderHeadParams (newtypeDeclHead newtypeDecl))
       constructor <- mapM (registerDataCon (tciTyCon info) kindParams paramInfos) (newtypeDeclConstructor newtypeDecl)
       constructors <- maybe (pure []) (checkedDataConInfos (tciTyCon info)) (newtypeDeclConstructor newtypeDecl)
-      mapM_ registerPromotedDataCon constructors
+      mapM_ registerTypeLevelDataCon constructors
       selectorBindings <- registerRecordSelectors constructors
       let tyVars = map paramTyVar paramInfos
       resultKind <- tcTypeKind (TcTyCon (tciTyCon info) (map TcTyVar tyVars))
@@ -2600,16 +2605,16 @@ registerNewtypeConstructor newtypeDecl = do
           }
       pure (maybeToList constructor <> selectorBindings)
 
-registerPromotedDataCon :: DataConInfo -> TcM ()
-registerPromotedDataCon constructor = do
-  let promotedName = "'" <> dciName constructor
+registerTypeLevelDataCon :: DataConInfo -> TcM ()
+registerTypeLevelDataCon constructor = do
+  let name = dciName constructor
       fieldTypes = dataConArgTypes constructor
       arity = length fieldTypes
       (packageId, moduleName') = dciOrigin constructor
-      promotedTyCon = mkTyConWithOrigin packageId moduleName' promotedName arity
+      dataConTyCon = mkTyConWithNamespace ResolutionNamespaceTerm packageId moduleName' name arity
   kindScheme <-
-    if moduleName' == "GHC.Types" && promotedName `elem` ["'[]", "':"]
-      then promotedListConstructorKind promotedName
+    if moduleName' == "GHC.Types" && name `elem` ["[]", ":"]
+      then listDataConstructorKind name
       else
         pure
           ( ForAll
@@ -2619,26 +2624,26 @@ registerPromotedDataCon constructor = do
           )
   let info =
         TyConInfo
-          { tciName = promotedName,
+          { tciName = name,
             tciArity = arity,
-            tciTyCon = promotedTyCon,
+            tciTyCon = dataConTyCon,
             tciKindScheme = kindScheme,
             tciFlavor = DataTyCon,
             tciTypeSynonym = Nothing
           }
-  if moduleName' == "GHC.Types" && promotedName `elem` ["'[]", "':"]
+  if moduleName' == "GHC.Types" && name `elem` ["[]", ":"]
     then replaceTyConEnvPermanent info
     else storeTyConInfo info
 
-promotedListConstructorKind :: Text -> TcM TypeScheme
-promotedListConstructorKind promotedName = do
+listDataConstructorKind :: Text -> TcM TypeScheme
+listDataConstructorKind name = do
   rawElementKind <- freshSkolemTv "k"
   let elementKindVar = setTyVarKind KType rawElementKind
       elementKind = TcTyVar elementKindVar
   resultKind <- listTypeForKind elementKind
   let body =
-        case promotedName of
-          "'[]" -> resultKind
+        case name of
+          "[]" -> resultKind
           _ -> TcFunTy elementKind (TcFunTy resultKind resultKind)
   pure (ForAll [elementKindVar] [] body)
 

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -31,9 +31,9 @@ import Aihc.Parser.Syntax
     TyVarBinder (..),
     Type (..),
     TypeBuiltinCon (..),
-    TypePromotion (..),
     UnqualifiedName (..),
     forallTelescopeBinders,
+    fromAnnotation,
     instanceHeadName,
     instanceHeadTypes,
     nameText,
@@ -42,6 +42,7 @@ import Aihc.Parser.Syntax
     tyVarBinderName,
     unqualifiedNameText,
   )
+import Aihc.Resolve (ResolutionNamespace (..), TypeSyntaxResolution (..))
 import Aihc.Tc.Env (TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Instantiate (instantiate)
@@ -129,21 +130,28 @@ checkRuntimeType tvEnv ty = do
     _ -> emitError NoSourceSpan (KindMismatch KType actual') >> pure tcTy
 
 convertSurfaceTypeWithKinds :: TvKindEnv -> Type -> TcM (TcType, TcType)
-convertSurfaceTypeWithKinds tvEnv ty = do
-  expanded <- expandTypeSynonym tvEnv (peelTypeHead ty)
-  case expanded of
-    Just result -> pure result
-    Nothing -> convertNonSynonymTypeWithKinds tvEnv (peelTypeHead ty)
+convertSurfaceTypeWithKinds tvEnv ty =
+  case ty of
+    TAnn ann _
+      | Just _ <- (fromAnnotation ann :: Maybe TypeSyntaxResolution) ->
+          convertNonSynonymTypeWithKinds tvEnv ty
+    _ -> do
+      expanded <- expandTypeSynonym tvEnv (peelTypeHead ty)
+      case expanded of
+        Just result -> pure result
+        Nothing -> convertNonSynonymTypeWithKinds tvEnv (peelTypeHead ty)
 
 convertNonSynonymTypeWithKinds :: TvKindEnv -> Type -> TcM (TcType, TcType)
 convertNonSynonymTypeWithKinds tvEnv ty =
   case ty of
-    TAnn _ inner ->
-      convertSurfaceTypeWithKinds tvEnv inner
+    TAnn ann inner ->
+      case fromAnnotation ann of
+        Just resolution -> convertResolvedSyntaxType tvEnv resolution inner
+        Nothing -> convertSurfaceTypeWithKinds tvEnv inner
     TVar name ->
       inferTypeVariable tvEnv name
-    TCon name promoted ->
-      inferTypeConstructor promoted name
+    TCon name _ ->
+      inferTypeConstructor name
     TBuiltinCon builtin ->
       inferBuiltinTypeConstructor builtin
     TStar {} ->
@@ -162,34 +170,15 @@ convertNonSynonymTypeWithKinds tvEnv ty =
       unifyKinds fKind (KFun aKind resultKind)
       resultKind' <- zonkKind resultKind
       pure (applyType fTy aTy, resultKind')
-    TInfix lhs name promoted rhs ->
-      convertSurfaceTypeWithKinds tvEnv (TApp (TApp (TCon name promoted) lhs) rhs)
+    TInfix lhs name _ rhs -> do
+      constructor <- inferTypeConstructor name
+      applySurfaceTypeArguments tvEnv constructor [lhs, rhs]
     TFun _ a b -> do
       aTy <- checkRuntimeType tvEnv a
       bTy <- checkRuntimeType tvEnv b
       pure (TcFunTy aTy bTy, KType)
-    TTuple flavor _ args -> do
-      tys <-
-        case flavor of
-          Boxed -> mapM (\arg -> checkSurfaceType tvEnv arg KType) args
-          Unboxed -> mapM (checkRuntimeType tvEnv) args
-      argumentKinds <- mapM tcTypeKind tys
-      let argumentReps = map runtimeRepOrLifted argumentKinds
-      let arity = length tys
-          fallbackResultKind =
-            case flavor of
-              Boxed -> KType
-              Unboxed -> KTYPE (TupleRep argumentReps)
-          fallbackKind = foldr KFun fallbackResultKind argumentKinds
-          typeName = tupleTyConText flavor arity
-      maybeTyCon <- lookupTyCon typeName
-      tyCon <-
-        case maybeTyCon of
-          Just info -> pure (tciTyCon info)
-          Nothing -> mkKnownTyCon (tupleTyConModule flavor) typeName arity fallbackKind
-      let tupleType = TcTyCon tyCon tys
-      tupleKind <- tcTypeKind tupleType
-      pure (tupleType, tupleKind)
+    TTuple flavor _ args ->
+      convertTupleType tvEnv flavor args
     TUnboxedSum args -> do
       tys <- mapM (checkRuntimeType tvEnv) args
       argumentKinds <- mapM tcTypeKind tys
@@ -199,22 +188,8 @@ convertNonSynonymTypeWithKinds tvEnv ty =
           name = "(#" <> bars (arity - 1) <> "#)"
       tyCon <- mkKnownTyCon "GHC.Types" name arity tyConKind'
       pure (TcTyCon tyCon tys, resultKind)
-    TList Unpromoted [arg] -> do
-      argTy <- checkSurfaceType tvEnv arg KType
-      listTy <- listType argTy
-      pure (listTy, KType)
-    TList Promoted args -> do
-      elemKind <- freshKindMeta
-      args' <- mapM (\arg -> checkSurfaceType tvEnv arg elemKind) args
-      promotedListKind <- listType elemKind
-      maybeNilInfo <- lookupTyCon "'[]"
-      nilTyCon <- maybe (mkKnownTyCon "GHC.Types" "'[]" 0 promotedListKind) (pure . tciTyCon) maybeNilInfo
-      maybeConsInfo <- lookupTyCon "':"
-      let consKind = TcFunTy elemKind (TcFunTy promotedListKind promotedListKind)
-      consTyCon <- maybe (mkKnownTyCon "GHC.Types" "':" 2 consKind) (pure . tciTyCon) maybeConsInfo
-      let nil = TcTyCon nilTyCon []
-          cons field rest = TcTyCon consTyCon [field, rest]
-      pure (foldr cons nil args', promotedListKind)
+    TList _ [arg] ->
+      convertListType tvEnv arg
     TKindSig inner kindTy -> do
       expected <- kindFromSurfaceType tvEnv kindTy
       checkSurfaceType tvEnv inner expected >>= \innerTy -> pure (innerTy, expected)
@@ -231,10 +206,84 @@ convertNonSynonymTypeWithKinds tvEnv ty =
       meta <- freshMetaTv
       pure (meta, KType)
 
+convertResolvedSyntaxType :: TvKindEnv -> TypeSyntaxResolution -> Type -> TcM (TcType, TcType)
+convertResolvedSyntaxType tvEnv resolution syntax =
+  case (typeSyntaxResolutionNamespace resolution, syntax) of
+    (ResolutionNamespaceType, TList _ [argument]) ->
+      convertListType tvEnv argument
+    (ResolutionNamespaceTerm, TList _ arguments) ->
+      convertDataConstructorList tvEnv arguments
+    (ResolutionNamespaceType, TTuple flavor _ arguments) ->
+      convertTupleType tvEnv flavor arguments
+    (ResolutionNamespaceTerm, TTuple _ _ arguments) ->
+      convertResolvedConstructorApplication tvEnv resolution arguments
+    _ -> convertSurfaceTypeWithKinds tvEnv syntax
+
+convertListType :: TvKindEnv -> Type -> TcM (TcType, TcType)
+convertListType tvEnv argument = do
+  argumentType <- checkSurfaceType tvEnv argument KType
+  result <- listType argumentType
+  pure (result, KType)
+
+convertDataConstructorList :: TvKindEnv -> [Type] -> TcM (TcType, TcType)
+convertDataConstructorList tvEnv arguments = do
+  elementKind <- freshKindMeta
+  argumentTypes <- mapM (\argument -> checkSurfaceType tvEnv argument elementKind) arguments
+  resultKind <- listType elementKind
+  let consKind = TcFunTy elementKind (TcFunTy resultKind resultKind)
+  nilTyCon <- mkKnownDataCon "GHC.Types" "[]" 0 resultKind
+  consTyCon <- mkKnownDataCon "GHC.Types" ":" 2 consKind
+  let nil = TcTyCon nilTyCon []
+      cons field rest = TcTyCon consTyCon [field, rest]
+  pure (foldr cons nil argumentTypes, resultKind)
+
+convertTupleType :: TvKindEnv -> TupleFlavor -> [Type] -> TcM (TcType, TcType)
+convertTupleType tvEnv flavor arguments = do
+  argumentTypes <-
+    case flavor of
+      Boxed -> mapM (\argument -> checkSurfaceType tvEnv argument KType) arguments
+      Unboxed -> mapM (checkRuntimeType tvEnv) arguments
+  argumentKinds <- mapM tcTypeKind argumentTypes
+  let argumentReps = map runtimeRepOrLifted argumentKinds
+      arity = length argumentTypes
+      fallbackResultKind =
+        case flavor of
+          Boxed -> KType
+          Unboxed -> KTYPE (TupleRep argumentReps)
+      fallbackKind = foldr KFun fallbackResultKind argumentKinds
+      typeName = tupleTyConText flavor arity
+  maybeTyCon <- lookupTyCon typeName
+  tyCon <-
+    case maybeTyCon of
+      Just info -> pure (tciTyCon info)
+      Nothing -> mkKnownTyCon (tupleTyConModule flavor) typeName arity fallbackKind
+  let tupleType = TcTyCon tyCon argumentTypes
+  tupleKind <- tcTypeKind tupleType
+  pure (tupleType, tupleKind)
+
+convertResolvedConstructorApplication :: TvKindEnv -> TypeSyntaxResolution -> [Type] -> TcM (TcType, TcType)
+convertResolvedConstructorApplication tvEnv resolution arguments = do
+  maybeInfo <- lookupResolvedTypeSyntax resolution
+  case maybeInfo of
+    Nothing -> inferUnknownType
+    Just info -> do
+      constructorKind <- instantiateTyConKind info
+      applySurfaceTypeArguments tvEnv (TcTyCon (tciTyCon info) [], constructorKind) arguments
+
+applySurfaceTypeArguments :: TvKindEnv -> (TcType, TcType) -> [Type] -> TcM (TcType, TcType)
+applySurfaceTypeArguments tvEnv = foldM applyArgument
+  where
+    applyArgument (functionType, functionKind) argument = do
+      (argumentType, argumentKind) <- convertSurfaceTypeWithKinds tvEnv argument
+      resultKind <- freshKindMeta
+      unifyKinds functionKind (KFun argumentKind resultKind)
+      resultKind' <- zonkKind resultKind
+      pure (applyType functionType argumentType, resultKind')
+
 expandTypeSynonym :: TvKindEnv -> Type -> TcM (Maybe (TcType, TcType))
 expandTypeSynonym tvEnv ty =
   case typeApplicationSpine ty of
-    (TCon name Unpromoted, arguments) -> do
+    (TCon name _, arguments) -> do
       maybeInfo <- lookupResolvedTyCon name
       case maybeInfo >>= tciTypeSynonym of
         Just synonym
@@ -324,27 +373,18 @@ inferTypeVariable tvEnv name =
         Just (tv, kind) -> pure (TcTyVar tv, kind)
         Nothing -> inferUnknownType
 
-inferTypeConstructor :: TypePromotion -> Name -> TcM (TcType, TcType)
-inferTypeConstructor promoted name =
-  case promoted of
-    Promoted -> do
-      maybeInfo <- lookupResolvedPromotedTyCon name
-      case maybeInfo of
+inferTypeConstructor :: Name -> TcM (TcType, TcType)
+inferTypeConstructor name =
+  case nameText name of
+    "Type" -> knownType "GHC.Types" "Type" KType
+    "Constraint" -> knownType "GHC.Types" "Constraint" KType
+    _ -> do
+      mInfo <- lookupResolvedTyCon name
+      case mInfo of
         Just info -> do
           kind <- instantiateTyConKind info
           pure (TcTyCon (tciTyCon info) [], kind)
-        Nothing -> inferPromotedTypeConstructor (nameText name)
-    Unpromoted ->
-      case nameText name of
-        "Type" -> knownType "GHC.Types" "Type" KType
-        "Constraint" -> knownType "GHC.Types" "Constraint" KType
-        _ -> do
-          mInfo <- lookupResolvedTyCon name
-          case mInfo of
-            Just info -> do
-              kind <- instantiateTyConKind info
-              pure (TcTyCon (tciTyCon info) [], kind)
-            Nothing -> inferUnknownType
+        Nothing -> inferUnknownType
 
 instantiateTyConKind :: TyConInfo -> TcM TcType
 instantiateTyConKind info = do
@@ -361,7 +401,7 @@ inferBuiltinTypeConstructor builtin =
         pure (TcTyCon tyCon [], KFun KType KType)
     TBuiltinCons -> do
       let kind = KFun KType (KFun (listTypeKind KType) (listTypeKind KType))
-      tyCon <- mkKnownTyCon "GHC.Types" "':" 2 kind
+      tyCon <- mkKnownDataCon "GHC.Types" ":" 2 kind
       pure (TcTyCon tyCon [], kind)
     TBuiltinTuple arity ->
       let argKinds = replicate arity KType
@@ -380,21 +420,6 @@ knownTypeWithArity moduleName name arity kind = do
   maybeInfo <- lookupTyCon name
   tyCon <- maybe (mkKnownTyCon moduleName name arity kind) (pure . tciTyCon) maybeInfo
   pure (TcTyCon tyCon [], kind)
-
-inferPromotedTypeConstructor :: Text -> TcM (TcType, TcType)
-inferPromotedTypeConstructor name
-  | name == "[]" = do
-      elementKind <- freshKindMeta
-      resultKind <- listType elementKind
-      tyCon <- mkKnownTyCon "GHC.Types" "'[]" 0 resultKind
-      pure (TcTyCon tyCon [], resultKind)
-  | name == ":" = do
-      elementKind <- freshKindMeta
-      resultKind <- listType elementKind
-      let kind = TcFunTy elementKind (TcFunTy resultKind resultKind)
-      tyCon <- mkKnownTyCon "GHC.Types" "':" 2 kind
-      pure (TcTyCon tyCon [], kind)
-  | otherwise = inferUnknownType
 
 inferUnknownType :: TcM (TcType, TcType)
 inferUnknownType = do

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -41,6 +41,7 @@ module Aihc.Tc.Monad
     Closedness (..),
     emptyTcEnv,
     mkKnownTyCon,
+    mkKnownDataCon,
     configuredTyCon,
     lookupTerm,
     lookupKnownTerm,
@@ -61,7 +62,7 @@ module Aihc.Tc.Monad
     lookupTyCon,
     lookupTyConQualified,
     lookupResolvedTyCon,
-    lookupResolvedPromotedTyCon,
+    lookupResolvedTypeSyntax,
     lookupDeclaredTyCon,
     lookupTyConByIdentity,
     extendTyConEnvPermanent,
@@ -99,7 +100,7 @@ module Aihc.Tc.Monad
 where
 
 import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameText, unqualifiedNameText)
-import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..))
+import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..), TypeSyntaxResolution (..))
 import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeFamilyInstanceInfo (..), dataTypeKey)
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
@@ -166,9 +167,15 @@ tcConfig :: PackageId -> TcConfig
 tcConfig = TcConfig
 
 mkKnownTyCon :: Text -> Text -> Int -> TcType -> TcM TyCon
-mkKnownTyCon moduleName name arity kind = do
+mkKnownTyCon = mkKnownTyConInNamespace ResolutionNamespaceType
+
+mkKnownDataCon :: Text -> Text -> Int -> TcType -> TcM TyCon
+mkKnownDataCon = mkKnownTyConInNamespace ResolutionNamespaceTerm
+
+mkKnownTyConInNamespace :: ResolutionNamespace -> Text -> Text -> Int -> TcType -> TcM TyCon
+mkKnownTyConInNamespace namespace moduleName name arity kind = do
   TcConfig packageIdentity <- asks tcEnvConfig
-  let tyCon = mkTyConWithOrigin packageIdentity moduleName name arity
+  let tyCon = mkTyConWithNamespace namespace packageIdentity moduleName name arity
   maybeInfo <- lookupTyConByIdentity tyCon
   case maybeInfo of
     Just info -> pure (tciTyCon info)
@@ -182,7 +189,14 @@ configuredTyCon tyCon
   | tyConPackageId tyCon == PackageId "aihc-prim",
     tyConModuleName tyCon == "GHC.Types" = do
       TcConfig packageIdentity <- asks tcEnvConfig
-      pure (mkTyConWithOrigin packageIdentity (tyConModuleName tyCon) (tyConName tyCon) (tyConArity tyCon))
+      pure
+        ( mkTyConWithNamespace
+            (tyConNamespace tyCon)
+            packageIdentity
+            (tyConModuleName tyCon)
+            (tyConName tyCon)
+            (tyConArity tyCon)
+        )
   | otherwise = pure tyCon
 
 -- | Whether a polymorphic binding is known to have no free type variables.
@@ -494,61 +508,91 @@ termResolution =
     . mapMaybe fromAnnotation
 
 lookupTyCon :: Text -> TcM (Maybe TyConInfo)
-lookupTyCon name =
+lookupTyCon = lookupTyConInNamespace ResolutionNamespaceType
+
+lookupTyConInNamespace :: ResolutionNamespace -> Text -> TcM (Maybe TyConInfo)
+lookupTyConInNamespace namespace name =
   lift $ gets $ find matches . Map.elems . tcsGlobalTyCons
   where
-    matches info = tciName info == name || tyConName (tciTyCon info) == name
+    matches info =
+      tyConNamespace (tciTyCon info) == namespace
+        && (tciName info == name || tyConName (tciTyCon info) == name)
 
 lookupTyConQualified :: Text -> Text -> TcM (Maybe TyConInfo)
-lookupTyConQualified moduleName name =
+lookupTyConQualified = lookupTyConQualifiedInNamespace ResolutionNamespaceType
+
+lookupTyConQualifiedInNamespace :: ResolutionNamespace -> Text -> Text -> TcM (Maybe TyConInfo)
+lookupTyConQualifiedInNamespace namespace moduleName name =
   lift $ gets $ find matches . Map.elems . tcsGlobalTyCons
   where
     matches info =
       let tyCon = tciTyCon info
-       in tyConModuleName tyCon == moduleName
+       in tyConNamespace tyCon == namespace
+            && tyConModuleName tyCon == moduleName
             && (tciName info == name || tyConName tyCon == name)
 
 lookupResolvedTyCon :: Name -> TcM (Maybe TyConInfo)
 lookupResolvedTyCon name =
-  case typeResolution (nameAnns name) of
-    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
-      exact <- lookupTyConOrigin packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
-      maybe (lookupTyCon (nameText name)) (pure . Just) exact
+  case typeUseResolution (nameAnns name) of
+    Just ResolutionAnnotation {resolutionNamespace = namespace, resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
+      exact <- lookupTyConOrigin namespace packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+      maybe (lookupTyConInNamespace namespace (nameText name)) (pure . Just) exact
+    Just ResolutionAnnotation {resolutionTarget = ResolvedError {}} -> pure Nothing
+    Just ResolutionAnnotation {resolutionNamespace = namespace} ->
+      maybe
+        (lookupTyConInNamespace namespace (nameText name))
+        (\moduleName -> lookupTyConQualifiedInNamespace namespace moduleName (nameText name))
+        (nameQualifier name)
     _ -> maybe (lookupTyCon (nameText name)) (\moduleName -> lookupTyConQualified moduleName (nameText name)) (nameQualifier name)
 
-lookupResolvedPromotedTyCon :: Name -> TcM (Maybe TyConInfo)
-lookupResolvedPromotedTyCon name =
-  case typeResolution (nameAnns name) of
-    Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
-      let promotedName = "'" <> nameText resolvedName
-      exact <- lookupTyConOrigin packageId (fromMaybe "" (nameQualifier resolvedName)) promotedName
-      maybe (lookupTyCon ("'" <> nameText name)) (pure . Just) exact
-    _ -> maybe (lookupTyCon ("'" <> nameText name)) (\moduleName -> lookupTyConQualified moduleName ("'" <> nameText name)) (nameQualifier name)
+lookupResolvedTypeSyntax :: TypeSyntaxResolution -> TcM (Maybe TyConInfo)
+lookupResolvedTypeSyntax resolution =
+  case resolution of
+    TypeSyntaxResolution
+      { typeSyntaxResolutionName = sourceName,
+        typeSyntaxResolutionNamespace = namespace,
+        typeSyntaxResolutionTarget = ResolvedTopLevel packageId resolvedName
+      } -> do
+        exact <- lookupTyConOrigin namespace packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+        maybe (lookupTyConInNamespace namespace sourceName) (pure . Just) exact
+    TypeSyntaxResolution
+      { typeSyntaxResolutionTarget = ResolvedError {}
+      } -> pure Nothing
+    TypeSyntaxResolution
+      { typeSyntaxResolutionName = sourceName,
+        typeSyntaxResolutionNamespace = namespace
+      } -> lookupTyConInNamespace namespace sourceName
 
 lookupDeclaredTyCon :: UnqualifiedName -> TcM (Maybe TyConInfo)
 lookupDeclaredTyCon name =
   case typeResolution (unqualifiedNameAnns name) of
     Just ResolutionAnnotation {resolutionTarget = ResolvedTopLevel packageId resolvedName} -> do
-      exact <- lookupTyConOrigin packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
+      exact <- lookupTyConOrigin ResolutionNamespaceType packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
       maybe (lookupTyCon (unqualifiedNameText name)) (pure . Just) exact
     _ -> lookupTyCon (unqualifiedNameText name)
 
 lookupTyConByIdentity :: TyCon -> TcM (Maybe TyConInfo)
 lookupTyConByIdentity tyCon = lift $ gets $ Map.lookup tyCon . tcsGlobalTyCons
 
-lookupTyConOrigin :: PackageId -> Text -> Text -> TcM (Maybe TyConInfo)
-lookupTyConOrigin packageId moduleName name =
+lookupTyConOrigin :: ResolutionNamespace -> PackageId -> Text -> Text -> TcM (Maybe TyConInfo)
+lookupTyConOrigin namespace packageId moduleName name =
   lift $ gets $ find matches . Map.elems . tcsGlobalTyCons
   where
     matches info =
       let tyCon = tciTyCon info
-       in tyConPackageId tyCon == packageId
+       in tyConNamespace tyCon == namespace
+            && tyConPackageId tyCon == packageId
             && tyConModuleName tyCon == moduleName
             && tyConName tyCon == name
 
 typeResolution :: [Annotation] -> Maybe ResolutionAnnotation
 typeResolution =
   find ((== ResolutionNamespaceType) . resolutionNamespace)
+    . mapMaybe fromAnnotation
+
+typeUseResolution :: [Annotation] -> Maybe ResolutionAnnotation
+typeUseResolution =
+  find ((/= ResolutionNamespaceModule) . resolutionNamespace)
     . mapMaybe fromAnnotation
 
 getTyConEnv :: TcM (Map TyCon TyConInfo)

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -15,7 +15,9 @@ module Aihc.Tc.Types
     tyConKey,
     tyConPackageId,
     tyConModuleName,
+    tyConNamespace,
     mkTyConWithOrigin,
+    mkTyConWithNamespace,
     TypeScheme (..),
     boxedTupleTyConName,
     unboxedTupleTyConName,
@@ -96,7 +98,7 @@ module Aihc.Tc.Types
   )
 where
 
-import Aihc.Resolve (PackageId (..))
+import Aihc.Resolve (PackageId (..), ResolutionNamespace (..))
 import Control.Monad (zipWithM)
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -124,29 +126,37 @@ setTyVarKind :: TcType -> TyVarId -> TyVarId
 setTyVarKind kind (TyVarIdInternal name unique _) = TyVarIdInternal name unique kind
 
 -- | A type-constructor identity. Kind schemes live in the type-constructor environment.
-data TyCon = TyConInternal !PackageId !Text !Text !Int
+data TyCon = TyConInternal !PackageId !Text !ResolutionNamespace !Text !Int
   deriving (Eq, Ord, Show, Read)
 
 pattern TyCon :: Text -> Int -> TyCon
-pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ tyConName tyConArity
+pattern TyCon {tyConName, tyConArity} <- TyConInternal _ _ _ tyConName tyConArity
 
 {-# COMPLETE TyCon #-}
 
-type TcTypeKey = (PackageId, Text, Text)
+type TcTypeKey = (PackageId, Text, ResolutionNamespace, Text)
 
 type TcKindEnv = Map TcTypeKey TypeScheme
 
 tyConPackageId :: TyCon -> PackageId
-tyConPackageId (TyConInternal packageId _ _ _) = packageId
+tyConPackageId (TyConInternal packageId _ _ _ _) = packageId
 
 tyConModuleName :: TyCon -> Text
-tyConModuleName (TyConInternal _ moduleName _ _) = moduleName
+tyConModuleName (TyConInternal _ moduleName _ _ _) = moduleName
+
+tyConNamespace :: TyCon -> ResolutionNamespace
+tyConNamespace (TyConInternal _ _ namespace _ _) = namespace
 
 tyConKey :: TyCon -> TcTypeKey
-tyConKey tyCon = (tyConPackageId tyCon, tyConModuleName tyCon, tyConName tyCon)
+tyConKey tyCon = (tyConPackageId tyCon, tyConModuleName tyCon, tyConNamespace tyCon, tyConName tyCon)
 
 mkTyConWithOrigin :: PackageId -> Text -> Text -> Int -> TyCon
-mkTyConWithOrigin = TyConInternal
+mkTyConWithOrigin packageId moduleName =
+  TyConInternal packageId moduleName ResolutionNamespaceType
+
+mkTyConWithNamespace :: ResolutionNamespace -> PackageId -> Text -> Text -> Int -> TyCon
+mkTyConWithNamespace namespace packageId moduleName =
+  TyConInternal packageId moduleName namespace
 
 -- | Internal types. Kinds use this same representation.
 data TcType
@@ -184,8 +194,8 @@ unboxedTupleTyConName arity = "Tuple" <> T.pack (show arity) <> "#"
 primTypeCon :: Text -> Int -> TyCon
 primTypeCon = mkTyConWithOrigin (PackageId "aihc-prim") "GHC.Types"
 
-promotedTypeCon :: Text -> Int -> TyCon
-promotedTypeCon name = primTypeCon ("'" <> name)
+primDataCon :: Text -> Int -> TyCon
+primDataCon = mkTyConWithNamespace ResolutionNamespaceTerm (PackageId "aihc-prim") "GHC.Types"
 
 typeTyCon, constraintTyCon, runtimeRepTyCon, levityTyCon, vecCountTyCon, vecElemTyCon :: TyCon
 typeTyCon = primTypeCon "Type" 0
@@ -207,12 +217,12 @@ mkTYPEKind :: TcType -> TcType
 mkTYPEKind representation = TcTyCon (primTypeCon "TYPE" 1) [representation]
 
 nullaryRep :: Text -> TcType
-nullaryRep name = TcTyCon (promotedTypeCon name 0) []
+nullaryRep name = TcTyCon (primDataCon name 0) []
 
 liftedRep, unliftedRep, intRep, int8Rep, int16Rep, int32Rep, int64Rep :: TcType
 wordRep, word8Rep, word16Rep, word32Rep, word64Rep, addrRep, floatRep, doubleRep :: TcType
-liftedRep = boxedRep (TcTyCon (promotedTypeCon "Lifted" 0) [])
-unliftedRep = boxedRep (TcTyCon (promotedTypeCon "Unlifted" 0) [])
+liftedRep = boxedRep (TcTyCon (primDataCon "Lifted" 0) [])
+unliftedRep = boxedRep (TcTyCon (primDataCon "Unlifted" 0) [])
 intRep = nullaryRep "IntRep"
 int8Rep = nullaryRep "Int8Rep"
 int16Rep = nullaryRep "Int16Rep"
@@ -236,22 +246,22 @@ floatRep = nullaryRep "FloatRep"
 doubleRep = nullaryRep "DoubleRep"
 
 boxedRep :: TcType -> TcType
-boxedRep levity = TcTyCon (promotedTypeCon "BoxedRep" 1) [levity]
+boxedRep levity = TcTyCon (primDataCon "BoxedRep" 1) [levity]
 
 tupleRep :: [TcType] -> TcType
-tupleRep fields = TcTyCon (promotedTypeCon "TupleRep" 1) [promotedList fields]
+tupleRep fields = TcTyCon (primDataCon "TupleRep" 1) [dataConstructorList fields]
 
 sumRep :: [TcType] -> TcType
-sumRep fields = TcTyCon (promotedTypeCon "SumRep" 1) [promotedList fields]
+sumRep fields = TcTyCon (primDataCon "SumRep" 1) [dataConstructorList fields]
 
 vecRep :: TcType -> TcType -> TcType
-vecRep count element = TcTyCon (promotedTypeCon "VecRep" 2) [count, element]
+vecRep count element = TcTyCon (primDataCon "VecRep" 2) [count, element]
 
-promotedList :: [TcType] -> TcType
-promotedList = foldr promotedCons promotedNil
+dataConstructorList :: [TcType] -> TcType
+dataConstructorList = foldr cons nil
   where
-    promotedNil = TcTyCon (promotedTypeCon "[]" 0) []
-    promotedCons field rest = TcTyCon (promotedTypeCon ":" 2) [field, rest]
+    nil = TcTyCon (primDataCon "[]" 0) []
+    cons field rest = TcTyCon (primDataCon ":" 2) [field, rest]
 
 -- | Get a type kind from the complete type-constructor identity table.
 typeKindInEnv :: TcKindEnv -> TcType -> Either String TcType
@@ -332,13 +342,19 @@ typeKindInEnv kindEnv = go
     configurePrimitiveTyCon tyCon
       | tyConPackageId tyCon == PackageId "aihc-prim",
         tyConModuleName tyCon == "GHC.Types" =
-          mkTyConWithOrigin primitivePackage "GHC.Types" (tyConName tyCon) (tyConArity tyCon)
+          mkTyConWithNamespace
+            (tyConNamespace tyCon)
+            primitivePackage
+            "GHC.Types"
+            (tyConName tyCon)
+            (tyConArity tyCon)
       | otherwise = tyCon
 
     primitivePackage =
       case [ packageId
-           | ((packageId, moduleName, name), _) <- Map.toList kindEnv,
+           | ((packageId, moduleName, namespace, name), _) <- Map.toList kindEnv,
              moduleName == "GHC.Types",
+             namespace == ResolutionNamespaceType,
              name == "TYPE"
            ] of
         packageId : _ -> packageId
@@ -390,11 +406,11 @@ pattern KTYPE representation <- (matchTYPEKind -> Just representation)
     KTYPE representation = mkTYPEKind representation
 
 pattern KConstraint, KRuntimeRep, KLevity, KVecCount, KVecElem, KType :: TcType
-pattern KConstraint <- (matchesNullary "Constraint" -> True) where KConstraint = constraintKind
-pattern KRuntimeRep <- (matchesNullary "RuntimeRep" -> True) where KRuntimeRep = runtimeRepKind
-pattern KLevity <- (matchesNullary "Levity" -> True) where KLevity = levityKind
-pattern KVecCount <- (matchesNullary "VecCount" -> True) where KVecCount = vecCountKind
-pattern KVecElem <- (matchesNullary "VecElem" -> True) where KVecElem = vecElemKind
+pattern KConstraint <- (matchesNullary ResolutionNamespaceType "Constraint" -> True) where KConstraint = constraintKind
+pattern KRuntimeRep <- (matchesNullary ResolutionNamespaceType "RuntimeRep" -> True) where KRuntimeRep = runtimeRepKind
+pattern KLevity <- (matchesNullary ResolutionNamespaceType "Levity" -> True) where KLevity = levityKind
+pattern KVecCount <- (matchesNullary ResolutionNamespaceType "VecCount" -> True) where KVecCount = vecCountKind
+pattern KVecElem <- (matchesNullary ResolutionNamespaceType "VecElem" -> True) where KVecElem = vecElemKind
 pattern KType <- (matchesLiftedTypeKind -> True) where KType = typeKindType
 
 pattern KFun :: TcType -> TcType -> TcType
@@ -420,8 +436,10 @@ matchesLiftedRuntimeRep :: TcType -> Bool
 matchesLiftedRuntimeRep representation =
   case representation of
     TcTyCon boxed [TcTyCon levity []] ->
-      tyConName boxed == "'BoxedRep"
-        && tyConName levity == "'Lifted"
+      tyConNamespace boxed == ResolutionNamespaceTerm
+        && tyConName boxed == "BoxedRep"
+        && tyConNamespace levity == ResolutionNamespaceTerm
+        && tyConName levity == "Lifted"
     _ -> False
 
 pattern BoxedRep :: TcType -> TcType
@@ -445,12 +463,12 @@ pattern VecRep count element <- (matchBinaryRep "VecRep" -> Just (count, element
     VecRep count element = vecRep count element
 
 pattern Lifted, Unlifted :: TcType
-pattern Lifted <- (matchesNullary "Lifted" -> True)
+pattern Lifted <- (matchesNullary ResolutionNamespaceTerm "Lifted" -> True)
   where
-    Lifted = TcTyCon (promotedTypeCon "Lifted" 0) []
-pattern Unlifted <- (matchesNullary "Unlifted" -> True)
+    Lifted = TcTyCon (primDataCon "Lifted" 0) []
+pattern Unlifted <- (matchesNullary ResolutionNamespaceTerm "Unlifted" -> True)
   where
-    Unlifted = TcTyCon (promotedTypeCon "Unlifted" 0) []
+    Unlifted = TcTyCon (primDataCon "Unlifted" 0) []
 
 pattern IntRep, Int8Rep, Int16Rep, Int32Rep, Int64Rep :: TcType
 
@@ -458,59 +476,70 @@ pattern WordRep, Word8Rep, Word16Rep, Word32Rep, Word64Rep :: TcType
 
 pattern AddrRep, FloatRep, DoubleRep :: TcType
 
-pattern IntRep <- (matchesNullary "IntRep" -> True) where IntRep = intRep
+pattern IntRep <- (matchesNullary ResolutionNamespaceTerm "IntRep" -> True) where IntRep = intRep
 
-pattern Int8Rep <- (matchesNullary "Int8Rep" -> True) where Int8Rep = int8Rep
+pattern Int8Rep <- (matchesNullary ResolutionNamespaceTerm "Int8Rep" -> True) where Int8Rep = int8Rep
 
-pattern Int16Rep <- (matchesNullary "Int16Rep" -> True) where Int16Rep = int16Rep
+pattern Int16Rep <- (matchesNullary ResolutionNamespaceTerm "Int16Rep" -> True) where Int16Rep = int16Rep
 
-pattern Int32Rep <- (matchesNullary "Int32Rep" -> True) where Int32Rep = int32Rep
+pattern Int32Rep <- (matchesNullary ResolutionNamespaceTerm "Int32Rep" -> True) where Int32Rep = int32Rep
 
-pattern Int64Rep <- (matchesNullary "Int64Rep" -> True) where Int64Rep = int64Rep
+pattern Int64Rep <- (matchesNullary ResolutionNamespaceTerm "Int64Rep" -> True) where Int64Rep = int64Rep
 
-pattern WordRep <- (matchesNullary "WordRep" -> True) where WordRep = wordRep
+pattern WordRep <- (matchesNullary ResolutionNamespaceTerm "WordRep" -> True) where WordRep = wordRep
 
-pattern Word8Rep <- (matchesNullary "Word8Rep" -> True) where Word8Rep = word8Rep
+pattern Word8Rep <- (matchesNullary ResolutionNamespaceTerm "Word8Rep" -> True) where Word8Rep = word8Rep
 
-pattern Word16Rep <- (matchesNullary "Word16Rep" -> True) where Word16Rep = word16Rep
+pattern Word16Rep <- (matchesNullary ResolutionNamespaceTerm "Word16Rep" -> True) where Word16Rep = word16Rep
 
-pattern Word32Rep <- (matchesNullary "Word32Rep" -> True) where Word32Rep = word32Rep
+pattern Word32Rep <- (matchesNullary ResolutionNamespaceTerm "Word32Rep" -> True) where Word32Rep = word32Rep
 
-pattern Word64Rep <- (matchesNullary "Word64Rep" -> True) where Word64Rep = word64Rep
+pattern Word64Rep <- (matchesNullary ResolutionNamespaceTerm "Word64Rep" -> True) where Word64Rep = word64Rep
 
-pattern AddrRep <- (matchesNullary "AddrRep" -> True) where AddrRep = addrRep
+pattern AddrRep <- (matchesNullary ResolutionNamespaceTerm "AddrRep" -> True) where AddrRep = addrRep
 
-pattern FloatRep <- (matchesNullary "FloatRep" -> True) where FloatRep = floatRep
+pattern FloatRep <- (matchesNullary ResolutionNamespaceTerm "FloatRep" -> True) where FloatRep = floatRep
 
-pattern DoubleRep <- (matchesNullary "DoubleRep" -> True) where DoubleRep = doubleRep
+pattern DoubleRep <- (matchesNullary ResolutionNamespaceTerm "DoubleRep" -> True) where DoubleRep = doubleRep
 
 matchUnaryRep :: Text -> TcType -> Maybe TcType
 matchUnaryRep expected (TcTyCon tyCon [argument])
-  | T.dropWhile (== '\'') (tyConName tyCon) == expected = Just argument
+  | tyConNamespace tyCon == ResolutionNamespaceTerm,
+    tyConName tyCon == expected =
+      Just argument
 matchUnaryRep _ _ = Nothing
 
 matchBinaryRep :: Text -> TcType -> Maybe (TcType, TcType)
 matchBinaryRep expected (TcTyCon tyCon [left, right])
-  | T.dropWhile (== '\'') (tyConName tyCon) == expected = Just (left, right)
+  | tyConNamespace tyCon == ResolutionNamespaceTerm,
+    tyConName tyCon == expected =
+      Just (left, right)
 matchBinaryRep _ _ = Nothing
 
 matchListRep :: Text -> TcType -> Maybe [TcType]
 matchListRep expected (TcTyCon tyCon [listType])
-  | T.dropWhile (== '\'') (tyConName tyCon) == expected = decodePromotedList listType
+  | tyConNamespace tyCon == ResolutionNamespaceTerm,
+    tyConName tyCon == expected =
+      decodeDataConstructorList listType
 matchListRep _ _ = Nothing
 
-decodePromotedList :: TcType -> Maybe [TcType]
-decodePromotedList ty =
+decodeDataConstructorList :: TcType -> Maybe [TcType]
+decodeDataConstructorList ty =
   case ty of
     TcTyCon tyCon []
-      | tyConName tyCon == "'[]" -> Just []
+      | tyConNamespace tyCon == ResolutionNamespaceTerm,
+        tyConName tyCon == "[]" ->
+          Just []
     TcTyCon tyCon [field, rest]
-      | tyConName tyCon == "':" -> (field :) <$> decodePromotedList rest
+      | tyConNamespace tyCon == ResolutionNamespaceTerm,
+        tyConName tyCon == ":" ->
+          (field :) <$> decodeDataConstructorList rest
     _ -> Nothing
 
-matchesNullary :: Text -> TcType -> Bool
-matchesNullary expected (TcTyCon tyCon []) = T.dropWhile (== '\'') (tyConName tyCon) == expected
-matchesNullary _ _ = False
+matchesNullary :: ResolutionNamespace -> Text -> TcType -> Bool
+matchesNullary namespace expected (TcTyCon tyCon []) =
+  tyConNamespace tyCon == namespace && tyConName tyCon == expected
+matchesNullary _ _ _ = False
 
 runtimeRepFromKind :: TcType -> Either String TcType
 runtimeRepFromKind kind =


### PR DESCRIPTION
## Summary

- Resolve promoted identifiers in the term namespace.
- Resolve promoted infix, list, and tuple syntax before type checks.
- Store the resolution namespace in each type-constructor identity.
- Remove apostrophe-based identities and promotion lookups from the type checker.
- Convert the stored namespace directly to the System FC name sort.
- Remove the fixed System FC promotion table.
- Store namespaces in type artifacts and update the artifact version to 6.
- Keep all referenced type constructors in installed module interfaces.

## Test progress

- Increase resolver golden `PASS` cases by 1.
- Increase System FC 2 golden `PASS` cases by 3.
- Do not change `XFAIL`, `XPASS`, or `FAIL` counts.

## Checks

- `just fmt`
- `just check`