### PR TITLE
refactor(resolve): use structured syntax identifiers

### DIFF
--- a/bin/aihc/src/Aihc/Cli/ResolveArtifact.hs
+++ b/bin/aihc/src/Aihc/Cli/ResolveArtifact.hs
@@ -33,7 +33,7 @@ encodeResolveArtifact artifact =
   Builder.toLazyByteString $
     cborArray 5
       <> cborText "aihc-resolve"
-      <> cborWord 2
+      <> cborWord 3
       <> cborText (resolveArtifactModuleName artifact)
       <> encodeHashes (resolveArtifactInputHashes artifact)
       <> encodeScope (resolveArtifactScope artifact)
@@ -53,7 +53,7 @@ getArtifact :: Get.Get ResolveArtifact
 getArtifact = do
   5 <- getArrayLength
   "aihc-resolve" <- getText
-  2 <- getWord
+  3 <- getWord
   resolveArtifactModuleName <- getText
   resolveArtifactInputHashes <- getHashes
   resolveArtifactScope <- getScope
@@ -113,7 +113,7 @@ encodeResolvedName resolved =
   case resolved of
     ResolvedTopLevel (PackageId packageId) name ->
       cborArray 5 <> cborWord 0 <> cborText packageId <> cborText (fromMaybe "" (nameQualifier name)) <> cborWord (nameTypeTag (nameType name)) <> cborText (nameText name)
-    ResolvedBuiltin name -> cborArray 2 <> cborWord 1 <> cborText name
+    ResolvedSyntax -> cborArray 1 <> cborWord 1
     ResolvedLocal unique name -> cborArray 3 <> cborWord 2 <> cborWord (fromIntegral unique) <> cborText (renderUnqualifiedName name)
     ResolvedError message -> cborArray 2 <> cborWord 3 <> cborText (T.pack message)
 
@@ -129,7 +129,7 @@ getResolvedName = do
       text <- getText
       let qualifier = if T.null qualifierText then Nothing else Just qualifierText
       pure (ResolvedTopLevel packageId (Name qualifier nameType' text []))
-    (2, 1) -> ResolvedBuiltin <$> getText
+    (1, 1) -> pure ResolvedSyntax
     _ -> fail "unsupported resolved name"
 
 nameTypeTag :: NameType -> Word64

--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -12,10 +12,12 @@ import Aihc.Fc2.Name
 import Aihc.Fc2.Syntax
 import Aihc.Parser.Syntax qualified as Syn
 import Aihc.Resolve
-  ( PackageId (..),
+  ( Identifier (..),
+    PackageId (..),
     ResolutionAnnotation (..),
     ResolutionNamespace (..),
     ResolvedName (..),
+    displayIdentifier,
     packageIdText,
   )
 import Aihc.Tc
@@ -675,7 +677,7 @@ patternOccurrence target = go Nothing
           case (Syn.fromAnnotation annotation :: Maybe TcAnnotation, Syn.fromAnnotation annotation :: Maybe ResolutionAnnotation) of
             (Just checked, _) -> go (Just checked) inner
             (_, Just resolution)
-              | resolutionName resolution == target,
+              | resolutionIdentifier resolution == IdentifierNamed target,
                 resolutionNamespace resolution == ResolutionNamespaceTerm ->
                   (,resolution) <$> currentType
             _ -> go currentType inner
@@ -1116,7 +1118,7 @@ desugarAnnotatedExpr annotation inner = do
       Syn.EAnn resolutionAnnotation (Syn.EInt value Syn.TInteger _)
         | Just resolution <- Syn.fromAnnotation resolutionAnnotation,
           resolutionNamespace resolution == ResolutionNamespaceTerm,
-          resolutionName resolution == "fromInteger" ->
+          resolutionIdentifier resolution == IdentifierNamed "fromInteger" ->
             desugarOverloadedInteger annotation resolution value
       Syn.EInt value numericType _
         | numericType /= Syn.TInteger -> do
@@ -1664,7 +1666,7 @@ resolvedAnnotationName resolution =
       case local of
         Just (binder, _) -> pure (binderName binder)
         Nothing -> failValue ("missing local occurrence " <> T.unpack (Syn.unqualifiedNameText localName))
-    ResolvedBuiltin name -> pure (Name name SortValue (OriginLocal (Unique 0)))
+    ResolvedSyntax -> failValue ("syntax identifier reached ordinary occurrence " <> T.unpack (displayIdentifier (resolutionIdentifier resolution)))
     ResolvedError message -> failValue message
 
 desugarOverloadedInteger :: TcAnnotation -> ResolutionAnnotation -> Integer -> ValueM Expr
@@ -1721,7 +1723,7 @@ resolvedTermName sourceName =
                 (sourceNameSort target)
                 (OriginTop package (fromMaybe "" (Syn.nameQualifier target)))
             )
-        ResolvedBuiltin name -> pure (Name name SortValue (OriginLocal (Unique 0)))
+        ResolvedSyntax -> failValue ("syntax identifier reached ordinary term " <> T.unpack (Syn.nameText sourceName))
         ResolvedLocal _ localName -> do
           local <- Map.lookup (Syn.unqualifiedNameText localName) <$> gets vsLocals
           case local of

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -25,7 +25,6 @@ import Aihc.Parser.Syntax
     Extension,
     Module,
     Name (..),
-    SourceSpan (..),
     fromAnnotation,
     moduleName,
     parseExtensionName,
@@ -241,9 +240,7 @@ renderAnnotatedResolveResult sources result =
 resolutionAnnotationDoc :: Annotation -> Maybe (Doc ann)
 resolutionAnnotationDoc annotation = do
   resolution <- fromAnnotation annotation
-  case resolutionSpan resolution of
-    NoSourceSpan -> Nothing
-    _ -> pure (pretty (annotationLabel resolution))
+  pure (pretty (annotationLabel resolution))
 
 moduleDisplayName :: Module -> Text
 moduleDisplayName modu = fromMaybe (T.pack "<unnamed>") (moduleName modu)

--- a/components/aihc-resolve/common/ResolverGolden.hs
+++ b/components/aihc-resolve/common/ResolverGolden.hs
@@ -25,18 +25,21 @@ import Aihc.Parser.Syntax
     Extension,
     Module,
     Name (..),
+    SourceSpan (..),
     fromAnnotation,
     moduleName,
     parseExtensionName,
     renderName,
   )
 import Aihc.Resolve
-  ( Package (..),
+  ( Identifier,
+    Package (..),
     PackageId (..),
     ResolutionAnnotation (..),
     ResolutionNamespace (..),
     ResolveResult (..),
     ResolvedName (..),
+    displayIdentifier,
     resolveWithDeps,
     unnamedPackage,
   )
@@ -238,7 +241,9 @@ renderAnnotatedResolveResult sources result =
 resolutionAnnotationDoc :: Annotation -> Maybe (Doc ann)
 resolutionAnnotationDoc annotation = do
   resolution <- fromAnnotation annotation
-  pure (pretty (annotationLabel resolution))
+  case resolutionSpan resolution of
+    NoSourceSpan -> Nothing
+    _ -> pure (pretty (annotationLabel resolution))
 
 moduleDisplayName :: Module -> Text
 moduleDisplayName modu = fromMaybe (T.pack "<unnamed>") (moduleName modu)
@@ -247,7 +252,7 @@ annotationLabel :: ResolutionAnnotation -> Text
 annotationLabel ann =
   renderConciseNamespace (resolutionNamespace ann)
     <> " "
-    <> renderConciseOrigin (resolutionTarget ann)
+    <> renderConciseOrigin (resolutionIdentifier ann) (resolutionTarget ann)
 
 renderConciseNamespace :: ResolutionNamespace -> Text
 renderConciseNamespace namespace =
@@ -256,14 +261,14 @@ renderConciseNamespace namespace =
     ResolutionNamespaceType -> "t"
     ResolutionNamespaceModule -> "m"
 
-renderConciseOrigin :: ResolvedName -> Text
-renderConciseOrigin resolvedName =
+renderConciseOrigin :: Identifier -> ResolvedName -> Text
+renderConciseOrigin identifier resolvedName =
   case resolvedName of
     ResolvedTopLevel identity name
       | packageIdText identity `elem` ["", "main"] -> fromMaybe (renderName name) (nameQualifier name)
       | otherwise -> packageIdText identity <> ":" <> fromMaybe (renderName name) (nameQualifier name)
     ResolvedLocal uniqueId _ -> T.pack (show uniqueId)
-    ResolvedBuiltin name -> "Builtin " <> name
+    ResolvedSyntax -> "Builtin " <> displayIdentifier identifier
     ResolvedError msg -> T.pack ("Error " <> msg)
 
 listFixtureFiles :: FilePath -> IO [FilePath]

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -684,8 +684,17 @@ resolveExpr expr =
       ETypeSig <$> resolveExpr inner <*> resolveType ty
     EParen inner ->
       EParen <$> resolveExpr inner
-    EList items ->
-      EList <$> mapM resolveExpr items
+    EList items -> do
+      items' <- mapM resolveExpr items
+      sp <- currentSpan
+      scope <- currentScope
+      let resolved = lookupTerm "[]" scope
+          target =
+            case resolved of
+              ResolvedError {} -> ResolvedSyntax
+              _ -> resolved
+          annotation = ResolutionAnnotation sp IdentifierList ResolutionNamespaceTerm target
+      pure (EAnn (mkAnnotation annotation) (EList items'))
     ETuple flavor items -> do
       items' <- mapM resolveMaybeExpr items
       sp <- currentSpan
@@ -1684,7 +1693,9 @@ resolveDataConDefinitions scope =
           GadtCon forallVars context (map (resolveConstructor ambient) names) body
         TupleCon {} -> current
         UnboxedSumCon {} -> current
-        ListCon {} -> current
+        ListCon {} ->
+          let resolution = ResolutionAnnotation ambient IdentifierList ResolutionNamespaceTerm (lookupTerm "[]" scope)
+           in DataConAnn (mkAnnotation resolution) current
 
     resolveConstructor span' name =
       let rendered = renderUnqualifiedName name

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -687,13 +687,7 @@ resolveExpr expr =
     EList items -> do
       items' <- mapM resolveExpr items
       sp <- currentSpan
-      scope <- currentScope
-      let resolved = lookupTerm "[]" scope
-          target =
-            case resolved of
-              ResolvedError {} -> ResolvedSyntax
-              _ -> resolved
-          annotation = ResolutionAnnotation sp IdentifierList ResolutionNamespaceTerm target
+      let annotation = ResolutionAnnotation sp IdentifierList ResolutionNamespaceTerm ResolvedSyntax
       pure (EAnn (mkAnnotation annotation) (EList items'))
     ETuple flavor items -> do
       items' <- mapM resolveMaybeExpr items

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -25,10 +25,10 @@ module Aihc.Resolve
     ResolveResult (..),
     resolvedModuleAsts,
     ResolutionNamespace (..),
-    ResolutionForm (..),
+    Identifier (..),
+    displayIdentifier,
     ResolvedName (..),
     ResolutionAnnotation (..),
-    TypeSyntaxResolution (..),
   )
 where
 
@@ -80,7 +80,6 @@ import Aihc.Parser.Syntax
     Rhs (..),
     SourceSpan (..),
     StandaloneDerivingDecl (..),
-    TupleFlavor (..),
     TyVarBinder (..),
     Type (..),
     TypeFamilyDecl (..),
@@ -194,11 +193,11 @@ annotationResolveError resolution =
       Just
         ResolveResolutionError
           { resolveErrorSpan = resolutionSpan resolution,
-            resolveErrorName = resolutionName resolution,
+            resolveErrorName = displayIdentifier (resolutionIdentifier resolution),
             resolveErrorNamespace = resolutionNamespace resolution,
             resolveErrorMessage = msg
           }
-    ResolvedBuiltin _ -> Nothing
+    ResolvedSyntax -> Nothing
     _ -> Nothing
 
 resolveWithDeps :: ModuleExports -> [(Package, Module)] -> ResolveResult
@@ -241,9 +240,7 @@ moduleInfo package exports modu =
         any ((== "Prelude") . importDeclModule) (moduleImports modu),
       moduleInfoGhcBaseScope = lookupImportedModule package Nothing "GHC.Base" exports,
       moduleInfoGhcClassesScope = lookupImportedModule package Nothing "GHC.Classes" exports,
-      moduleInfoGhcNumScope = lookupImportedModule package Nothing "GHC.Num" exports,
-      moduleInfoGhcTupleScope = lookupImportedModule package Nothing "GHC.Tuple" exports,
-      moduleInfoGhcTypesScope = lookupImportedModule package Nothing "GHC.Types" exports
+      moduleInfoGhcNumScope = lookupImportedModule package Nothing "GHC.Num" exports
     }
 
 resolveModuleImports :: Package -> ModuleExports -> [ImportDecl] -> [ImportDecl]
@@ -263,10 +260,9 @@ missingModuleImportAnnotation message importDecl =
   let importedModule = importDeclModule importDecl
    in ResolutionAnnotation
         (importModuleNameSpan importDecl)
-        importedModule
+        (IdentifierNamed importedModule)
         ResolutionNamespaceModule
         (ResolvedError message)
-        ResolutionNamed
 
 annotateMissingImportItems :: Scope -> ImportDecl -> ImportDecl
 annotateMissingImportItems originScope importDecl =
@@ -321,10 +317,9 @@ missingImportMemberAnnotation originScope item members =
       let memberName = nameText (ieBundledMemberName member)
        in ResolutionAnnotation
             (importMemberNameSpan (peelImportItemSpan NoSourceSpan item) memberName)
-            memberName
+            (IdentifierNamed memberName)
             ResolutionNamespaceTerm
             (ResolvedError "not exported")
-            ResolutionNamed
 
 missingImportedName :: ImportItem -> ResolutionNamespace -> UnqualifiedName -> Map.Map Text ResolvedName -> Maybe ResolutionAnnotation
 missingImportedName item namespace itemName candidates
@@ -333,10 +328,9 @@ missingImportedName item namespace itemName candidates
       Just
         ( ResolutionAnnotation
             (spanStartNameSpan (peelImportItemSpan NoSourceSpan item) rendered)
-            rendered
+            (IdentifierNamed rendered)
             namespace
             (ResolvedError "not exported")
-            ResolutionNamed
         )
   where
     rendered = renderUnqualifiedName itemName
@@ -695,18 +689,8 @@ resolveExpr expr =
     ETuple flavor items -> do
       items' <- mapM resolveMaybeExpr items
       sp <- currentSpan
-      info <- currentModuleInfo
-      let constructorName = tupleConName flavor (length items)
-          renderedName = renderUnqualifiedName constructorName
-          tupleScope =
-            case flavor of
-              Boxed -> moduleInfoGhcTupleScope info
-              Unboxed -> moduleInfoGhcTypesScope info
-          resolved =
-            case lookupTerm renderedName tupleScope of
-              ResolvedError {} -> ResolvedBuiltin renderedName
-              sourceName -> sourceName
-          annotation = ResolutionAnnotation sp renderedName ResolutionNamespaceTerm resolved ResolutionTuple
+      let identifier = IdentifierTuple flavor (length items)
+          annotation = ResolutionAnnotation sp identifier ResolutionNamespaceTerm ResolvedSyntax
       pure (EAnn (mkAnnotation annotation) (ETuple flavor items'))
     EUnboxedSum alt arity inner ->
       EUnboxedSum alt arity <$> resolveExpr inner
@@ -748,12 +732,7 @@ resolveIntegerLiteral expr = do
           then rebindableFromInteger info scope
           else lookupTerm "fromInteger" (moduleInfoGhcNumScope info)
       annotation =
-        ResolutionAnnotation
-          sp
-          "fromInteger"
-          ResolutionNamespaceTerm
-          resolved
-          ResolutionNamed
+        ResolutionAnnotation sp (IdentifierNamed "fromInteger") ResolutionNamespaceTerm resolved
   pure (EAnn (mkAnnotation annotation) expr)
 
 rebindableFromInteger :: ModuleInfo -> Scope -> ResolvedName
@@ -785,7 +764,7 @@ literalSpan ambient _ = ambient
 syntaxTermAnnotation :: SourceSpan -> Text -> ResolveM ResolutionAnnotation
 syntaxTermAnnotation sp name = do
   resolved <- resolveSyntaxTerm name
-  pure (ResolutionAnnotation sp name ResolutionNamespaceTerm resolved ResolutionNamed)
+  pure (ResolutionAnnotation sp (IdentifierNamed name) ResolutionNamespaceTerm resolved)
 
 resolveSyntaxTerm :: Text -> ResolveM ResolvedName
 resolveSyntaxTerm name = do
@@ -944,7 +923,7 @@ doBindAnnotation sp = do
         if RebindableSyntax `elem` moduleInfoExtensions info
           then rebindableSyntaxTerm info scope ">>="
           else lookupTerm ">>=" (moduleInfoGhcBaseScope info)
-  pure (ResolutionAnnotation sp ">>=" ResolutionNamespaceTerm resolved ResolutionNamed)
+  pure (ResolutionAnnotation sp (IdentifierNamed ">>=") ResolutionNamespaceTerm resolved)
 
 resolveArithSeq :: ArithSeq -> ResolveM ArithSeq
 resolveArithSeq arithSeq =
@@ -1387,15 +1366,8 @@ resolveType ty =
       TFun <$> resolveArrowKind arrowKind <*> resolveType left <*> resolveType right
     TTuple flavor promotion items -> do
       items' <- mapM resolveType items
-      info <- currentModuleInfo
-      let constructorName = tupleConName flavor (length items)
-          renderedName = renderUnqualifiedName constructorName
-          tupleScope =
-            case flavor of
-              Boxed -> moduleInfoGhcTupleScope info
-              Unboxed -> moduleInfoGhcTypesScope info
-          (namespace, resolved) = resolveSyntaxName promotion renderedName tupleScope
-          syntaxResolution = TypeSyntaxResolution renderedName namespace resolved
+      let namespace = typePromotionNamespace promotion
+          syntaxResolution = ResolutionAnnotation NoSourceSpan (IdentifierTuple flavor (length items)) namespace ResolvedSyntax
           tupleType = TTuple flavor promotion items'
       pure $
         case promotion of
@@ -1405,10 +1377,8 @@ resolveType ty =
       TUnboxedSum <$> mapM resolveType items
     TList promotion items -> do
       items' <- mapM resolveType items
-      info <- currentModuleInfo
-      let renderedName = "[]"
-          (namespace, resolved) = resolveSyntaxName promotion renderedName (moduleInfoGhcTypesScope info)
-          syntaxResolution = TypeSyntaxResolution renderedName namespace resolved
+      let namespace = typePromotionNamespace promotion
+          syntaxResolution = ResolutionAnnotation NoSourceSpan IdentifierList namespace ResolvedSyntax
           listType = TList promotion items'
       pure $
         case promotion of
@@ -1524,7 +1494,7 @@ resolveUnqualifiedNameTo :: SourceSpan -> ResolutionNamespace -> ResolvedName ->
 resolveUnqualifiedNameTo span' namespace resolved name =
   name
     { unqualifiedNameAnns =
-        mkAnnotation (ResolutionAnnotation span' (renderUnqualifiedName name) namespace resolved ResolutionNamed)
+        mkAnnotation (ResolutionAnnotation span' (IdentifierNamed (renderUnqualifiedName name)) namespace resolved)
           : unqualifiedNameAnns name
     }
 
@@ -1532,7 +1502,7 @@ resolveNameTo :: SourceSpan -> ResolutionNamespace -> ResolvedName -> Name -> Na
 resolveNameTo span' namespace resolved name =
   name
     { nameAnns =
-        mkAnnotation (ResolutionAnnotation span' (nameText name) namespace resolved ResolutionNamed)
+        mkAnnotation (ResolutionAnnotation span' (IdentifierNamed (nameText name)) namespace resolved)
           : nameAnns name
     }
 
@@ -1583,10 +1553,9 @@ ambiguousFixityName ambient op =
         mkAnnotation
           ( ResolutionAnnotation
               (effectiveResolutionSpan (spanStartNameSpan ambient (nameText name)) (sourceSpanFromAnns (nameAnns name)))
-              (nameText name)
+              (IdentifierNamed (nameText name))
               ResolutionNamespaceTerm
               (ResolvedError "ambiguous fixity")
-              ResolutionNamed
           )
           : filter (not . isResolutionAnnotation) (nameAnns name)
     }
@@ -1674,18 +1643,11 @@ resolveTypeConstructorUse promotion name =
       scope <- currentScope
       pure (resolveNameTo sp ResolutionNamespaceTerm (resolveTermName scope name) name)
 
-resolveSyntaxName :: TypePromotion -> Text -> Scope -> (ResolutionNamespace, ResolvedName)
-resolveSyntaxName promotion renderedName scope =
+typePromotionNamespace :: TypePromotion -> ResolutionNamespace
+typePromotionNamespace promotion =
   case promotion of
-    Unpromoted ->
-      (ResolutionNamespaceType, fallbackBuiltin (lookupType renderedName scope))
-    Promoted ->
-      (ResolutionNamespaceTerm, fallbackBuiltin (lookupTerm renderedName scope))
-  where
-    fallbackBuiltin resolved =
-      case resolved of
-        ResolvedError {} -> ResolvedBuiltin renderedName
-        _ -> resolved
+    Unpromoted -> ResolutionNamespaceType
+    Promoted -> ResolutionNamespaceTerm
 
 resolveTypeUseAtName :: Name -> ResolveM Name
 resolveTypeUseAtName name = do

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -1688,7 +1688,7 @@ resolveDataConDefinitions scope =
         TupleCon {} -> current
         UnboxedSumCon {} -> current
         ListCon {} ->
-          let resolution = ResolutionAnnotation ambient IdentifierList ResolutionNamespaceTerm (lookupTerm "[]" scope)
+          let resolution = ResolutionAnnotation ambient IdentifierList ResolutionNamespaceTerm ResolvedSyntax
            in DataConAnn (mkAnnotation resolution) current
 
     resolveConstructor span' name =

--- a/components/aihc-resolve/src/Aihc/Resolve.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve.hs
@@ -1366,24 +1366,20 @@ resolveType ty =
       TFun <$> resolveArrowKind arrowKind <*> resolveType left <*> resolveType right
     TTuple flavor promotion items -> do
       items' <- mapM resolveType items
+      sp <- currentSpan
       let namespace = typePromotionNamespace promotion
-          syntaxResolution = ResolutionAnnotation NoSourceSpan (IdentifierTuple flavor (length items)) namespace ResolvedSyntax
+          syntaxResolution = ResolutionAnnotation sp (IdentifierTuple flavor (length items)) namespace ResolvedSyntax
           tupleType = TTuple flavor promotion items'
-      pure $
-        case promotion of
-          Promoted -> TAnn (mkAnnotation syntaxResolution) tupleType
-          Unpromoted -> tupleType
+      pure (annotateTypeSyntax sp syntaxResolution tupleType)
     TUnboxedSum items ->
       TUnboxedSum <$> mapM resolveType items
     TList promotion items -> do
       items' <- mapM resolveType items
+      sp <- currentSpan
       let namespace = typePromotionNamespace promotion
-          syntaxResolution = ResolutionAnnotation NoSourceSpan IdentifierList namespace ResolvedSyntax
+          syntaxResolution = ResolutionAnnotation sp IdentifierList namespace ResolvedSyntax
           listType = TList promotion items'
-      pure $
-        case promotion of
-          Promoted -> TAnn (mkAnnotation syntaxResolution) listType
-          Unpromoted -> listType
+      pure (annotateTypeSyntax sp syntaxResolution listType)
     TParen inner ->
       TParen <$> resolveType inner
     TKindSig inner kind ->
@@ -1415,6 +1411,10 @@ resolveTypeSignature ty =
     _ -> do
       ty' <- resolveType ty
       pure (emptyScope, ty')
+
+annotateTypeSyntax :: SourceSpan -> ResolutionAnnotation -> Type -> Type
+annotateTypeSyntax sp resolution =
+  TAnn (mkAnnotation resolution) . TAnn (mkAnnotation sp)
 
 bindTyVarBinders :: [TyVarBinder] -> ResolveM (Scope, [TyVarBinder])
 bindTyVarBinders =

--- a/components/aihc-resolve/src/Aihc/Resolve/Monad.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Monad.hs
@@ -36,9 +36,7 @@ data ModuleInfo = ModuleInfo
     moduleInfoExplicitPreludeImport :: !Bool,
     moduleInfoGhcBaseScope :: !Scope,
     moduleInfoGhcClassesScope :: !Scope,
-    moduleInfoGhcNumScope :: !Scope,
-    moduleInfoGhcTupleScope :: !Scope,
-    moduleInfoGhcTypesScope :: !Scope
+    moduleInfoGhcNumScope :: !Scope
   }
 
 newtype ResolveState = ResolveState

--- a/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Scope.hs
@@ -533,8 +533,8 @@ builtinScope =
       scopeQualifiedModules = Map.empty
     }
   where
-    mkBuiltinTerm n = (n, ResolvedBuiltin n)
-    mkBuiltinType n = (n, ResolvedBuiltin n)
+    mkBuiltinTerm n = (n, ResolvedSyntax)
+    mkBuiltinType n = (n, ResolvedSyntax)
 
 builtinPromotedConstructorNames :: [T.Text]
 builtinPromotedConstructorNames = []

--- a/components/aihc-resolve/src/Aihc/Resolve/Span.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Span.hs
@@ -103,10 +103,9 @@ unhandledSyntaxAnnotation :: (Data a) => ResolutionNamespace -> SourceSpan -> a 
 unhandledSyntaxAnnotation namespace span' node =
   ResolutionAnnotation
     span'
-    (T.pack (showConstr (toConstr node)))
+    (IdentifierNamed (T.pack (showConstr (toConstr node))))
     namespace
     (ResolvedError "unhandled syntax")
-    ResolutionNamed
 
 annotateUnhandledDecl :: SourceSpan -> Decl -> Decl
 annotateUnhandledDecl span' decl =

--- a/components/aihc-resolve/src/Aihc/Resolve/Types.hs
+++ b/components/aihc-resolve/src/Aihc/Resolve/Types.hs
@@ -9,14 +9,14 @@ module Aihc.Resolve.Types
     pattern PResolution,
     pattern TResolution,
     ResolutionNamespace (..),
-    ResolutionForm (..),
+    Identifier (..),
+    displayIdentifier,
     PackageId (..),
     Package (..),
     unnamedPackage,
     modulesInPackage,
     ResolvedName (..),
     ResolutionAnnotation (..),
-    TypeSyntaxResolution (..),
     ResolveError (..),
     ResolveResult (..),
     resolvedModuleAsts,
@@ -31,6 +31,7 @@ import Aihc.Parser.Syntax
     Name (..),
     Pattern (..),
     SourceSpan (..),
+    TupleFlavor (..),
     Type (..),
     UnqualifiedName (..),
     fromAnnotation,
@@ -65,9 +66,27 @@ modulesInPackage package = map pairWithPackage
 data ResolvedName
   = ResolvedTopLevel PackageId Name
   | ResolvedLocal Int UnqualifiedName
-  | ResolvedBuiltin Text
+  | ResolvedSyntax
   | ResolvedError String
   deriving (Eq, Show)
+
+-- | The source identifier that caused one resolution request.
+data Identifier
+  = IdentifierTuple !TupleFlavor !Int
+  | IdentifierList
+  | IdentifierNamed !Text
+  deriving (Eq, Show)
+
+-- | Render an identifier for diagnostics and other user output.
+displayIdentifier :: Identifier -> Text
+displayIdentifier identifier =
+  case identifier of
+    IdentifierTuple flavor arity ->
+      case flavor of
+        Boxed -> "(" <> T.replicate (max 0 (arity - 1)) "," <> ")"
+        Unboxed -> "(#" <> T.replicate (max 0 (arity - 1)) "," <> "#)"
+    IdentifierList -> "[]"
+    IdentifierNamed name -> name
 
 data ResolutionNamespace
   = ResolutionNamespaceTerm
@@ -75,26 +94,11 @@ data ResolutionNamespace
   | ResolutionNamespaceModule
   deriving (Eq, Ord, Show, Read)
 
--- | The syntax form that caused one resolution request.
-data ResolutionForm
-  = ResolutionNamed
-  | ResolutionTuple
-  deriving (Eq, Show)
-
 data ResolutionAnnotation = ResolutionAnnotation
   { resolutionSpan :: !SourceSpan,
-    resolutionName :: !Text,
+    resolutionIdentifier :: !Identifier,
     resolutionNamespace :: !ResolutionNamespace,
-    resolutionTarget :: !ResolvedName,
-    resolutionForm :: !ResolutionForm
-  }
-  deriving (Eq, Show)
-
--- | A resolved namespace and target for type syntax that has no identifier node.
-data TypeSyntaxResolution = TypeSyntaxResolution
-  { typeSyntaxResolutionName :: !Text,
-    typeSyntaxResolutionNamespace :: !ResolutionNamespace,
-    typeSyntaxResolutionTarget :: !ResolvedName
+    resolutionTarget :: !ResolvedName
   }
   deriving (Eq, Show)
 

--- a/components/aihc-resolve/test/Test/Fixtures/golden/builtin-cons-operator.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/builtin-cons-operator.yaml
@@ -2,7 +2,8 @@ annotated:
 - |-
   module Main where
   cons :: a -> [a] -> [a]
-  └─ v Main
+  └─ v Main    │      └─ t Builtin []
+               └─ t Builtin []
   cons x xs = (:) x xs
   │    │ └─ v 1│  │ └─ v 1
   │    └─ v 0  │  └─ v 0

--- a/components/aihc-resolve/test/Test/Fixtures/golden/builtin-type-syntax.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/builtin-type-syntax.yaml
@@ -14,15 +14,20 @@ annotated:
   - |
     module Main where
     type Int = ()
+         │     └─ t Builtin ()
          └─ t Main
     type Bool = ()
+         │      └─ t Builtin ()
          └─ t Main
     type Pair = '(Int, Bool)
-         └─ t Main│    └─ t Main
-                  └─ t Main
+         │       ││    └─ t Main
+         │       │└─ t Main
+         │       └─ v Builtin (,)
+         └─ t Main
     type Items = '[Int, Bool]
-         └─ t Main │    └─ t Main
-                   └─ t Main
+         └─ t Main││    └─ t Main
+                  │└─ t Main
+                  └─ v Builtin []
     tuple x y = (x, y)
     │     │ │   ││  └─ v 1
     │     │ │   │└─ v 0

--- a/components/aihc-resolve/test/Test/Fixtures/golden/builtin-type-syntax.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/builtin-type-syntax.yaml
@@ -1,0 +1,41 @@
+extensions:
+  - DataKinds
+  - UnboxedTuples
+modules:
+  - |
+    module Main where
+    type Int = ()
+    type Bool = ()
+    type Pair = '(Int, Bool)
+    type Items = '[Int, Bool]
+    tuple x y = (x, y)
+    unboxed x y = (# x, y #)
+annotated:
+  - |
+    module Main where
+    type Int = ()
+         └─ t Main
+    type Bool = ()
+         └─ t Main
+    type Pair = '(Int, Bool)
+         └─ t Main│    └─ t Main
+                  └─ t Main
+    type Items = '[Int, Bool]
+         └─ t Main │    └─ t Main
+                   └─ t Main
+    tuple x y = (x, y)
+    │     │ │   ││  └─ v 1
+    │     │ │   │└─ v 0
+    │     │ │   └─ v Builtin (,)
+    │     │ └─ v 1
+    │     └─ v 0
+    └─ v Main
+    unboxed x y = (# x, y #)
+    │       │ │   │  │  └─ v 3
+    │       │ │   │  └─ v 2
+    │       │ │   └─ v Builtin (#,#)
+    │       │ └─ v 3
+    │       └─ v 2
+    └─ v Main
+status: pass
+reason: built-in list and tuple syntax uses structured identifiers

--- a/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
@@ -2,14 +2,17 @@ annotated:
 - |-
   module Main where
   xs = 'a' : 'b' : 'c' : []
-  └─ v Main│     │     └─ v Prelude
+  └─ v Main│     │     │ └─ v Prelude
+           │     │     └─ v Prelude
            │     └─ v Prelude
            └─ v Prelude
 - |-
   module Prelude where
   data List a = [] | a : [a]
-       └─ t Prelude    │ └─ t Builtin []
-                       └─ v Prelude
+       │        │      │ └─ t Builtin []
+       │        │      └─ v Prelude
+       │        └─ v Prelude
+       └─ t Prelude
   infixr 5 :
 extensions: []
 modules:

--- a/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
@@ -11,7 +11,7 @@ annotated:
   data List a = [] | a : [a]
        │        │      │ └─ t Builtin []
        │        │      └─ v Prelude
-       │        └─ v Prelude
+       │        └─ v Builtin []
        └─ t Prelude
   infixr 5 :
 extensions: []

--- a/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
@@ -2,7 +2,7 @@ annotated:
 - |-
   module Main where
   xs = 'a' : 'b' : 'c' : []
-  └─ v Main│     │     │ └─ v Prelude
+  └─ v Main│     │     │ └─ v Builtin []
            │     │     └─ v Prelude
            │     └─ v Prelude
            └─ v Prelude

--- a/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/list-cons-right-assoc.yaml
@@ -8,7 +8,8 @@ annotated:
 - |-
   module Prelude where
   data List a = [] | a : [a]
-       └─ t Prelude    └─ v Prelude
+       └─ t Prelude    │ └─ t Builtin []
+                       └─ v Prelude
   infixr 5 :
 extensions: []
 modules:

--- a/components/aihc-resolve/test/Test/Fixtures/golden/tuple-pattern.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/tuple-pattern.yaml
@@ -9,6 +9,7 @@ annotated:
 - |
   module Main where
   fst3 :: (a, b, c) -> a
+  │       └─ t Builtin (,,)
   └─ v Main
   fst3 (x, _, _) = x
   │     └─ v 0     └─ v 0

--- a/components/aihc-resolve/test/Test/Fixtures/golden/type-synonym.yaml
+++ b/components/aihc-resolve/test/Test/Fixtures/golden/type-synonym.yaml
@@ -10,7 +10,8 @@ annotated:
 - |
   module Main where
   type String = [Char]
-       └─ t Main └─ t Error unbound
+       └─ t Main│└─ t Error unbound
+                └─ t Builtin []
   hello :: String
   │        └─ t Main
   └─ v Main

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Expr.hs
@@ -31,7 +31,7 @@ import Aihc.Parser.Syntax
     fromAnnotation,
     mkAnnotation,
   )
-import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
+import Aihc.Resolve (Identifier (..), ResolutionAnnotation (..), ResolutionNamespace (..))
 import Aihc.Tc.Annotations (PendingTcAnnotation (..), pendingAnnotation, pendingTypeLambdaAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (TyConInfo (..))
@@ -244,12 +244,12 @@ inferResolvedFromInteger sp resolution = do
 isFromIntegerResolution :: ResolutionAnnotation -> Bool
 isFromIntegerResolution resolution =
   resolutionNamespace resolution == ResolutionNamespaceTerm
-    && resolutionName resolution == "fromInteger"
+    && resolutionIdentifier resolution == IdentifierNamed "fromInteger"
 
 isDoBindResolution :: ResolutionAnnotation -> Bool
 isDoBindResolution resolution =
   resolutionNamespace resolution == ResolutionNamespaceTerm
-    && resolutionName resolution == ">>="
+    && resolutionIdentifier resolution == IdentifierNamed ">>="
 
 annotatePendingExpr :: PendingTcAnnotation -> Expr -> Expr
 annotatePendingExpr ann =

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -29,7 +29,7 @@ import Aihc.Parser.Syntax
     peelLiteralAnn,
     peelPatternAnn,
   )
-import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
+import Aihc.Resolve (Identifier (..), ResolutionAnnotation (..), ResolutionNamespace (..))
 import Aihc.Tc.Annotations (PendingTcAnnotation (..), TcAnnotation, pendingAnnotation)
 import Aihc.Tc.Constraint
 import Aihc.Tc.Env (TyConInfo (..))
@@ -437,7 +437,7 @@ predToCt sp name pred' = do
 
 requiredPatternResolution :: Text -> Pattern -> TcM ResolutionAnnotation
 requiredPatternResolution name pat =
-  case [resolution | resolution <- patternResolutions pat, resolutionName resolution == name, resolutionNamespace resolution == ResolutionNamespaceTerm] of
+  case [resolution | resolution <- patternResolutions pat, resolutionIdentifier resolution == IdentifierNamed name, resolutionNamespace resolution == ResolutionNamespaceTerm] of
     resolution : _ -> pure resolution
     [] -> do
       emitError NoSourceSpan (OtherError ("missing resolver annotation for overloaded pattern method " <> T.unpack name))
@@ -460,7 +460,7 @@ attachPendingPatternAnnotation target pending pat =
     PAnn ann inner ->
       case fromAnnotation ann of
         Just resolution
-          | resolutionName resolution == target,
+          | resolutionIdentifier resolution == IdentifierNamed target,
             resolutionNamespace resolution == ResolutionNamespaceTerm ->
               PAnn (mkAnnotation pending) (PAnn ann inner)
         _ -> PAnn ann (attachPendingPatternAnnotation target pending inner)

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -42,7 +42,7 @@ import Aihc.Parser.Syntax
     tyVarBinderName,
     unqualifiedNameText,
   )
-import Aihc.Resolve (ResolutionNamespace (..), TypeSyntaxResolution (..))
+import Aihc.Resolve (ResolutionAnnotation (..), ResolutionNamespace (..))
 import Aihc.Tc.Env (TyConInfo (..), TypeSynonymInfo (..))
 import Aihc.Tc.Error (TcErrorKind (..))
 import Aihc.Tc.Instantiate (instantiate)
@@ -133,7 +133,7 @@ convertSurfaceTypeWithKinds :: TvKindEnv -> Type -> TcM (TcType, TcType)
 convertSurfaceTypeWithKinds tvEnv ty =
   case ty of
     TAnn ann _
-      | Just _ <- (fromAnnotation ann :: Maybe TypeSyntaxResolution) ->
+      | Just _ <- (fromAnnotation ann :: Maybe ResolutionAnnotation) ->
           convertNonSynonymTypeWithKinds tvEnv ty
     _ -> do
       expanded <- expandTypeSynonym tvEnv (peelTypeHead ty)
@@ -206,9 +206,9 @@ convertNonSynonymTypeWithKinds tvEnv ty =
       meta <- freshMetaTv
       pure (meta, KType)
 
-convertResolvedSyntaxType :: TvKindEnv -> TypeSyntaxResolution -> Type -> TcM (TcType, TcType)
+convertResolvedSyntaxType :: TvKindEnv -> ResolutionAnnotation -> Type -> TcM (TcType, TcType)
 convertResolvedSyntaxType tvEnv resolution syntax =
-  case (typeSyntaxResolutionNamespace resolution, syntax) of
+  case (resolutionNamespace resolution, syntax) of
     (ResolutionNamespaceType, TList _ [argument]) ->
       convertListType tvEnv argument
     (ResolutionNamespaceTerm, TList _ arguments) ->
@@ -261,7 +261,7 @@ convertTupleType tvEnv flavor arguments = do
   tupleKind <- tcTypeKind tupleType
   pure (tupleType, tupleKind)
 
-convertResolvedConstructorApplication :: TvKindEnv -> TypeSyntaxResolution -> [Type] -> TcM (TcType, TcType)
+convertResolvedConstructorApplication :: TvKindEnv -> ResolutionAnnotation -> [Type] -> TcM (TcType, TcType)
 convertResolvedConstructorApplication tvEnv resolution arguments = do
   maybeInfo <- lookupResolvedTypeSyntax resolution
   case maybeInfo of

--- a/components/aihc-tc/src/Aihc/Tc/Kind.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Kind.hs
@@ -133,7 +133,8 @@ convertSurfaceTypeWithKinds :: TvKindEnv -> Type -> TcM (TcType, TcType)
 convertSurfaceTypeWithKinds tvEnv ty =
   case ty of
     TAnn ann _
-      | Just _ <- (fromAnnotation ann :: Maybe ResolutionAnnotation) ->
+      | Just resolution <- (fromAnnotation ann :: Maybe ResolutionAnnotation),
+        resolutionNamespace resolution == ResolutionNamespaceTerm ->
           convertNonSynonymTypeWithKinds tvEnv ty
     _ -> do
       expanded <- expandTypeSynonym tvEnv (peelTypeHead ty)
@@ -146,8 +147,10 @@ convertNonSynonymTypeWithKinds tvEnv ty =
   case ty of
     TAnn ann inner ->
       case fromAnnotation ann of
-        Just resolution -> convertResolvedSyntaxType tvEnv resolution inner
-        Nothing -> convertSurfaceTypeWithKinds tvEnv inner
+        Just resolution
+          | resolutionNamespace resolution == ResolutionNamespaceTerm ->
+              convertPromotedSyntaxType tvEnv resolution inner
+        _ -> convertSurfaceTypeWithKinds tvEnv inner
     TVar name ->
       inferTypeVariable tvEnv name
     TCon name _ ->
@@ -206,16 +209,12 @@ convertNonSynonymTypeWithKinds tvEnv ty =
       meta <- freshMetaTv
       pure (meta, KType)
 
-convertResolvedSyntaxType :: TvKindEnv -> ResolutionAnnotation -> Type -> TcM (TcType, TcType)
-convertResolvedSyntaxType tvEnv resolution syntax =
-  case (resolutionNamespace resolution, syntax) of
-    (ResolutionNamespaceType, TList _ [argument]) ->
-      convertListType tvEnv argument
-    (ResolutionNamespaceTerm, TList _ arguments) ->
+convertPromotedSyntaxType :: TvKindEnv -> ResolutionAnnotation -> Type -> TcM (TcType, TcType)
+convertPromotedSyntaxType tvEnv resolution syntax =
+  case peelTypeHead syntax of
+    TList _ arguments ->
       convertDataConstructorList tvEnv arguments
-    (ResolutionNamespaceType, TTuple flavor _ arguments) ->
-      convertTupleType tvEnv flavor arguments
-    (ResolutionNamespaceTerm, TTuple _ _ arguments) ->
+    TTuple _ _ arguments ->
       convertResolvedConstructorApplication tvEnv resolution arguments
     _ -> convertSurfaceTypeWithKinds tvEnv syntax
 

--- a/components/aihc-tc/src/Aihc/Tc/Monad.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Monad.hs
@@ -100,7 +100,7 @@ module Aihc.Tc.Monad
 where
 
 import Aihc.Parser.Syntax (Annotation, Name (..), SourceSpan (..), UnqualifiedName (..), fromAnnotation, nameText, unqualifiedNameText)
-import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..), TypeSyntaxResolution (..))
+import Aihc.Resolve (PackageId (..), ResolutionAnnotation (..), ResolutionNamespace (..), ResolvedName (..), displayIdentifier)
 import Aihc.Tc.Env (ClassInfo (..), DataFamilyInstanceInfo (..), DataTypeInfo (..), InstanceInfo (..), TyConFlavor (..), TyConInfo (..), TypeFamilyInstanceInfo (..), dataTypeKey)
 import Aihc.Tc.Error
 import Aihc.Tc.Evidence
@@ -407,8 +407,8 @@ resolvedNameTermKey displayName resolved =
       pure (TcTermLocal unique)
     ResolvedTopLevel packageId name ->
       pure (TcTermGlobal packageId (fromMaybe "" (nameQualifier name)) (nameText name))
-    ResolvedBuiltin name ->
-      pure (unqualifiedTermKey name)
+    ResolvedSyntax ->
+      pure (unqualifiedTermKey displayName)
     ResolvedError msg ->
       abortTc ("resolver error reached type checker for term " <> show displayName <> ": " <> msg)
 
@@ -545,23 +545,23 @@ lookupResolvedTyCon name =
         (nameQualifier name)
     _ -> maybe (lookupTyCon (nameText name)) (\moduleName -> lookupTyConQualified moduleName (nameText name)) (nameQualifier name)
 
-lookupResolvedTypeSyntax :: TypeSyntaxResolution -> TcM (Maybe TyConInfo)
+lookupResolvedTypeSyntax :: ResolutionAnnotation -> TcM (Maybe TyConInfo)
 lookupResolvedTypeSyntax resolution =
   case resolution of
-    TypeSyntaxResolution
-      { typeSyntaxResolutionName = sourceName,
-        typeSyntaxResolutionNamespace = namespace,
-        typeSyntaxResolutionTarget = ResolvedTopLevel packageId resolvedName
+    ResolutionAnnotation
+      { resolutionIdentifier = identifier,
+        resolutionNamespace = namespace,
+        resolutionTarget = ResolvedTopLevel packageId resolvedName
       } -> do
         exact <- lookupTyConOrigin namespace packageId (fromMaybe "" (nameQualifier resolvedName)) (nameText resolvedName)
-        maybe (lookupTyConInNamespace namespace sourceName) (pure . Just) exact
-    TypeSyntaxResolution
-      { typeSyntaxResolutionTarget = ResolvedError {}
+        maybe (lookupTyConInNamespace namespace (displayIdentifier identifier)) (pure . Just) exact
+    ResolutionAnnotation
+      { resolutionTarget = ResolvedError {}
       } -> pure Nothing
-    TypeSyntaxResolution
-      { typeSyntaxResolutionName = sourceName,
-        typeSyntaxResolutionNamespace = namespace
-      } -> lookupTyConInNamespace namespace sourceName
+    ResolutionAnnotation
+      { resolutionIdentifier = identifier,
+        resolutionNamespace = namespace
+      } -> lookupTyConInNamespace namespace (displayIdentifier identifier)
 
 lookupDeclaredTyCon :: UnqualifiedName -> TcM (Maybe TyConInfo)
 lookupDeclaredTyCon name =


### PR DESCRIPTION
## Summary

- Replace text syntax names with structured identifiers for tuples and lists.
- Remove `TypeSyntaxResolution`, `ResolutionForm`, and `ResolvedBuiltin`.
- Use one resolution annotation type for named and intrinsic syntax.
- Annotate promoted and unpromoted list and tuple type syntax.
- Keep source spans on each built-in type-syntax annotation.
- Keep empty-list expressions and list constructor definitions intrinsic.
- Remove tuple and list scope lookups because this syntax has a fixed meaning.
- Remove the unused GHC tuple and type scopes from resolver module information.
- Update the resolver artifact format to version 3.

## Tests

- Add resolver pointer coverage for list and tuple type syntax.
- Run `just fmt`.
- Run `just check`.

## Progress

- Resolver golden `PASS` count changes from 53 to 54.
- Resolver golden `XFAIL` count stays at 1.
- Resolver golden fixture count changes from 54 to 55.
- Resolver golden completion changes from 98.15% to 98.18%.