### PR TITLE
fix(fc): resolve prim types before lint

### DIFF
--- a/bin/aihc/src/Aihc/Cli/Install.hs
+++ b/bin/aihc/src/Aihc/Cli/Install.hs
@@ -408,7 +408,7 @@ buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
         sourcePath <- sourcePathForSpec resolver spec
         analysis <- analyzeSourceWith mode sourcePath
         recordPackagePlanSourceLineCount cache mode spec (sourceLineCount analysis)
-        dependencySpecs <- mapM resolveDependencySpec (sourceDependencyNames analysis)
+        dependencySpecs <- mapM resolveDependencySpec (withImplicitPrimDependency spec (sourceDependencyNames analysis))
         dependencyPlans <- mapM (buildPackagePlanRecursive cache mode resolver storeRoot (spec : stack)) dependencySpecs
         let plan =
               buildPackagePlanFromAnalysis
@@ -430,6 +430,14 @@ buildPackagePlanRecursive cache mode resolver storeRoot stack rawSpec
       case lookupCoreProvider dependencyName of
         Just provider -> pure (coreProviderVersion provider)
         Nothing -> resolverResolveVersion resolver dependencyName
+
+withImplicitPrimDependency :: PackageSpec -> [String] -> [String]
+withImplicitPrimDependency spec dependencies
+  | pkgName spec == "aihc-prim" = dependencies
+  | any isPrimDependency dependencies = dependencies
+  | otherwise = "aihc-prim" : dependencies
+  where
+    isPrimDependency name = name == "aihc-prim" || name == "ghc-prim"
 
 buildPackagePlanCached :: PackagePlanCache -> SourceAnalysisMode -> PackageSpec -> IO (ResolvedDependency, PackagePlan) -> IO (ResolvedDependency, PackagePlan)
 buildPackagePlanCached cache mode spec action = mask $ \restore -> do

--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -214,9 +214,12 @@ parseSource root fileInfo = do
 sourceModuleSccs :: [SourceModule] -> [[SourceModule]]
 sourceModuleSccs = map flatten . stronglyConnComp . map node
   where
-    node source = (source, sourceName source, map importDeclModule (moduleImportsOf source))
+    node source = (source, sourceName source, moduleDependencies source)
     sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
     moduleImportsOf = Syntax.moduleImports . sourceModuleAst
+    moduleDependencies source
+      | sourceName source == "GHC.Types" = map importDeclModule (moduleImportsOf source)
+      | otherwise = "GHC.Types" : map importDeclModule (moduleImportsOf source)
     flatten (AcyclicSCC value) = [value]
     flatten (CyclicSCC values) = values
 

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -171,11 +171,8 @@ test_installV2Fc2Ccall =
     writeFile
       (sourceDir </> "Demo.hs")
       "module Demo where\ndata Int = I\nforeign import ccall unsafe \"foo\" foo :: Int -> Int\n"
-    _ <- installV2 options
-    storeEntries <- listDirectory storeRoot
-    case storeEntries of
-      [packageDir] -> assertCoreV2File (storeRoot </> packageDir </> "Demo" </> "core-v2")
-      other -> assertFailure ("expected one package directory, got " <> show other)
+    result <- installV2 options
+    assertCoreV2File (installV2StorePath result </> "Demo" </> "core-v2")
 
 test_installV2AihcPrim :: Assertion
 test_installV2AihcPrim = do

--- a/components/aihc-fc/common/Fc2Golden.hs
+++ b/components/aihc-fc/common/Fc2Golden.hs
@@ -8,6 +8,7 @@ module Fc2Golden
     fixtureRoot,
     loadFc2Cases,
     evaluateFc2Case,
+    primitivePrograms,
   )
 where
 
@@ -100,6 +101,9 @@ primitiveSupport = unsafePerformIO $ do
     Left errMsg -> fail errMsg
     Right support -> pure support
 {-# NOINLINE primitiveSupport #-}
+
+primitivePrograms :: [Program]
+primitivePrograms = supportPrograms primitiveSupport
 
 loadPrimitiveModules :: IO [(FilePath, Text)]
 loadPrimitiveModules = do

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -245,8 +245,8 @@ typeUsesName target ty =
 
 isTYPEName :: LintEnv -> Type -> Bool
 isTYPEName env ty =
-  case ty of
-    TyCon name -> isWiredText env name "TYPE"
+  case (tePrimPackage (leTypes env), ty) of
+    (Just package, TyCon name) -> name == typeConstructor package
     _ -> False
 
 isTypeKind :: LintEnv -> Type -> Bool
@@ -260,12 +260,6 @@ isRuntimeRepKind env ty =
   case runtimeRepKind env of
     Right expected -> typesEqual (leTypes env) expected ty
     Left _ -> False
-
-isWiredText :: LintEnv -> Name -> Text -> Bool
-isWiredText env name expected =
-  case tePrimPackage (leTypes env) of
-    Nothing -> False
-    Just package -> isGhcTypesOrigin package name && nameText name == expected
 
 viewForAll :: LintEnv -> Type -> Maybe (Binder, Type)
 viewForAll env ty =
@@ -648,10 +642,10 @@ checkCoercionArgumentKind env expected left right = do
 representationOf :: LintEnv -> Type -> Either LintError Type
 representationOf env ty = do
   kind <- lintType env ty
-  case reduceType (leTypes env) kind of
-    TyApp (TyCon name) representation
-      | isWiredText env name "TYPE" -> Right representation
-    other -> Left (LintFailure ("term type does not have a TYPE representation: " <> show other))
+  case (tePrimPackage (leTypes env), reduceType (leTypes env) kind) of
+    (Just package, TyApp (TyCon name) representation)
+      | name == typeConstructor package -> Right representation
+    (_, other) -> Left (LintFailure ("term type does not have a TYPE representation: " <> show other))
 
 eitherToList :: Either LintError a -> [LintError]
 eitherToList = either pure (const [])

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -93,10 +93,7 @@ lookupBinderType :: TypeEnv -> Name -> Maybe Type
 lookupBinderType env name = Map.lookup name (teBinders env)
 
 lookupHeaderType :: TypeEnv -> Name -> Maybe Type
-lookupHeaderType env name =
-  case Map.lookup name (teHeaders env) of
-    Just header -> Just header
-    Nothing -> wiredTypeOf env name
+lookupHeaderType env name = Map.lookup name (teHeaders env)
 
 typeOf :: TypeEnv -> Type -> Maybe Type
 typeOf env ty =
@@ -281,30 +278,6 @@ isWiredName env name expected =
     Nothing -> False
     Just package ->
       isGhcTypesOrigin package name && nameText name == expected
-
-wiredTypeOf :: TypeEnv -> Name -> Maybe Type
-wiredTypeOf env name =
-  case tePrimPackage env of
-    Nothing -> Nothing
-    Just package
-      | not (isGhcTypesOrigin package name) -> Nothing
-      | nameText name == "Type" -> Just (typeSynonym package)
-      | nameText name == "Constraint" -> Just (typeSynonym package)
-      | nameText name == "TYPE" ->
-          do
-            lifted <- liftedRepType env
-            Just (TyFun lifted lifted (TyCon (runtimeRepConstructor package)) (typeSynonym package))
-      | nameText name == "RuntimeRep" -> Just (typeSynonym package)
-      | nameText name == "Levity" -> Just (typeSynonym package)
-      | nameText name == "LiftedRep" -> Just (TyCon (runtimeRepConstructor package))
-      | nameText name == "UnliftedRep" -> Just (TyCon (runtimeRepConstructor package))
-      | nameText name == "BoxedRep" ->
-          do
-            lifted <- liftedRepType env
-            Just (TyFun lifted lifted (TyCon (levityConstructor package)) (TyCon (runtimeRepConstructor package)))
-      | nameText name == "Lifted" -> Just (TyCon (levityConstructor package))
-      | nameText name == "Unlifted" -> Just (TyCon (levityConstructor package))
-      | otherwise -> Nothing
 
 typeAppTYPE :: TypeEnv -> Type -> Type
 typeAppTYPE env representation =

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -8,9 +8,7 @@ module Aihc.Fc2.TypeOf
     typeEnvFromPrograms,
     typeOf,
     unfoldType,
-    unfoldRep,
     isLiftedRep,
-    liftedRepType,
     repOf,
     headerType,
     applyType,
@@ -147,36 +145,6 @@ unfoldType env ty =
     TyCon name
       | Just body <- Map.lookup name (teSynonyms env) ->
           unfoldType env (stripForAlls body)
-      | isWiredName env name "Type",
-        Just representation <- liftedRepType env ->
-          typeAppTYPE env representation
-      | isWiredName env name "Constraint",
-        Just representation <- liftedRepType env ->
-          typeAppTYPE env representation
-      | isWiredName env name "TYPE" -> ty
-      | isWiredName env name "RuntimeRep" -> ty
-      | isWiredName env name "Levity" -> ty
-      | otherwise -> ty
-    TyApp (TyCon name) argument
-      | isWiredName env name "TYPE" -> TyApp (TyCon name) argument
-      | otherwise -> ty
-    _ -> ty
-
-unfoldRep :: TypeEnv -> Type -> Type
-unfoldRep env ty =
-  case ty of
-    TyCon name
-      | Just body <- Map.lookup name (teSynonyms env) ->
-          unfoldRep env (stripForAlls body)
-      | isWiredName env name "LiftedRep",
-        Just package <- tePrimPackage env ->
-          TyApp (TyCon (boxedRepName package)) (TyCon (liftedName package))
-      | isWiredName env name "UnliftedRep",
-        Just package <- tePrimPackage env ->
-          TyApp (TyCon (boxedRepName package)) (TyCon (unliftedName package))
-      | otherwise -> ty
-    TyApp (TyCon name) argument
-      | isWiredName env name "BoxedRep" -> TyApp (TyCon name) argument
       | otherwise -> ty
     _ -> ty
 
@@ -191,12 +159,11 @@ repOf env ty = do
 -- | True when a stored FUN representation is lifted.
 isLiftedRep :: TypeEnv -> Type -> Bool
 isLiftedRep env ty =
-  case unfoldRep env ty of
+  case unfoldType env ty of
     TyApp (TyCon boxed) (TyCon levity)
       | isWiredName env boxed "BoxedRep",
         isWiredName env levity "Lifted" ->
           True
-    TyCon name -> isWiredName env name "LiftedRep"
     _ -> False
 
 extendBinder :: TypeEnv -> Binder -> TypeEnv
@@ -279,23 +246,13 @@ isWiredName env name expected =
     Just package ->
       isGhcTypesOrigin package name && nameText name == expected
 
-typeAppTYPE :: TypeEnv -> Type -> Type
-typeAppTYPE env representation =
-  case tePrimPackage env of
-    Nothing -> representation
-    Just package -> TyApp (TyCon (typeConstructor package)) representation
-
-liftedRepType :: TypeEnv -> Maybe Type
-liftedRepType env =
-  TyCon . liftedRepName <$> tePrimPackage env
-
--- | Unfold synonyms and wired Type, then compare structure.
+-- | Unfold synonyms, then compare structure.
 reduceType :: TypeEnv -> Type -> Type
 reduceType env ty =
   case ty of
     TyVar {} -> ty
     TyCon {} ->
-      let unfolded = unfoldRep env (unfoldType env ty)
+      let unfolded = unfoldType env ty
        in if unfolded == ty then ty else reduceType env unfolded
     TyApp function argument ->
       case reduceType env function of

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -31,7 +31,6 @@ import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
 import Data.Maybe (listToMaybe, mapMaybe)
-import Data.Text (Text)
 
 -- | Local headers, synonym bodies, and binder types used by typeOf.
 data TypeEnv = TypeEnv
@@ -151,18 +150,19 @@ unfoldType env ty =
 repOf :: TypeEnv -> Type -> Maybe Type
 repOf env ty = do
   kind <- typeOf env ty
+  package <- tePrimPackage env
   case unfoldType env kind of
     TyApp (TyCon name) representation
-      | isWiredName env name "TYPE" -> Just representation
+      | name == typeConstructor package -> Just representation
     _ -> Nothing
 
 -- | True when a stored FUN representation is lifted.
 isLiftedRep :: TypeEnv -> Type -> Bool
 isLiftedRep env ty =
-  case unfoldType env ty of
-    TyApp (TyCon boxed) (TyCon levity)
-      | isWiredName env boxed "BoxedRep",
-        isWiredName env levity "Lifted" ->
+  case (tePrimPackage env, unfoldType env ty) of
+    (Just package, TyApp (TyCon boxed) (TyCon levity))
+      | boxed == boxedRepName package,
+        levity == liftedName package ->
           True
     _ -> False
 
@@ -238,13 +238,6 @@ freshTypeVariableName name used =
     choose unique =
       let candidate = name {nameOrigin = OriginLocal (Unique unique)}
        in if candidate `elem` used then choose (unique + 1) else candidate
-
-isWiredName :: TypeEnv -> Name -> Text -> Bool
-isWiredName env name expected =
-  case tePrimPackage env of
-    Nothing -> False
-    Just package ->
-      isGhcTypesOrigin package name && nameText name == expected
 
 -- | Unfold synonyms, then compare structure.
 reduceType :: TypeEnv -> Type -> Type

--- a/components/aihc-fc/test/Test/Fc2/Suite.hs
+++ b/components/aihc-fc/test/Test/Fc2/Suite.hs
@@ -15,7 +15,7 @@ import Data.List (dropWhileEnd, isInfixOf, sort)
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.IO qualified as TIO
-import Fc2Golden (Fc2Case (..), Outcome (..), evaluateFc2Case, loadFc2Cases)
+import Fc2Golden (Fc2Case (..), Outcome (..), evaluateFc2Case, loadFc2Cases, primitivePrograms)
 import System.Directory (copyFile, createDirectoryIfMissing, doesDirectoryExist, getTemporaryDirectory, listDirectory, removeDirectoryRecursive)
 import System.FilePath (takeExtension, takeFileName, (</>))
 import Test.Tasty (TestTree, testGroup)
@@ -70,7 +70,7 @@ lintFileTests label expectPass dir = do
 lintFileTest :: Bool -> FilePath -> TestTree
 lintFileTest expectPass path = testCase path $ do
   program <- loadFc2Program path
-  let errors = lintPrograms [program]
+  let errors = lintPrograms (primitivePrograms <> [program])
   if expectPass
     then assertEqual (path <> " lint errors") [] errors
     else assertBool (path <> " expected lint errors") (matchesFail path errors)

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/constraint-is-not-type.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/fail/constraint-is-not-type.fc2
@@ -1,0 +1,6 @@
+scope 1 = "" Test
+scope 2 = "aihc-prim" GHC.Types
+
+val 1.vbad :: 2.tConstraint 2.→ 2.tType
+ = λ(x : 2.tConstraint).
+  x

--- a/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal.fc2
+++ b/components/aihc-fc/test/Test/Fixtures/fc2-lint/pass/string-literal.fc2
@@ -1,12 +1,7 @@
 scope 1 = "" Test
 scope 2 = "aihc-prim" GHC.Types
 
-pub type 1.tChar :: 2.tType {}
+pub type 2.tChar :: 2.tType {}
 
-pub type 1.t[] (a : 2.tType) :: 2.tType {
-    pub 1.v[] :: ∀(a : 2.tType). 1.t[] a
-    pub 1.v: :: ∀(a : 2.tType). a 2.→ 1.t[] a 2.→ 1.t[] a
-}
-
-val 1.vmsg :: 1.t[] 1.tChar
+val 1.vmsg :: 2.t[] 2.tChar
  = "x"


### PR DESCRIPTION
## Summary

- Add the implicit `aihc-prim` package dependency.
- Add the implicit `GHC.Types` module dependency to `install-v2`.
- Give the FC2 lint fixtures all prim programs.
- Remove the hard-coded `wiredTypeOf` table.
- Unfold types and runtime representations from prim synonyms.
- Compare complete primitive names without text-based helpers.

## Tests

- `just check`

## Progress counts

- Add one failing FC2 lint fixture.
