### PR TITLE
feat(grin): add FC2 lowering pass

### DIFF
--- a/bin/aihc/aihc.cabal
+++ b/bin/aihc/aihc.cabal
@@ -9,6 +9,8 @@ maintainer: lemmih@gmail.com
 category: Development
 synopsis: Production command-line interface for the aihc compiler
 extra-source-files:
+  test/Test/Fixtures/install-v2/keep-grin/demo.cabal
+  test/Test/Fixtures/install-v2/keep-grin/src/Demo.hs
   test/Test/Fixtures/install-v2/resolve-error/demo.cabal
   test/Test/Fixtures/install-v2/resolve-error/expected.txt
   test/Test/Fixtures/install-v2/resolve-error/src/Demo.hs
@@ -33,6 +35,7 @@ library
     aihc-arm64,
     aihc-cpp,
     aihc-fc,
+    aihc-grin,
     aihc-hackage,
     aihc-llvm,
     aihc-native,

--- a/bin/aihc/src/Aihc/Cli/InstallV2.hs
+++ b/bin/aihc/src/Aihc/Cli/InstallV2.hs
@@ -20,6 +20,8 @@ import Aihc.Cli.Store (defaultStoreRoot)
 import Aihc.Cli.TypeArtifact (TypeArtifact (..), decodeTypeArtifact, encodeTypeArtifact, encodeTypeInterface)
 import Aihc.Fc2 (DesugarConfig (..), Fc2DesugarResult (..), desugarModuleFc2)
 import Aihc.Fc2 qualified as Fc2
+import Aihc.Fc2.TypeOf qualified as Fc2Type
+import Aihc.Grin qualified as Grin
 import Aihc.Hackage.Cabal qualified as HackageCabal
 import Aihc.Hackage.Download qualified as HackageDownload
 import Aihc.Hackage.Util qualified as HackageUtil
@@ -116,7 +118,7 @@ installV2 options = do
       resolver = localDependencyResolverWithFallback fallbackResolver root
   spec <- packageSpecFromSource root
   plan <- buildPackagePlanWithResolver resolver storeRoot spec
-  installedV2Result <$> installPackagePlanV2 verbose storeRoot plan
+  installedV2Result <$> installPackagePlanV2 (installV2KeepGrin options) verbose storeRoot plan
 
 networkDependencyResolver :: DependencyResolver
 networkDependencyResolver =
@@ -129,13 +131,13 @@ networkDependencyResolver =
       result <- getLatestVersion Nothing name
       either (ioError . userError) pure result
 
-installPackagePlanV2 :: (String -> IO ()) -> FilePath -> PackagePlan -> IO InstalledV2Package
-installPackagePlanV2 verbose storeRoot plan = do
-  dependencies <- mapM (installPackagePlanV2 verbose storeRoot) (planDependencyPlans plan)
-  installPackageV2 verbose storeRoot dependencies (planSourcePath plan)
+installPackagePlanV2 :: Bool -> (String -> IO ()) -> FilePath -> PackagePlan -> IO InstalledV2Package
+installPackagePlanV2 keepGrin verbose storeRoot plan = do
+  dependencies <- mapM (installPackagePlanV2 keepGrin verbose storeRoot) (planDependencyPlans plan)
+  installPackageV2 keepGrin verbose storeRoot dependencies (planSourcePath plan)
 
-installPackageV2 :: (String -> IO ()) -> FilePath -> [InstalledV2Package] -> FilePath -> IO InstalledV2Package
-installPackageV2 verbose storeRoot dependencies root = do
+installPackageV2 :: Bool -> (String -> IO ()) -> FilePath -> [InstalledV2Package] -> FilePath -> IO InstalledV2Package
+installPackageV2 keepGrin verbose storeRoot dependencies root = do
   verbose ("Read Cabal package: " <> root)
   cabalFiles <- HackageUtil.findCabalFiles root
   cabalFile <- case cabalFiles of
@@ -175,7 +177,7 @@ installPackageV2 verbose storeRoot dependencies root = do
   verbose ("Compute " <> show (length units) <> " SCC units")
   (allExports, allScopeHashes, _, allTypeHashes, written, reused) <-
     foldM
-      (installUnit verbose storePath resolvePackage primIdentity root)
+      (installUnit keepGrin verbose storePath resolvePackage primIdentity root)
       (dependencyExports, dependencyScopeHashes, dependencyTypes, dependencyTypeHashes, Set.empty, Set.empty)
       units
   let exposedNames = Set.fromList (HackageCabal.collectLibraryExposedModules gpd)
@@ -281,8 +283,8 @@ renderResolveExcerpt sourceLines sourceSpan =
                 <> replicate caretStart ' '
                 <> replicate caretWidth '^'
 
-installUnit :: (String -> IO ()) -> FilePath -> Package -> PackageId -> FilePath -> (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text) -> [SourceModule] -> IO (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text)
-installUnit verbose storePath resolvePackage primIdentity root (dependencyExports, scopeHashes, dependencyTypes, typeHashes, written, reused) unit = do
+installUnit :: Bool -> (String -> IO ()) -> FilePath -> Package -> PackageId -> FilePath -> (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text) -> [SourceModule] -> IO (ModuleExports, Map.Map Text Text, TcInterface, Map.Map Text Text, Set.Set Text, Set.Set Text)
+installUnit keepGrin verbose storePath resolvePackage primIdentity root (dependencyExports, scopeHashes, dependencyTypes, typeHashes, written, reused) unit = do
   let packageModules = modulesInPackage resolvePackage (map sourceModuleAst unit)
       unitNames = map sourceName unit
       importedNames = nub (concatMap (map importDeclModule . Syntax.moduleImports . sourceModuleAst) unit)
@@ -292,6 +294,7 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       resolvePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "resolve.cbor"
       typePath source = storePath </> moduleDirectory (sourceModuleAst source) </> "type.cbor"
       coreV2Path modu = storePath </> moduleDirectory modu </> "core-v2"
+      grinPath modu = storePath </> moduleDirectory modu </> "grin"
   cachedExports <- tryReadUnitArtifacts hashes resolvePackage resolvePath unit
   (diskExports, resolveResult, resolveChanged) <- case cachedExports of
     Just exports -> do
@@ -337,16 +340,23 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
       pure (storedInterfaces, True, Just checked)
   updatedTypeHashes <- updateTypeHashes typePath typeHashes unit
   coreV2Exists <- and <$> mapM (doesFileExist . coreV2Path . sourceModuleAst) unit
-  coreChanged <-
+  grinExists <- and <$> mapM (doesFileExist . grinPath . sourceModuleAst) unit
+  (coreChanged, grinChanged) <-
     if typeChanged || not coreV2Exists
       then do
         (checkedModules, completeInterface) <- maybe checkUnit pure checkedResult
-        writeCoreV2Files verbose (packageId resolvePackage) primIdentity completeInterface (takeDirectory storePath) coreV2Path checkedModules
-        pure True
-      else do
-        mapM_ (verbose . ("Reuse Core-v2: " <>) . T.unpack) unitNames
-        pure False
-  let changed = resolveChanged || typeChanged || coreChanged
+        writeCoreV2Files True keepGrin verbose (packageId resolvePackage) primIdentity completeInterface (takeDirectory storePath) coreV2Path grinPath checkedModules
+        pure (True, keepGrin)
+      else
+        if keepGrin && not grinExists
+          then do
+            (checkedModules, completeInterface) <- maybe checkUnit pure checkedResult
+            writeCoreV2Files False True verbose (packageId resolvePackage) primIdentity completeInterface (takeDirectory storePath) coreV2Path grinPath checkedModules
+            pure (False, True)
+          else do
+            mapM_ (verbose . ("Reuse Core-v2: " <>) . T.unpack) unitNames
+            pure (False, False)
+  let changed = resolveChanged || typeChanged || coreChanged || grinChanged
       unitSet = Set.fromList unitNames
       localUnitTypes = mconcat unitTypes
       written' = if changed then written <> unitSet else written
@@ -362,8 +372,8 @@ installUnit verbose storePath resolvePackage primIdentity root (dependencyExport
   where
     sourceName = fromMaybe "Main" . moduleName . sourceModuleAst
 
-writeCoreV2Files :: (String -> IO ()) -> PackageId -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> [Module] -> IO ()
-writeCoreV2Files verbose currentPackage primIdentity interface storeRoot coreV2Path checkedModules = do
+writeCoreV2Files :: Bool -> Bool -> (String -> IO ()) -> PackageId -> PackageId -> TcInterface -> FilePath -> (Module -> FilePath) -> (Module -> FilePath) -> [Module] -> IO ()
+writeCoreV2Files writeCore keepGrin verbose currentPackage primIdentity interface storeRoot coreV2Path grinPath checkedModules = do
   let bindings = tcInterfaceBindings interface <> concatMap tcModuleBindings checkedModules
       config = DesugarConfig primIdentity
       results2 = map (desugarModuleFc2 config bindings interface) checkedModules
@@ -386,7 +396,10 @@ writeCoreV2Files verbose currentPackage primIdentity interface storeRoot coreV2P
               )
           )
       )
-  mapM_ writeCoreV2 (zip checkedModules results2)
+  when writeCore (mapM_ writeCoreV2 (zip checkedModules results2))
+  when keepGrin $ do
+    let typeEnv = Fc2Type.typeEnvFromPrograms loadedFc2
+    mapM_ (writeGrin typeEnv) (zip checkedModules results2)
   where
     writeBadFc2 (modu, result2) = do
       let pathV2 = coreV2Path modu <> ".bad"
@@ -407,6 +420,17 @@ writeCoreV2Files verbose currentPackage primIdentity interface storeRoot coreV2P
           output = if "\n" `isSuffixOf` rendered then rendered else rendered <> "\n"
       createDirectoryIfMissing True (takeDirectory path)
       writeFile path output
+
+    writeGrin typeEnv (modu, result2) = do
+      program <- either (ioError . userError . ("GRIN generation failed: " <>)) pure (Grin.lowerProgram typeEnv (ds2Program result2))
+      let errors = Grin.lintProgram program
+      unless (null errors) (ioError (userError ("GRIN lint failed: " <> show errors)))
+      let path = grinPath modu
+          rendered = Grin.renderProgram program
+          output = if "\n" `isSuffixOf` rendered then rendered else rendered <> "\n"
+      createDirectoryIfMissing True (takeDirectory path)
+      writeFile path output
+      verbose ("Write GRIN: " <> T.unpack (fromMaybe "Main" (moduleName modu)))
 
     removeFileIfExists path = do
       exists <- doesFileExist path

--- a/bin/aihc/src/Aihc/Cli/Options.hs
+++ b/bin/aihc/src/Aihc/Cli/Options.hs
@@ -33,6 +33,7 @@ data PrepareRuntimeOptions = PrepareRuntimeOptions
 data InstallV2Options = InstallV2Options
   { installV2PackageDirectory :: !FilePath,
     installV2StoreRoot :: !(Maybe FilePath),
+    installV2KeepGrin :: !Bool,
     installV2Verbose :: !Bool
   }
   deriving (Eq, Show)
@@ -131,6 +132,10 @@ installV2OptionsParser =
           <> OA.help "Local Cabal package directory"
       )
     <*> storeRootOption "Override the aihc store root"
+    <*> OA.switch
+      ( OA.long "keep-grin"
+          <> OA.help "Retain GRIN files"
+      )
     <*> OA.switch
       ( OA.long "verbose"
           <> OA.short 'v'

--- a/bin/aihc/test/Spec.hs
+++ b/bin/aihc/test/Spec.hs
@@ -49,6 +49,7 @@ main =
           testCase "stops invalidation when a rebuilt scope stays equal" test_installV2StopsAtEqualScope,
           testCase "reports resolve errors with source locations" test_installV2ResolveError,
           testCase "writes Core-v2 for a ccall import" test_installV2Fc2Ccall,
+          testCase "retains and repairs GRIN only with keep-grin" test_installV2KeepGrin,
           testCase "install-v2 writes core-v2 for aihc-prim and lints stored programs" test_installV2AihcPrim
         ],
       testProperty "Hedgehog options" prop_dummy
@@ -63,7 +64,7 @@ test_installV2ResolveArtifacts =
     let sourceRoot = root </> "source"
         storeRoot = root </> "store"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just storeRoot) False
+        options = InstallV2Options sourceRoot (Just storeRoot) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -113,7 +114,7 @@ test_installV2ResolveError = do
   fixtureRoot <- findFixtureRoot "bin/aihc/test/Test/Fixtures/install-v2/resolve-error"
   expected <- readFile (fixtureRoot </> "expected.txt")
   withTempDir "aihc-install-v2-resolve-error" $ \root -> do
-    let options = InstallV2Options fixtureRoot (Just (root </> "store")) False
+    let options = InstallV2Options fixtureRoot (Just (root </> "store")) False False
     result <- try (installV2 options) :: IO (Either IOException InstallV2Result)
     case result of
       Right _ -> assertFailure "expected name resolution to fail"
@@ -139,6 +140,24 @@ findFixtureRoot fixture = do
             then assertFailure ("could not find fixture " <> fixture)
             else findUp parent
 
+test_installV2KeepGrin :: Assertion
+test_installV2KeepGrin = do
+  fixtureRoot <- findFixtureRoot "bin/aihc/test/Test/Fixtures/install-v2/keep-grin"
+  withTempDir "aihc-install-v2-keep-grin" $ \root -> do
+    withoutGrin <- installV2 (InstallV2Options fixtureRoot (Just (root </> "without")) False False)
+    assertFileDoesNotExist (installV2StorePath withoutGrin </> "Demo" </> "grin")
+    retained <- installV2 (InstallV2Options fixtureRoot (Just (root </> "with")) True False)
+    let corePath = installV2StorePath retained </> "Demo" </> "core-v2"
+        grinPath = installV2StorePath retained </> "Demo" </> "grin"
+    assertFileExists grinPath
+    originalCore <- readFile corePath
+    removeFile grinPath
+    repaired <- installV2 (InstallV2Options fixtureRoot (Just (root </> "with")) True False)
+    assertFileExists grinPath
+    repairedCore <- readFile corePath
+    assertEqual "GRIN repair keeps Core-v2" originalCore repairedCore
+    assertEqual "GRIN repair writes the module" ["Demo"] (installV2WrittenModules repaired)
+
 assertCoreV2File :: FilePath -> Assertion
 assertCoreV2File path = do
   assertFileExists path
@@ -153,7 +172,7 @@ test_installV2Fc2Ccall =
     let sourceRoot = root </> "source"
         storeRoot = root </> "store"
         sourceDir = sourceRoot </> "src"
-        options = InstallV2Options sourceRoot (Just storeRoot) False
+        options = InstallV2Options sourceRoot (Just storeRoot) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -182,7 +201,7 @@ test_installV2AihcPrim = do
   aihcPrimRoot <- findAihcPrimRoot
   withTempDir "aihc-install-v2-aihc-prim" $ \root -> do
     let storeRoot = root </> "store"
-        options = InstallV2Options aihcPrimRoot (Just storeRoot) False
+        options = InstallV2Options aihcPrimRoot (Just storeRoot) True False
     createDirectoryIfMissing True storeRoot
     caught <- try (installV2 options) :: IO (Either IOException InstallV2Result)
     result <- case caught of
@@ -202,6 +221,8 @@ test_installV2AihcPrim = do
     mapM_ (assertModuleCoreV2 packageDir) aihcPrimLibraryModules
     coreV2Files <- listNamedFiles packageDir "core-v2"
     mapM_ assertCoreV2File coreV2Files
+    grinFiles <- listNamedFiles packageDir "grin"
+    assertEqual "one GRIN file for each Core-v2 file" (length coreV2Files) (length grinFiles)
     types <- loadStoredFc2 loader packageId "GHC.Types"
     prim <- loadStoredFc2 loader packageId "GHC.Prim"
     assertBool "GHC.Types lint needs GHC.Prim" (not (null (Fc2.lintPrograms [types])))
@@ -299,7 +320,7 @@ test_installV2TypeDependencies =
   withTempDir "aihc-install-v2-type-dependencies" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -326,7 +347,7 @@ test_installV2TypeReexports =
   withTempDir "aihc-install-v2-type-reexports" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -356,7 +377,7 @@ test_installV2LocalDependencies =
     let sourceRoot = root </> "demo"
         dependencyRoot = root </> "dep"
         storeRoot = root </> "store"
-        options = InstallV2Options sourceRoot (Just storeRoot) False
+        options = InstallV2Options sourceRoot (Just storeRoot) False False
     createDirectoryIfMissing True (sourceRoot </> "src")
     createDirectoryIfMissing True (dependencyRoot </> "src")
     writeFile
@@ -400,7 +421,7 @@ test_installV2StaleTypeArtifact =
   withTempDir "aihc-install-v2-stale-type" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -427,7 +448,7 @@ test_installV2ResolveDependencies =
   withTempDir "aihc-install-v2-dependencies" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")
@@ -458,7 +479,7 @@ test_installV2StopsAtEqualScope =
   withTempDir "aihc-install-v2-scope-boundary" $ \root -> do
     let sourceRoot = root </> "source"
         sourceDir = sourceRoot </> "src" </> "Demo"
-        options = InstallV2Options sourceRoot (Just (root </> "store")) False
+        options = InstallV2Options sourceRoot (Just (root </> "store")) False False
     createDirectoryIfMissing True sourceDir
     writeFile
       (sourceRoot </> "demo.cabal")

--- a/bin/aihc/test/Test/Fixtures/install-v2/keep-grin/demo.cabal
+++ b/bin/aihc/test/Test/Fixtures/install-v2/keep-grin/demo.cabal
@@ -1,0 +1,8 @@
+cabal-version: 3.0
+name: demo
+version: 0.1.0.0
+
+library
+  exposed-modules: Demo
+  hs-source-dirs: src
+  default-language: Haskell2010

--- a/bin/aihc/test/Test/Fixtures/install-v2/keep-grin/src/Demo.hs
+++ b/bin/aihc/test/Test/Fixtures/install-v2/keep-grin/src/Demo.hs
@@ -1,0 +1,3 @@
+module Demo where
+
+identity value = value

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen.hs
@@ -371,12 +371,9 @@ compileEnvironmentWith exposeAllFunctions continuationFrames layout program =
       ]
     constructorInfoLabels = Map.fromList [(key, label) | (key, label, _) <- constructorInfoEntries]
     functionLabels =
-      [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
-      | info <- grinExternalFunctions program
+      [ (grinFunctionName function, localFunctionLabelWith exposeAllFunctions index function)
+      | (index, function) <- zip [0 ..] (grinFunctions program)
       ]
-        <> [ (grinFunctionName function, localFunctionLabelWith exposeAllFunctions index function)
-           | (index, function) <- zip [0 ..] (grinFunctions program)
-           ]
     functionLabelMap = Map.fromList functionLabels
     functionInfoKeys =
       [ (key, functionName)
@@ -422,21 +419,25 @@ compileConstructorInitializers env =
 
 compileInitializers :: CompileEnv -> GrinProgram -> Either Amd64Error [Text]
 compileInitializers env program = do
-  whnfGlobalLines <- compileGlobals materializeNode (grinWhnfGlobals program)
-  cafAllocationLines <- compileGlobals allocateNode (grinCafs program)
-  cafInitializationLines <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
-    slot <- globalSlot env (grinVarName var)
+  valueGlobalLines <- compileGlobals materializeNode valueGlobals
+  thunkAllocationLines <- compileGlobals allocateNode thunkGlobals
+  thunkInitializationLines <- fmap concat . forM thunkGlobals $ \(name, node) -> do
+    slot <- globalSlot env name
     fieldLines <- initializeNodeFields valueEnv node
     pure $
       [loadByteOffset "r11" "r15" 0, loadAt "r13" "r11" slot]
         <> fieldLines
-  pure (cafAllocationLines <> whnfGlobalLines <> cafInitializationLines)
+  pure (thunkAllocationLines <> valueGlobalLines <> thunkInitializationLines)
   where
+    (thunkGlobals, valueGlobals) = partitionGlobals (grinGlobals program)
     valueEnv = ValueEnv env Map.empty ".Laihc_initializer" (FunctionName "") [] ".Laihc_initializer"
-    compileGlobals emit globals = fmap concat . forM globals $ \(var, node) -> do
-      slot <- globalSlot env (grinVarName var)
+    compileGlobals emit globals = fmap concat . forM globals $ \(name, node) -> do
+      slot <- globalSlot env name
       lines' <- emit valueEnv node
       pure (lines' <> storeGlobal slot)
+    partitionGlobals = foldr partitionOne ([], [])
+    partitionOne binding@(_, GrinNode GrinThunk {} _) (thunks, values) = (binding : thunks, values)
+    partitionOne binding (thunks, values) = (thunks, binding : values)
 
 validatePrimitiveName :: Bool -> Text -> Either Amd64Error ()
 validatePrimitiveName allowUnsupported name
@@ -456,11 +457,10 @@ programRuntimeReps :: GrinProgram -> [GrinRep]
 programRuntimeReps program =
   concatMap (concat . snd) (grinConstructors program)
     <> map (grinVarRuntimeRep . fst) (grinPrimitives program)
-    <> concatMap bindingRuntimeReps (grinWhnfGlobals program)
-    <> concatMap bindingRuntimeReps (grinCafs program)
+    <> concatMap bindingRuntimeReps (grinGlobals program)
     <> concatMap functionRuntimeReps (grinFunctions program)
   where
-    bindingRuntimeReps (var, node) = grinVarRuntimeRep var : nodeRuntimeReps node
+    bindingRuntimeReps (_, node) = nodeRuntimeReps node
     functionRuntimeReps function =
       grinFunctionResultRep function
         : map grinVarRuntimeRep (grinFunctionParameters function)
@@ -468,8 +468,7 @@ programRuntimeReps program =
 
 programNodes :: GrinProgram -> [GrinNode]
 programNodes program =
-  map snd (grinWhnfGlobals program)
-    <> map snd (grinCafs program)
+  map snd (grinGlobals program)
     <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
 
 exprNodes :: GrinExpr -> [GrinNode]
@@ -606,11 +605,7 @@ renderObservedMetadata env program resultReps = do
       [ (grinFunctionName function, map grinVarRuntimeRep (grinFunctionParameters function))
       | function <- grinFunctions program
       ]
-    externalFunctionEntries =
-      [ (grinCodeFunctionName info, concat (grinCodeParameterLayouts info))
-      | info <- grinExternalFunctions program
-      ]
-    functionEntries = externalFunctionEntries <> localFunctionEntries
+    functionEntries = localFunctionEntries
 
     renderConstructorDescriptor (identifier, name, fields) = do
       reps <- mapM snapshotRepName fields

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen/Function.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen/Function.hs
@@ -93,12 +93,9 @@ reserveLocalsLines functions =
     maximumSlots = maximum (2 : map compiledFunctionSlots functions)
 
 exportLines :: CompileEnv -> GrinFunction -> Text -> [Text]
-exportLines env function label
+exportLines env _function label
   | compileExposeAllFunctions env = [".globl " <> label]
-  | otherwise =
-      case grinFunctionLinkName function of
-        Just _ -> [".globl " <> label]
-        Nothing -> []
+  | otherwise = []
 
 compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
 compileExpr env prefix label expression =
@@ -660,6 +657,7 @@ moveValuesToLocations env values destinations
     alreadyThere value destination =
       case value of
         GrinVarValue var -> Map.lookup var (valueLocations env) == Just destination
+        GrinGlobalValue {} -> False
         GrinLitValue {} -> False
 
 moveSource :: ValueEnv -> GrinValue -> MoveSource
@@ -670,6 +668,7 @@ moveSource env value =
         Just (InRegister register) -> MoveRegister register
         Just (InHeapSpill slot) -> MoveSpill slot
         Nothing -> MoveValue value
+    GrinGlobalValue {} -> MoveValue value
     GrinLitValue {} -> MoveValue value
 
 renderRegisterMoves :: ValueEnv -> [(Text, MoveSource)] -> Either Amd64Error [Text]

--- a/components/aihc-amd64/src/Aihc/Amd64/Codegen/Runtime.hs
+++ b/components/aihc-amd64/src/Aihc/Amd64/Codegen/Runtime.hs
@@ -27,7 +27,6 @@ module Aihc.Amd64.Codegen.Runtime
     globalSlot,
     immediate,
     initializeNodeFields,
-    linkedFunctionLabel,
     loadAt,
     loadByteOffset,
     loadLocation,
@@ -65,7 +64,6 @@ where
 
 import Aihc.Grin.Cps (ContinuationFrameKind, continuationFrameKindCode)
 import Aihc.Grin.Syntax
-import Aihc.Native (renderLinkedFunctionSymbol)
 import Aihc.Native.BlockLayout qualified as BlockLayout
 import Aihc.Native.RegisterAllocate (Location (..))
 import Control.Monad (forM)
@@ -188,6 +186,9 @@ materializeValueTo env destination value =
         Nothing -> do
           slot <- globalSlot (valueCompileEnv env) (grinVarName var)
           pure [loadByteOffset "r11" "r15" 0, loadAt destination "r11" slot]
+    GrinGlobalValue name -> do
+      slot <- globalSlot (valueCompileEnv env) name
+      pure [loadByteOffset "r11" "r15" 0, loadAt destination "r11" slot]
     GrinLitValue literal -> materializeLiteralTo destination (valueCompileEnv env) literal
 
 materializeLiteralTo :: Text -> CompileEnv -> GrinLiteral -> Either Amd64Error [Text]
@@ -638,15 +639,9 @@ functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index
 
 localFunctionLabelWith :: Bool -> Int -> GrinFunction -> Text
-localFunctionLabelWith exposeAllFunctions index function
+localFunctionLabelWith exposeAllFunctions index _function
   | exposeAllFunctions = "aihc_snapshot_function_" <> tshow index
-  | otherwise =
-      case grinFunctionLinkName function of
-        Just name -> linkedFunctionLabel name
-        Nothing -> functionLabel index
-
-linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel = renderLinkedFunctionSymbol
+  | otherwise = functionLabel index
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot =

--- a/components/aihc-amd64/test/Test/Amd64/Suite.hs
+++ b/components/aihc-amd64/test/Test/Amd64/Suite.hs
@@ -55,10 +55,7 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(primitive, 2)],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions = []
                 }
         assertEqual "linked primitive validation" (Left (Amd64UnsupportedPrimitive "unsupported#")) (validateProgramPrimitives program)
@@ -73,14 +70,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(GrinVar "+#" 1 IntRep, 2)],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = entryName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = IntRep,
                           grinFunctionBody =
@@ -119,14 +112,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(GrinVar "timesWord2#" 1 (TupleRep [WordRep, WordRep]), 2)],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = entryName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [WordRep, WordRep],
                           grinFunctionBody =
@@ -149,14 +138,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [Int8Rep, Word64Rep],
                           grinFunctionBody =
@@ -191,14 +176,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [foreignCall],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int32Rep,
                           grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "\xFF\0bar")]
@@ -219,14 +200,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [TupleRep [], IntRep, WordRep],
                           grinFunctionBody =
@@ -243,42 +220,6 @@ tests =
             assertBool "passes two values" ("mov rdx, 2" `T.isInfixOf` assembly)
             assertBool "enters the continuation through registers" ("jmp .Laihc_enter" `T.isInfixOf` assembly)
             assertBool "does not call a C continuation adapter" (not ("aihc_continue_values" `T.isInfixOf` assembly)),
-      testCase "exports stable entries and branches directly to dependency code" $ do
-        let identityName = FunctionName "$entry$identity"
-            callerName = FunctionName "$entry$caller"
-            argument = GrinVar "argument" 1 (BoxedRep Lifted)
-            program =
-              GrinProgram
-                { grinConstructors = [],
-                  grinPrimitives = [],
-                  grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions =
-                    [ GrinCodeInfo
-                        { grinCodeSourceName = "identity",
-                          grinCodeFunctionName = identityName,
-                          grinCodeParameterLayouts = [[BoxedRep Lifted]],
-                          grinCodeResultRep = BoxedRep Lifted
-                        }
-                    ],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
-                  grinFunctions =
-                    [ GrinFunction
-                        { grinFunctionName = callerName,
-                          grinFunctionLinkName = Just "caller",
-                          grinFunctionParameters = [argument],
-                          grinFunctionResultRep = BoxedRep Lifted,
-                          grinFunctionBody = GrinCall (BoxedRep Lifted) identityName [GrinVarValue argument]
-                        }
-                    ]
-                }
-        case compileModule (buildLinkLayout [program]) "_aihc_init_direct_call" (expectGcGrin program) of
-          Left err -> assertFailure ("native compilation failed: " <> show err)
-          Right assembly -> do
-            assertBool "exports caller entry" (".globl aihc_entry_caller" `T.isInfixOf` assembly)
-            assertBool "branches to dependency entry" ("jmp aihc_entry_identity" `T.isInfixOf` assembly)
-            assertBool "does not publish direct-call arguments through the machine" (not ("mov QWORD PTR [r15], r12" `T.isInfixOf` assembly)),
       testGroup "raw GRIN heap snapshots" (map snapshotTest snapshotCases),
       testCase "case and apply never evaluate operands implicitly" $ do
         case compileModule (buildLinkLayout [explicitEvaluationProgram]) "_aihc_init_explicit_eval" (expectGcGrin explicitEvaluationProgram) of
@@ -555,14 +496,10 @@ explicitEvaluationProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "case_operand",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [caseOperand],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
@@ -573,7 +510,6 @@ explicitEvaluationProgram =
             },
           GrinFunction
             { grinFunctionName = FunctionName "apply_operand",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [applyOperand],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody = GrinApply (BoxedRep Lifted) (GrinVarValue applyOperand) []
@@ -591,14 +527,10 @@ caseDispatchProgram =
     { grinConstructors = [("CaseA", [[]]), ("CaseB", [[]])],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "data_case_dispatch",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [dataOperand],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
@@ -611,7 +543,6 @@ caseDispatchProgram =
             },
           GrinFunction
             { grinFunctionName = FunctionName "literal_case_dispatch",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [literalOperand],
               grinFunctionResultRep = IntRep,
               grinFunctionBody =

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen.hs
@@ -295,12 +295,9 @@ compileEnvironmentWith exposeAllFunctions continuationFrames layout program =
       ]
     constructorInfoLabels = Map.fromList [(key, label) | (key, label, _) <- constructorInfoEntries]
     functionLabels =
-      [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
-      | info <- grinExternalFunctions program
+      [ (grinFunctionName function, localFunctionLabelWith exposeAllFunctions index function)
+      | (index, function) <- zip [0 ..] (grinFunctions program)
       ]
-        <> [ (grinFunctionName function, localFunctionLabelWith exposeAllFunctions index function)
-           | (index, function) <- zip [0 ..] (grinFunctions program)
-           ]
     functionLabelMap = Map.fromList functionLabels
     functionInfoKeys =
       [ (key, functionName)
@@ -346,21 +343,25 @@ compileConstructorInitializers env =
 
 compileInitializers :: CompileEnv -> GrinProgram -> Either Arm64Error [Text]
 compileInitializers env program = do
-  whnfGlobalLines <- compileGlobals materializeNode (grinWhnfGlobals program)
-  cafAllocationLines <- compileGlobals allocateNode (grinCafs program)
-  cafInitializationLines <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
-    slot <- globalSlot env (grinVarName var)
+  valueGlobalLines <- compileGlobals materializeNode valueGlobals
+  thunkAllocationLines <- compileGlobals allocateNode thunkGlobals
+  thunkInitializationLines <- fmap concat . forM thunkGlobals $ \(name, node) -> do
+    slot <- globalSlot env name
     fieldLines <- initializeNodeFields valueEnv node
     pure $
       ["  ldr x9, [x22, #0]", loadAt "x20" "x9" slot]
         <> fieldLines
-  pure (cafAllocationLines <> whnfGlobalLines <> cafInitializationLines)
+  pure (thunkAllocationLines <> valueGlobalLines <> thunkInitializationLines)
   where
+    (thunkGlobals, valueGlobals) = partitionGlobals (grinGlobals program)
     valueEnv = ValueEnv env Map.empty ".Laihc_initializer" (FunctionName "") [] ".Laihc_initializer"
-    compileGlobals emit globals = fmap concat . forM globals $ \(var, node) -> do
-      slot <- globalSlot env (grinVarName var)
+    compileGlobals emit globals = fmap concat . forM globals $ \(name, node) -> do
+      slot <- globalSlot env name
       lines' <- emit valueEnv node
       pure (lines' <> storeGlobal slot)
+    partitionGlobals = foldr partitionOne ([], [])
+    partitionOne binding@(_, GrinNode GrinThunk {} _) (thunks, values) = (binding : thunks, values)
+    partitionOne binding (thunks, values) = (thunks, binding : values)
 
 mainPrologue :: Int -> [Text]
 mainPrologue globalCount =
@@ -444,11 +445,10 @@ programRuntimeReps :: GrinProgram -> [GrinRep]
 programRuntimeReps program =
   concatMap (concat . snd) (grinConstructors program)
     <> map (grinVarRuntimeRep . fst) (grinPrimitives program)
-    <> concatMap bindingRuntimeReps (grinWhnfGlobals program)
-    <> concatMap bindingRuntimeReps (grinCafs program)
+    <> concatMap bindingRuntimeReps (grinGlobals program)
     <> concatMap functionRuntimeReps (grinFunctions program)
   where
-    bindingRuntimeReps (var, node) = grinVarRuntimeRep var : nodeRuntimeReps node
+    bindingRuntimeReps (_, node) = nodeRuntimeReps node
     functionRuntimeReps function =
       grinFunctionResultRep function
         : map grinVarRuntimeRep (grinFunctionParameters function)
@@ -456,8 +456,7 @@ programRuntimeReps program =
 
 programNodes :: GrinProgram -> [GrinNode]
 programNodes program =
-  map snd (grinWhnfGlobals program)
-    <> map snd (grinCafs program)
+  map snd (grinGlobals program)
     <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
 
 exprNodes :: GrinExpr -> [GrinNode]
@@ -585,11 +584,7 @@ renderObservedMetadata env program resultReps = do
       [ (grinFunctionName function, map grinVarRuntimeRep (grinFunctionParameters function))
       | function <- grinFunctions program
       ]
-    externalFunctionEntries =
-      [ (grinCodeFunctionName info, concat (grinCodeParameterLayouts info))
-      | info <- grinExternalFunctions program
-      ]
-    functionEntries = externalFunctionEntries <> localFunctionEntries
+    functionEntries = localFunctionEntries
 
     renderConstructorDescriptor (identifier, name, fields) = do
       reps <- mapM snapshotRepName fields

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen/Function.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen/Function.hs
@@ -86,12 +86,9 @@ reserveLocalsLines functions =
     maximumSlots = maximum (2 : map compiledFunctionSlots functions)
 
 exportLines :: CompileEnv -> GrinFunction -> Text -> [Text]
-exportLines env function label
+exportLines env _function label
   | compileExposeAllFunctions env = [".globl " <> label]
-  | otherwise =
-      case grinFunctionLinkName function of
-        Just _ -> [".globl " <> label]
-        Nothing -> []
+  | otherwise = []
 
 compileExpr :: ValueEnv -> [Text] -> Text -> GrinExpr -> FunctionM ()
 compileExpr env prefix label expression =
@@ -644,6 +641,7 @@ moveValuesToLocations env values destinations
     alreadyThere value destination =
       case value of
         GrinVarValue var -> Map.lookup var (valueLocations env) == Just destination
+        GrinGlobalValue {} -> False
         GrinLitValue {} -> False
 
 saveValueOverflowLines :: ValueEnv -> [GrinValue] -> Either Arm64Error [Text]

--- a/components/aihc-arm64/src/Aihc/Arm64/Codegen/Runtime.hs
+++ b/components/aihc-arm64/src/Aihc/Arm64/Codegen/Runtime.hs
@@ -24,7 +24,6 @@ module Aihc.Arm64.Codegen.Runtime
     functionCodeLabel,
     globalSlot,
     immediate,
-    linkedFunctionLabel,
     loadAt,
     loadByteOffset,
     loadLocation,
@@ -64,7 +63,6 @@ where
 
 import Aihc.Grin.Cps (ContinuationFrameKind, continuationFrameKindCode)
 import Aihc.Grin.Syntax
-import Aihc.Native (renderLinkedFunctionSymbol)
 import Aihc.Native.BlockLayout qualified as BlockLayout
 import Aihc.Native.RegisterAllocate (Location (..))
 import Control.Monad (forM)
@@ -515,15 +513,9 @@ functionLabel :: Int -> Text
 functionLabel index = ".Laihc_function_" <> tshow index
 
 localFunctionLabelWith :: Bool -> Int -> GrinFunction -> Text
-localFunctionLabelWith exposeAllFunctions index function
+localFunctionLabelWith exposeAllFunctions index _function
   | exposeAllFunctions = "_aihc_snapshot_function_" <> tshow index
-  | otherwise =
-      case grinFunctionLinkName function of
-        Just name -> linkedFunctionLabel name
-        Nothing -> functionLabel index
-
-linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel = ("_" <>) . renderLinkedFunctionSymbol
+  | otherwise = functionLabel index
 
 storeGlobal :: Int -> [Text]
 storeGlobal slot = ["  ldr x9, [x22, #0]", storeAt "x0" "x9" slot]
@@ -564,6 +556,9 @@ materializeValueTo env destination value =
         Nothing -> do
           slot <- globalSlot (valueCompileEnv env) (grinVarName var)
           pure ["  ldr x9, [x22, #0]", loadAt destination "x9" slot]
+    GrinGlobalValue name -> do
+      slot <- globalSlot (valueCompileEnv env) name
+      pure ["  ldr x9, [x22, #0]", loadAt destination "x9" slot]
     GrinLitValue literal -> materializeLiteralTo destination (valueCompileEnv env) literal
 
 materializeLiteralTo :: Text -> CompileEnv -> GrinLiteral -> Either Arm64Error [Text]

--- a/components/aihc-arm64/test/Test/Arm64/Suite.hs
+++ b/components/aihc-arm64/test/Test/Arm64/Suite.hs
@@ -55,10 +55,7 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(primitive, 2)],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions = []
                 }
         assertEqual "linked primitive validation" (Left (Arm64UnsupportedPrimitive "unsupported#")) (validateProgramPrimitives program)
@@ -73,14 +70,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(GrinVar "+#" 1 IntRep, 2)],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = entryName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = IntRep,
                           grinFunctionBody =
@@ -119,14 +112,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [(GrinVar "timesWord2#" 1 (TupleRep [WordRep, WordRep]), 2)],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = entryName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [WordRep, WordRep],
                           grinFunctionBody =
@@ -150,14 +139,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int8Rep,
                           grinFunctionBody = GrinConstant [GrinLitValue (GrinLitInt Int8Rep 255)]
@@ -185,14 +170,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [foreignCall],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = Int32Rep,
                           grinFunctionBody = GrinForeignCallExpr foreignCall [GrinLitValue (GrinLitAddr "\xFF\0bar")]
@@ -212,14 +193,10 @@ tests =
                 { grinConstructors = [],
                   grinPrimitives = [],
                   grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions = [],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
+                  grinGlobals = [],
                   grinFunctions =
                     [ GrinFunction
                         { grinFunctionName = functionName,
-                          grinFunctionLinkName = Nothing,
                           grinFunctionParameters = [],
                           grinFunctionResultRep = TupleRep [TupleRep [], IntRep, WordRep],
                           grinFunctionBody =
@@ -236,42 +213,6 @@ tests =
             assertBool "passes two values" ("ldr x2, =2" `T.isInfixOf` assembly)
             assertBool "enters the continuation through registers" ("b .Laihc_enter" `T.isInfixOf` assembly)
             assertBool "does not call a C continuation adapter" (not ("_aihc_continue_values" `T.isInfixOf` assembly)),
-      testCase "exports stable entries and branches directly to dependency code" $ do
-        let identityName = FunctionName "$entry$identity"
-            callerName = FunctionName "$entry$caller"
-            argument = GrinVar "argument" 1 (BoxedRep Lifted)
-            program =
-              GrinProgram
-                { grinConstructors = [],
-                  grinPrimitives = [],
-                  grinForeignCalls = [],
-                  grinExternalGlobals = [],
-                  grinExternalFunctions =
-                    [ GrinCodeInfo
-                        { grinCodeSourceName = "identity",
-                          grinCodeFunctionName = identityName,
-                          grinCodeParameterLayouts = [[BoxedRep Lifted]],
-                          grinCodeResultRep = BoxedRep Lifted
-                        }
-                    ],
-                  grinWhnfGlobals = [],
-                  grinCafs = [],
-                  grinFunctions =
-                    [ GrinFunction
-                        { grinFunctionName = callerName,
-                          grinFunctionLinkName = Just "caller",
-                          grinFunctionParameters = [argument],
-                          grinFunctionResultRep = BoxedRep Lifted,
-                          grinFunctionBody = GrinCall (BoxedRep Lifted) identityName [GrinVarValue argument]
-                        }
-                    ]
-                }
-        case compileModule (buildLinkLayout [program]) "_aihc_init_direct_call" (expectGcGrin program) of
-          Left err -> assertFailure ("native compilation failed: " <> show err)
-          Right assembly -> do
-            assertBool "exports caller entry" (".globl _aihc_entry_caller" `T.isInfixOf` assembly)
-            assertBool "branches to dependency entry" ("b _aihc_entry_identity" `T.isInfixOf` assembly)
-            assertBool "does not publish direct-call arguments through the machine" (not ("str x8, [x22, #0]" `T.isInfixOf` assembly)),
       testGroup "raw GRIN heap snapshots" (map snapshotTest snapshotCases),
       testCase "case and apply never evaluate operands implicitly" $ do
         case compileModule (buildLinkLayout [explicitEvaluationProgram]) "_aihc_init_explicit_eval" (expectGcGrin explicitEvaluationProgram) of
@@ -702,14 +643,10 @@ explicitEvaluationProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "case_operand",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [caseOperand],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
@@ -720,7 +657,6 @@ explicitEvaluationProgram =
             },
           GrinFunction
             { grinFunctionName = FunctionName "apply_operand",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [applyOperand],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody = GrinApply (BoxedRep Lifted) (GrinVarValue applyOperand) []

--- a/components/aihc-fc/common/Fc2Golden.hs
+++ b/components/aihc-fc/common/Fc2Golden.hs
@@ -8,6 +8,7 @@ module Fc2Golden
     fixtureRoot,
     loadFc2Cases,
     evaluateFc2Case,
+    buildFc2CasePrograms,
   )
 where
 
@@ -186,7 +187,22 @@ evaluateFc2Case tc =
     Right actual -> classifySuccess tc actual
 
 renderFc2Case :: Fc2Case -> Either String String
-renderFc2Case tc =
+renderFc2Case tc = do
+  (_, fixturePrograms) <- buildFc2CasePrograms tc
+  unlines <$> traverse renderResult fixturePrograms
+  where
+    renderResult program =
+      let rendered = renderProgram program
+       in case parseProgram (T.pack rendered) of
+            Left parseError -> Left ("System FC 2 round-trip parse error:\n" <> renderParseError parseError <> "\n" <> rendered)
+            Right parsed ->
+              let canonical = renderProgram parsed
+               in if canonical == rendered
+                    then Right rendered
+                    else Left ("System FC 2 round trip changed canonical syntax:\n" <> canonical <> "\noriginal:\n" <> rendered)
+
+buildFc2CasePrograms :: Fc2Case -> Either String ([Program], [Program])
+buildFc2CasePrograms tc =
   let parsedModules = map parseFixtureModule (caseModules tc)
    in case sequence parsedModules of
         Left errMsg -> Left ("parse error: " <> errMsg)
@@ -203,7 +219,7 @@ renderFc2Case tc =
                               (desugarModuleFc2 desugarConfig fixtureBindings tcInterface)
                               fixtureTcResults
                        in if all ds2Success fixtureResults
-                            then lintAndRenderResults (supportPrograms primitiveSupport <> map ds2Program fixtureResults) fixtureResults
+                            then lintResults (supportPrograms primitiveSupport <> map ds2Program fixtureResults) (map ds2Program fixtureResults)
                             else Left (unlines (concatMap ds2Errors fixtureResults))
                     else Left ("typecheck error: " <> unlines [show d | r <- fixtureTcResults, d <- tcModuleDiagnostics r])
             ResolveResult {resolveErrors} ->
@@ -211,29 +227,10 @@ renderFc2Case tc =
   where
     parseFixtureModule input =
       parseModuleText (T.unpack (T.takeWhile (/= '\n') input)) (caseExtensions tc) input
-    lintAndRenderResults programs fixtureResults =
-      case renderResults fixtureResults of
-        Left renderError -> Left renderError
-        Right rendered ->
-          case lintPrograms programs of
-            [] -> Right rendered
-            lintErrors ->
-              Left
-                ( unlines ["System FC 2 lint error: " <> show lintError | lintError <- lintErrors]
-                    <> "\nSystem FC 2 output:\n"
-                    <> rendered
-                )
-    renderResults results =
-      unlines <$> traverse renderResult results
-    renderResult result =
-      let rendered = renderProgram (ds2Program result)
-       in case parseProgram (T.pack rendered) of
-            Left parseError -> Left ("System FC 2 round-trip parse error:\n" <> renderParseError parseError <> "\n" <> rendered)
-            Right parsed ->
-              let canonical = renderProgram parsed
-               in if canonical == rendered
-                    then Right rendered
-                    else Left ("System FC 2 round trip changed canonical syntax:\n" <> canonical <> "\noriginal:\n" <> rendered)
+    lintResults programs fixturePrograms =
+      case lintPrograms programs of
+        [] -> Right (programs, fixturePrograms)
+        lintErrors -> Left (unlines ["System FC 2 lint error: " <> show lintError | lintError <- lintErrors])
 
 preparePrimitiveSupport :: [(FilePath, Text)] -> Either String PrimitiveSupport
 preparePrimitiveSupport primitiveModules =

--- a/components/aihc-fc/common/Fc2Golden.hs
+++ b/components/aihc-fc/common/Fc2Golden.hs
@@ -8,7 +8,6 @@ module Fc2Golden
     fixtureRoot,
     loadFc2Cases,
     evaluateFc2Case,
-    buildFc2CasePrograms,
   )
 where
 
@@ -187,22 +186,7 @@ evaluateFc2Case tc =
     Right actual -> classifySuccess tc actual
 
 renderFc2Case :: Fc2Case -> Either String String
-renderFc2Case tc = do
-  (_, fixturePrograms) <- buildFc2CasePrograms tc
-  unlines <$> traverse renderResult fixturePrograms
-  where
-    renderResult program =
-      let rendered = renderProgram program
-       in case parseProgram (T.pack rendered) of
-            Left parseError -> Left ("System FC 2 round-trip parse error:\n" <> renderParseError parseError <> "\n" <> rendered)
-            Right parsed ->
-              let canonical = renderProgram parsed
-               in if canonical == rendered
-                    then Right rendered
-                    else Left ("System FC 2 round trip changed canonical syntax:\n" <> canonical <> "\noriginal:\n" <> rendered)
-
-buildFc2CasePrograms :: Fc2Case -> Either String ([Program], [Program])
-buildFc2CasePrograms tc =
+renderFc2Case tc =
   let parsedModules = map parseFixtureModule (caseModules tc)
    in case sequence parsedModules of
         Left errMsg -> Left ("parse error: " <> errMsg)
@@ -219,7 +203,7 @@ buildFc2CasePrograms tc =
                               (desugarModuleFc2 desugarConfig fixtureBindings tcInterface)
                               fixtureTcResults
                        in if all ds2Success fixtureResults
-                            then lintResults (supportPrograms primitiveSupport <> map ds2Program fixtureResults) (map ds2Program fixtureResults)
+                            then lintAndRenderResults (supportPrograms primitiveSupport <> map ds2Program fixtureResults) fixtureResults
                             else Left (unlines (concatMap ds2Errors fixtureResults))
                     else Left ("typecheck error: " <> unlines [show d | r <- fixtureTcResults, d <- tcModuleDiagnostics r])
             ResolveResult {resolveErrors} ->
@@ -227,10 +211,29 @@ buildFc2CasePrograms tc =
   where
     parseFixtureModule input =
       parseModuleText (T.unpack (T.takeWhile (/= '\n') input)) (caseExtensions tc) input
-    lintResults programs fixturePrograms =
-      case lintPrograms programs of
-        [] -> Right (programs, fixturePrograms)
-        lintErrors -> Left (unlines ["System FC 2 lint error: " <> show lintError | lintError <- lintErrors])
+    lintAndRenderResults programs fixtureResults =
+      case renderResults fixtureResults of
+        Left renderError -> Left renderError
+        Right rendered ->
+          case lintPrograms programs of
+            [] -> Right rendered
+            lintErrors ->
+              Left
+                ( unlines ["System FC 2 lint error: " <> show lintError | lintError <- lintErrors]
+                    <> "\nSystem FC 2 output:\n"
+                    <> rendered
+                )
+    renderResults results =
+      unlines <$> traverse renderResult results
+    renderResult result =
+      let rendered = renderProgram (ds2Program result)
+       in case parseProgram (T.pack rendered) of
+            Left parseError -> Left ("System FC 2 round-trip parse error:\n" <> renderParseError parseError <> "\n" <> rendered)
+            Right parsed ->
+              let canonical = renderProgram parsed
+               in if canonical == rendered
+                    then Right rendered
+                    else Left ("System FC 2 round trip changed canonical syntax:\n" <> canonical <> "\noriginal:\n" <> rendered)
 
 preparePrimitiveSupport :: [(FilePath, Text)] -> Either String PrimitiveSupport
 preparePrimitiveSupport primitiveModules =

--- a/components/aihc-fc/src/Aihc/Fc2/Lint.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Lint.hs
@@ -13,7 +13,7 @@ where
 import Aihc.Fc2.Name
 import Aihc.Fc2.Parser (parseProgram, renderParseError)
 import Aihc.Fc2.Syntax
-import Aihc.Fc2.TypeOf
+import Aihc.Fc2.TypeOf hiding (coercionEndpoints)
 import Aihc.Fc2.Wired
 import Aihc.Resolve (PackageId (..), packageIdText)
 import Control.Monad (foldM, unless, when)

--- a/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/TypeOf.hs
@@ -21,6 +21,8 @@ module Aihc.Fc2.TypeOf
     substTypes,
     reduceType,
     typesEqual,
+    coercionEndpoints,
+    unwrapNewtype,
   )
 where
 
@@ -40,6 +42,7 @@ data TypeEnv = TypeEnv
   { tePrimPackage :: Maybe PackageId,
     teHeaders :: Map Name Type,
     teSynonyms :: Map Name Type,
+    teAxioms :: Map Name AxiomDecl,
     teBinders :: Map Name Type
   }
   deriving (Eq, Show)
@@ -50,6 +53,7 @@ emptyTypeEnv =
     { tePrimPackage = Nothing,
       teHeaders = Map.empty,
       teSynonyms = Map.empty,
+      teAxioms = Map.empty,
       teBinders = Map.empty
     }
 
@@ -80,7 +84,7 @@ addDecl env decl =
         { teHeaders = Map.insert (synName declaration) (headerType (synBinders declaration) (synResult declaration)) (teHeaders env),
           teSynonyms = Map.insert (synName declaration) (foldr TyForAll (synBody declaration) (synBinders declaration)) (teSynonyms env)
         }
-    DeclAxiom {} -> env
+    DeclAxiom declaration -> env {teAxioms = Map.insert (axiomName declaration) declaration (teAxioms env)}
     DeclVal declaration ->
       env {teHeaders = Map.insert (valName declaration) (valType declaration) (teHeaders env)}
     DeclForeignImport declaration ->
@@ -335,6 +339,84 @@ reduceType env ty =
       TyForAll binder {binderType = reduceType env (binderType binder)} (reduceType env body)
     TyEq left right ->
       TyEq (reduceType env left) (reduceType env right)
+
+coercionEndpoints :: TypeEnv -> Coercion -> Maybe (Type, Type)
+coercionEndpoints env coercion =
+  case coercion of
+    CoVar name ->
+      case Map.lookup name (teBinders env) of
+        Just (TyEq left right) -> Just (left, right)
+        _ -> Nothing
+    CoRefl ty -> Just (ty, ty)
+    CoSym inner -> swap <$> coercionEndpoints env inner
+    CoTrans first second -> do
+      (left, middle) <- coercionEndpoints env first
+      (middle', right) <- coercionEndpoints env second
+      if typesEqual env middle middle' then Just (left, right) else Nothing
+    CoTyConApp name arguments -> do
+      endpoints <- traverse (coercionEndpoints env) arguments
+      pure (foldl TyApp (TyCon name) (map fst endpoints), foldl TyApp (TyCon name) (map snd endpoints))
+    CoAxiom name arguments -> do
+      declaration <- Map.lookup name (teAxioms env)
+      if length arguments /= length (axiomBinders declaration)
+        then Nothing
+        else
+          let substitution = Map.fromList (zip (map binderName (axiomBinders declaration)) arguments)
+           in Just (substTypes substitution (axiomLeft declaration), substTypes substitution (axiomRight declaration))
+  where
+    swap (left, right) = (right, left)
+
+unwrapNewtype :: TypeEnv -> Type -> Maybe Type
+unwrapNewtype env source = listToMaybe (mapMaybe unwrap (Map.elems (teAxioms env)))
+  where
+    source' = reduceType env source
+    unwrap declaration
+      | axiomRole declaration /= Representational = Nothing
+      | otherwise = do
+          substitution <- matchTypes (Map.fromList [(binderName binder, Nothing) | binder <- axiomBinders declaration]) (reduceType env (axiomLeft declaration)) source'
+          resolved <- sequenceA substitution
+          pure (substTypes resolved (axiomRight declaration))
+
+    matchTypes substitution patternType actualType =
+      case patternType of
+        TyVar name
+          | Just current <- Map.lookup name substitution ->
+              case current of
+                Nothing -> Just (Map.insert name (Just actualType) substitution)
+                Just previous
+                  | typesEqual env previous actualType -> Just substitution
+                  | otherwise -> Nothing
+        TyVar name ->
+          case actualType of
+            TyVar actualName | name == actualName -> Just substitution
+            _ -> Nothing
+        TyCon name ->
+          case actualType of
+            TyCon actualName | name == actualName -> Just substitution
+            _ -> Nothing
+        TyApp function argument ->
+          case actualType of
+            TyApp actualFunction actualArgument ->
+              matchTypes substitution function actualFunction
+                >>= \next -> matchTypes next argument actualArgument
+            _ -> Nothing
+        TyFun r1 r2 argument result ->
+          case actualType of
+            TyFun actualR1 actualR2 actualArgument actualResult ->
+              matchTypes substitution r1 actualR1
+                >>= \s1 ->
+                  matchTypes s1 r2 actualR2
+                    >>= \s2 ->
+                      matchTypes s2 argument actualArgument
+                        >>= \s3 -> matchTypes s3 result actualResult
+            _ -> Nothing
+        TyForAll {} -> Nothing
+        TyEq left right ->
+          case actualType of
+            TyEq actualLeft actualRight ->
+              matchTypes substitution left actualLeft
+                >>= \next -> matchTypes next right actualRight
+            _ -> Nothing
 
 typesEqual :: TypeEnv -> Type -> Type -> Bool
 typesEqual env left right =

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -79,12 +79,10 @@ test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:
     test
-    ../aihc-fc/common
     ../../test/support
 
   main-is: Spec.hs
   other-modules:
-    Fc2Golden
     GrinGolden
     Test.Grin.Arbitrary
 

--- a/components/aihc-grin/aihc-grin.cabal
+++ b/components/aihc-grin/aihc-grin.cabal
@@ -22,6 +22,7 @@ library
     Aihc.Grin.Gc
     Aihc.Grin.Interpret
     Aihc.Grin.Lint
+    Aihc.Grin.Lower
     Aihc.Grin.Parser
     Aihc.Grin.Pretty
     Aihc.Grin.Snapshot
@@ -32,6 +33,8 @@ library
 
   hs-source-dirs: src
   build-depends:
+    aihc-fc,
+    aihc-resolve,
     aihc-tc,
     base >=4.16 && <5,
     bytestring,
@@ -60,6 +63,7 @@ library fuzz
     Test.Grin.Arbitrary
 
   build-depends:
+    aihc-fc,
     aihc-grin,
     aihc-tc,
     base >=4.16 && <5,
@@ -75,22 +79,33 @@ test-suite spec
   type: exitcode-stdio-1.0
   hs-source-dirs:
     test
+    ../aihc-fc/common
     ../../test/support
 
   main-is: Spec.hs
   other-modules:
+    Fc2Golden
+    GrinGolden
     Test.Grin.Arbitrary
 
   build-depends:
+    aeson,
+    aihc-fc,
     aihc-grin,
+    aihc-parser,
+    aihc-resolve,
     aihc-tc,
     base >=4.16 && <5,
     bytestring,
     containers,
+    directory,
+    filepath,
     hedgehog,
     tasty,
     tasty-hedgehog,
+    tasty-hunit,
     text,
+    yaml,
 
   ghc-options:
     -Wall

--- a/components/aihc-grin/src/Aihc/Grin.hs
+++ b/components/aihc-grin/src/Aihc/Grin.hs
@@ -20,6 +20,7 @@ module Aihc.Grin
     gcGrinProgram,
     gcUpdateFunction,
     lowerGc,
+    lowerProgram,
     lintProgram,
     GrinLintError (..),
     GrinParseError,
@@ -58,6 +59,7 @@ import Aihc.Grin.Cps
 import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcFunctionContinuations, gcGrinProgram, gcUpdateFunction, lowerGc)
 import Aihc.Grin.Interpret (InterpretError (..), RuntimeValue (..), interpretProgramBinding, interpretProgramFunctionSnapshot, interpretProgramIoBinding)
 import Aihc.Grin.Lint (GrinLintError (..), lintProgram)
+import Aihc.Grin.Lower (lowerProgram)
 import Aihc.Grin.Parser (GrinParseError, parseExpr, parseProgram, renderParseError)
 import Aihc.Grin.Pretty (renderExpr, renderProgram)
 import Aihc.Grin.Snapshot

--- a/components/aihc-grin/src/Aihc/Grin/Analysis.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Analysis.hs
@@ -58,6 +58,7 @@ freeValueVars :: GrinValue -> Set GrinVar
 freeValueVars value =
   case value of
     GrinVarValue var -> Set.singleton var
+    GrinGlobalValue {} -> Set.empty
     GrinLitValue {} -> Set.empty
 
 freeNodeVars :: GrinNode -> Set GrinVar

--- a/components/aihc-grin/src/Aihc/Grin/Cps.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Cps.hs
@@ -91,8 +91,7 @@ toCpsGrin sourceProgram = do
     CpsGrinProgram
       { cpsGrinProgram =
           program
-            { grinExternalFunctions = map addExternalContinuation (grinExternalFunctions program),
-              grinFunctions =
+            { grinFunctions =
                 functions
                   <> reverse (cpsGeneratedFunctionsRev finalState)
                   <> [updateFunction]
@@ -119,12 +118,6 @@ toCpsGrin sourceProgram = do
       functions <- mapM (transformFunction updateName) sourceFunctions
       updateFunction <- makeUpdateFunction updateName
       pure (functions, updateFunction)
-
-    addExternalContinuation info =
-      info
-        { grinCodeParameterLayouts =
-            grinCodeParameterLayouts info <> [[liftedGrinRep]]
-        }
 
 transformFunction :: FunctionName -> GrinFunction -> CpsM GrinFunction
 transformFunction updateName function = do
@@ -292,13 +285,13 @@ reifyContinuation updateName parent bound resultRep outerContinuation resultVars
   parentContinuation <-
     case outerContinuation of
       GrinVarValue var -> pure var
+      GrinGlobalValue {} -> lift (Left (CpsGrinInvalidContinuationParent parent))
       GrinLitValue {} -> lift (Left (CpsGrinInvalidContinuationParent parent))
   let freeCaptures = freeExprVars transformedBody `Set.intersection` bound
       captures = parentContinuation : Set.toAscList (Set.delete parentContinuation freeCaptures)
       continuationFunction =
         GrinFunction
           { grinFunctionName = continuationName,
-            grinFunctionLinkName = Nothing,
             grinFunctionParameters = captures <> resultVars,
             grinFunctionResultRep = resultRep,
             grinFunctionBody = transformedBody
@@ -333,6 +326,7 @@ makeCatchContinuation parent resultRep outerContinuation handler = do
   parentContinuation <-
     case outerContinuation of
       GrinVarValue var -> pure var
+      GrinGlobalValue {} -> lift (Left (CpsGrinInvalidContinuationParent parent))
       GrinLitValue {} -> lift (Left (CpsGrinInvalidContinuationParent parent))
   catchName <- freshContinuationName parent
   pointer <- freshVar "$cps_catch" liftedGrinRep
@@ -341,7 +335,6 @@ makeCatchContinuation parent resultRep outerContinuation handler = do
   let catchFunction =
         GrinFunction
           { grinFunctionName = catchName,
-            grinFunctionLinkName = Nothing,
             grinFunctionParameters = parentContinuation : capturedHandler : resultVars,
             grinFunctionResultRep = resultRep,
             grinFunctionBody = GrinContinue (GrinVarValue parentContinuation) (map GrinVarValue resultVars)
@@ -367,7 +360,6 @@ makeUpdateFunction updateName = do
   pure
     GrinFunction
       { grinFunctionName = updateName,
-        grinFunctionLinkName = Nothing,
         grinFunctionParameters = [outerContinuation, blackhole, result],
         grinFunctionResultRep = liftedGrinRep,
         grinFunctionBody =
@@ -450,12 +442,11 @@ maximumProgramVarUnique program =
   maximum
     ( 0
         : map (grinVarUnique . fst) (grinPrimitives program)
-          <> concatMap bindingUniques (grinWhnfGlobals program)
-          <> concatMap bindingUniques (grinCafs program)
+          <> concatMap bindingUniques (grinGlobals program)
           <> concatMap functionUniques (grinFunctions program)
     )
   where
-    bindingUniques (var, node) = grinVarUnique var : nodeUniques node
+    bindingUniques (_, node) = nodeUniques node
     functionUniques function =
       map grinVarUnique (grinFunctionParameters function)
         <> exprUniques (grinFunctionBody function)
@@ -513,6 +504,7 @@ valueUniques :: GrinValue -> [Int]
 valueUniques value =
   case value of
     GrinVarValue var -> [grinVarUnique var]
+    GrinGlobalValue {} -> []
     GrinLitValue {} -> []
 
 nodeUniques :: GrinNode -> [Int]

--- a/components/aihc-grin/src/Aihc/Grin/Gc.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Gc.hs
@@ -243,6 +243,7 @@ substituteValue :: Map GrinVar GrinVar -> GrinValue -> GrinValue
 substituteValue substitutions value =
   case value of
     GrinVarValue var -> GrinVarValue (Map.findWithDefault var var substitutions)
+    GrinGlobalValue {} -> value
     GrinLitValue {} -> value
 
 without :: [GrinVar] -> Map GrinVar GrinVar -> Map GrinVar GrinVar
@@ -253,16 +254,16 @@ maximumProgramVarUnique program =
   maximum
     ( 0
         : map (grinVarUnique . fst) (grinPrimitives program)
-          <> concatMap staticUniques (grinWhnfGlobals program)
-          <> concatMap staticUniques (grinCafs program)
+          <> concatMap staticUniques (grinGlobals program)
           <> concatMap functionUniques (grinFunctions program)
     )
   where
-    staticUniques (var, node) = grinVarUnique var : concatMap valueUnique (grinNodeFields node)
+    staticUniques (_, node) = concatMap valueUnique (grinNodeFields node)
     functionUniques function = map grinVarUnique (grinFunctionParameters function) <> exprUniques (grinFunctionBody function)
     valueUnique value =
       case value of
         GrinVarValue var -> [grinVarUnique var]
+        GrinGlobalValue {} -> []
         GrinLitValue {} -> []
     nodeUniques = concatMap valueUnique . grinNodeFields
     altUniques alternative = map grinVarUnique (grinAltBinders alternative) <> exprUniques (grinAltRhs alternative)

--- a/components/aihc-grin/src/Aihc/Grin/Interpret.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Interpret.hs
@@ -280,8 +280,7 @@ initialMachine program =
     globalNodes = Map.toAscList globalNodeMap
     globalNodeMap =
       Map.unions
-        [ Map.fromList [(grinVarName var, node) | (var, node) <- grinCafs program],
-          Map.fromList [(grinVarName var, node) | (var, node) <- grinWhnfGlobals program],
+        [ Map.fromList (grinGlobals program),
           Map.fromList
             [ (constructor, GrinNode (GrinConstructor constructor 0) [])
             | (constructor, layouts) <- builtinConstructors <> grinConstructors program,
@@ -300,6 +299,10 @@ initialMachine program =
           case Map.lookup (grinVarName var) globals of
             Just runtimeValue -> runtimeValue
             Nothing -> error ("GRIN interpreter found an unbound static global " <> T.unpack (grinVarName var))
+        GrinGlobalValue name ->
+          case Map.lookup name globals of
+            Just runtimeValue -> runtimeValue
+            Nothing -> error ("GRIN interpreter found an external static global " <> T.unpack name)
         GrinLitValue literal -> RuntimeLit literal
 
 evalScheduledExpr :: Env -> GrinExpr -> ScheduledContinuation -> EvalM [RuntimeValue]
@@ -619,6 +622,11 @@ materializeValue env value =
           case Map.lookup (grinVarName var) globals of
             Just runtimeValue -> pure runtimeValue
             Nothing -> throwInterpret (InterpretUnboundVariable var)
+    GrinGlobalValue name -> do
+      globals <- getsMachine machineGlobals
+      case Map.lookup name globals of
+        Just runtimeValue -> pure runtimeValue
+        Nothing -> throwInterpret (InterpretMissingBinding name)
     GrinLitValue literal -> pure (RuntimeLit literal)
 
 materializeNode :: Env -> GrinNode -> EvalM RuntimeValue

--- a/components/aihc-grin/src/Aihc/Grin/Lint.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lint.hs
@@ -17,8 +17,7 @@ import Data.Text qualified as T
 
 data GrinLintError
   = GrinLintDuplicateFunction !FunctionName
-  | GrinLintDuplicateWhnfGlobal !GrinVar
-  | GrinLintDuplicateCaf !GrinVar
+  | GrinLintDuplicateGlobal !Text
   | GrinLintUnboundVariable !GrinVar
   | GrinLintUnknownFunction !FunctionName
   | GrinLintUnknownPrimitive !Text
@@ -40,8 +39,6 @@ data LintEnv = LintEnv
     lintFunctionNodeArities :: !(Map FunctionName Int),
     lintFunctionResults :: !(Map FunctionName GrinRep),
     lintPrimitiveArities :: !(Map Text Int),
-    lintGlobalVars :: !(Set GrinVar),
-    lintGlobalNames :: !(Set Text),
     lintConstructorLayouts :: !(Map Text [[GrinRep]]),
     lintForeignCalls :: !(Map Text GrinForeignCall)
   }
@@ -50,55 +47,31 @@ lintProgram :: GrinProgram -> [GrinLintError]
 lintProgram program =
   duplicateFunctionErrors
     <> duplicateGlobalErrors
-    <> duplicateCafErrors
-    <> concatMap (lintWhnfGlobal env) (grinWhnfGlobals program)
-    <> concatMap (lintCaf env) (grinCafs program)
+    <> concatMap (lintGlobal env) (grinGlobals program)
     <> concatMap (lintFunction env) (grinFunctions program)
   where
     functions = grinFunctions program
-    globals = grinWhnfGlobals program
-    cafs = grinCafs program
+    globals = grinGlobals program
     functionNames = map grinFunctionName functions
-    globalVars = map fst globals
-    cafVars = map fst cafs
+    globalNames = map fst globals
     duplicateFunctionErrors = map GrinLintDuplicateFunction (duplicates functionNames)
-    duplicateGlobalErrors = map GrinLintDuplicateWhnfGlobal (duplicates globalVars)
-    duplicateCafErrors = map GrinLintDuplicateCaf (duplicates cafVars)
+    duplicateGlobalErrors = map GrinLintDuplicateGlobal (duplicates globalNames)
     env =
       LintEnv
         { lintFunctionArities =
             Map.fromList
-              ( [ (grinFunctionName function, length (grinFunctionParameters function))
-                | function <- functions
-                ]
-                  <> [ (grinCodeFunctionName info, length (concat (grinCodeParameterLayouts info)))
-                     | info <- grinExternalFunctions program
-                     ]
-              ),
+              [ (grinFunctionName function, length (grinFunctionParameters function))
+              | function <- functions
+              ],
           lintFunctionResults =
             Map.fromList
-              ( [(grinFunctionName function, grinFunctionResultRep function) | function <- functions]
-                  <> [(grinCodeFunctionName info, grinCodeResultRep info) | info <- grinExternalFunctions program]
-              ),
+              [(grinFunctionName function, grinFunctionResultRep function) | function <- functions],
           lintFunctionNodeArities =
             Map.fromList
-              ( [ (grinFunctionName function, semanticFunctionArity function)
-                | function <- functions
-                ]
-                  <> [ (grinCodeFunctionName info, semanticExternalArity info)
-                     | info <- grinExternalFunctions program
-                     ]
-              ),
+              [ (grinFunctionName function, semanticFunctionArity function)
+              | function <- functions
+              ],
           lintPrimitiveArities = Map.fromList [(grinVarName var, arity) | (var, arity) <- grinPrimitives program],
-          lintGlobalVars = Set.fromList (globalVars <> cafVars),
-          lintGlobalNames =
-            Set.fromList
-              ( [name | (name, layouts) <- builtinConstructors, null layouts]
-                  <> [name | (name, fields) <- grinConstructors program, null fields]
-                  <> grinExternalGlobals program
-                  <> map grinVarName globalVars
-                  <> map grinVarName cafVars
-              ),
           lintConstructorLayouts = Map.fromList (grinConstructors program),
           lintForeignCalls = Map.fromList [(grinForeignCallName call, call) | call <- grinForeignCalls program]
         }
@@ -109,24 +82,9 @@ lintProgram program =
           continuation : rest
             | grinVarName continuation == "$cps_return" -> length rest
           _ -> length (grinFunctionParameters function)
-    semanticExternalArity info =
-      case reverse (grinCodeParameterLayouts info) of
-        [BoxedRep Lifted] : rest -> length (concat (reverse rest))
-        _ -> length (concat (grinCodeParameterLayouts info))
 
-lintWhnfGlobal :: LintEnv -> (GrinVar, GrinNode) -> [GrinLintError]
-lintWhnfGlobal env (var, node) =
-  [ GrinLintRepresentationMismatch "global" (grinVarRuntimeRep var) liftedGrinRep
-  | grinVarRuntimeRep var /= liftedGrinRep
-  ]
-    <> lintNode env (lintGlobalVars env) node
-
-lintCaf :: LintEnv -> (GrinVar, GrinNode) -> [GrinLintError]
-lintCaf env (var, node) =
-  [ GrinLintRepresentationMismatch "CAF" (grinVarRuntimeRep var) liftedGrinRep
-  | grinVarRuntimeRep var /= liftedGrinRep
-  ]
-    <> lintNode env (lintGlobalVars env) node
+lintGlobal :: LintEnv -> (Text, GrinNode) -> [GrinLintError]
+lintGlobal env (_, node) = lintNode env Set.empty node
 
 lintFunction :: LintEnv -> GrinFunction -> [GrinLintError]
 lintFunction env function =
@@ -134,7 +92,7 @@ lintFunction env function =
     <> lintFunctionResult env (grinFunctionResultRep function) (grinFunctionBody function)
     <> lintExpr env bound (grinFunctionBody function)
   where
-    bound = Set.fromList (grinFunctionParameters function) <> lintGlobalVars env
+    bound = Set.fromList (grinFunctionParameters function)
     resultErrors =
       case exprRuntimeReps (grinFunctionBody function) of
         Just actual
@@ -274,12 +232,12 @@ lintAlt env bound alt =
   lintExpr env (Set.fromList (grinAltBinders alt) <> bound) (grinAltRhs alt)
 
 lintValue :: LintEnv -> Set GrinVar -> GrinValue -> [GrinLintError]
-lintValue env bound value =
+lintValue _ bound value =
   case value of
     GrinVarValue var
       | var `Set.member` bound -> []
-      | grinVarName var `Set.member` lintGlobalNames env -> []
       | otherwise -> [GrinLintUnboundVariable var]
+    GrinGlobalValue _ -> []
     GrinLitValue _ -> []
 
 lintNode :: LintEnv -> Set GrinVar -> GrinNode -> [GrinLintError]

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -1,0 +1,922 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Conservative lowering from System FC 2 to GRIN.
+module Aihc.Grin.Lower
+  ( lowerProgram,
+  )
+where
+
+import Aihc.Fc2 qualified as Fc2
+import Aihc.Fc2.TypeOf qualified as TypeOf
+import Aihc.Grin.Anf (normalizeGrinProgram)
+import Aihc.Grin.Syntax
+import Aihc.Resolve (PackageId (..))
+import Aihc.Tc.Types (Unique (..))
+import Control.Applicative ((<|>))
+import Control.Monad (foldM, zipWithM)
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.State.Strict (StateT, get, modify', runStateT)
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
+import Data.Maybe (listToMaybe, mapMaybe)
+import Data.Set (Set)
+import Data.Set qualified as Set
+import Data.Text (Text)
+import Data.Text qualified as T
+import Text.Read (readMaybe)
+
+data LowerEnv = LowerEnv
+  { lowerTypes :: !TypeOf.TypeEnv,
+    lowerLocals :: !(Map Fc2.Name [GrinVar]),
+    lowerTypeSubstitution :: !(Map Fc2.Name Fc2.Type),
+    lowerGlobalNames :: !(Map Fc2.Name Text)
+  }
+
+data LowerState = LowerState
+  { lowerNextUnique :: !Int,
+    lowerNextFunction :: !Int,
+    lowerFunctionsRev :: ![GrinFunction]
+  }
+
+type LowerM = StateT LowerState (Either String)
+
+data TopParts = TopParts
+  { topConstructors :: ![(Text, [[GrinRep]])],
+    topPrimitives :: ![(GrinVar, Int)],
+    topForeignCalls :: ![GrinForeignCall],
+    topGlobals :: ![(Text, GrinNode)]
+  }
+
+instance Semigroup TopParts where
+  left <> right =
+    TopParts
+      { topConstructors = topConstructors left <> topConstructors right,
+        topPrimitives = topPrimitives left <> topPrimitives right,
+        topForeignCalls = topForeignCalls left <> topForeignCalls right,
+        topGlobals = topGlobals left <> topGlobals right
+      }
+
+instance Monoid TopParts where
+  mempty = TopParts [] [] [] []
+
+lowerProgram :: TypeOf.TypeEnv -> Fc2.Program -> Either String GrinProgram
+lowerProgram types program = do
+  let globals = globalNameTable types
+      env = LowerEnv types Map.empty Map.empty globals
+      initialState = LowerState (-1000000000) 0 []
+  (parts, finalState) <- runStateT (foldMapM (lowerDecl env) (Fc2.programDecls program)) initialState
+  pure
+    ( normalizeGrinProgram
+        GrinProgram
+          { grinConstructors = topConstructors parts,
+            grinPrimitives = topPrimitives parts,
+            grinForeignCalls = topForeignCalls parts,
+            grinGlobals = topGlobals parts,
+            grinFunctions = reverse (lowerFunctionsRev finalState)
+          }
+    )
+
+foldMapM :: (Monad monad, Monoid value) => (item -> monad value) -> [item] -> monad value
+foldMapM action = foldM (\result item -> (result <>) <$> action item) mempty
+
+lowerDecl :: LowerEnv -> Fc2.Decl -> LowerM TopParts
+lowerDecl env declaration =
+  case declaration of
+    Fc2.DeclType value -> lowerTypeDecl env value
+    Fc2.DeclVal value -> lowerValueDecl env value
+    Fc2.DeclForeignImport value -> lowerForeignDecl env value
+    Fc2.DeclSynonym {} -> pure mempty
+    Fc2.DeclAxiom {} -> pure mempty
+
+lowerTypeDecl :: LowerEnv -> Fc2.TypeDecl -> LowerM TopParts
+lowerTypeDecl env declaration = do
+  converted <- mapM lowerConstructor (Fc2.typeCons declaration)
+  pure
+    mempty
+      { topConstructors = concatMap first converted,
+        topGlobals = concatMap second converted
+      }
+  where
+    first (constructors, _) = constructors
+    second (_, globals) = globals
+    lowerConstructor constructor = do
+      let name = Fc2.conName constructor
+          (typeBinders, monotype) = splitForAlls (applySubstitution env (Fc2.conType constructor))
+          constructorEnv = foldl extendTypeBinder env typeBinders
+      if "(#" `T.isPrefixOf` Fc2.nameText name
+        then pure ([], [])
+        else do
+          fieldTypes <- liftEither (constructorArgumentTypes monotype)
+          fieldLayouts <- mapM (runtimeComponents constructorEnv) fieldTypes
+          resultType <- liftEither (constructorResultType monotype)
+          resultRep <- runtimeRep constructorEnv resultType
+          case resultRep of
+            TupleRep {} -> pure ([], [])
+            _ -> do
+              globalName <- lookupGlobalName env name
+              let tag = constructorTag name
+              pure ([(tag, fieldLayouts)], [(globalName, GrinNode (GrinConstructor tag (length fieldTypes)) [])])
+
+lowerValueDecl :: LowerEnv -> Fc2.ValDecl -> LowerM TopParts
+lowerValueDecl env declaration = do
+  representation <- runtimeRep env (Fc2.valType declaration)
+  if representation /= liftedGrinRep
+    then throwLower ("GRIN does not support an unlifted top-level value: " <> show (Fc2.valName declaration))
+    else do
+      globalName <- lookupGlobalName env (Fc2.valName declaration)
+      node <- makeThunk env (Fc2.nameText (Fc2.valName declaration)) (Fc2.valBody declaration)
+      pure mempty {topGlobals = [(globalName, node)]}
+
+lowerForeignDecl :: LowerEnv -> Fc2.ForeignImportDecl -> LowerM TopParts
+lowerForeignDecl env declaration = do
+  let name = Fc2.foreignImportName declaration
+      sourceType = applySubstitution env (Fc2.foreignImportType declaration)
+      (typeBinders, monotype) = splitForAlls sourceType
+      foreignEnv = defaultRuntimeReps (foldl extendTypeBinder env typeBinders) typeBinders
+  (argumentTypes, resultType) <- splitOperationalFunctionType foreignEnv monotype
+  argumentGroups <-
+    mapM
+      (\(index, argumentType) -> freshVarsForType foreignEnv ("foreign_argument_" <> T.pack (show index), argumentType))
+      (zip [0 :: Int ..] argumentTypes)
+  resultRep <- runtimeRep foreignEnv resultType
+  functionName <- freshFunction (Fc2.nameText name <> "_foreign")
+  globalName <- lookupGlobalName env name
+  let parameters = concat argumentGroups
+      layouts = map (map grinVarRuntimeRep) argumentGroups
+      valueGroups = map (map GrinVarValue) argumentGroups
+      arity = length argumentTypes
+  (body, primitives, foreignCalls) <-
+    case Fc2.foreignImportCallingConvention declaration of
+      Fc2.Prim -> do
+        expression <- lowerPrimitiveBody resultRep (Fc2.nameText name) valueGroups
+        let primitive =
+              [ (GrinVar (Fc2.nameText name) (-2000000000 + arity) resultRep, arity)
+              | Fc2.nameText name `notElem` compilerPrimitives
+              ]
+        pure (expression, primitive, [])
+      Fc2.CCall specification -> do
+        let foreignCall = lowerForeignCall name specification
+        expression <- lowerForeignBody foreignEnv foreignCall argumentTypes valueGroups resultType
+        pure (expression, [], [foreignCall])
+  emitFunction
+    GrinFunction
+      { grinFunctionName = functionName,
+        grinFunctionParameters = parameters,
+        grinFunctionResultRep = resultRep,
+        grinFunctionBody = body
+      }
+  pure
+    mempty
+      { topPrimitives = primitives,
+        topForeignCalls = foreignCalls,
+        topGlobals = [(globalName, GrinNode (GrinClosure functionName layouts) [])]
+      }
+
+compilerPrimitives :: [Text]
+compilerPrimitives = ["aihcExit#", "unsafeCoerce#", "raise#", "catch#", "seq"]
+
+lowerPrimitiveBody :: GrinRep -> Text -> [[GrinValue]] -> LowerM GrinExpr
+lowerPrimitiveBody resultRep name valueGroups =
+  case (name, valueGroups) of
+    ("aihcExit#", (status : _) : _) -> pure (GrinExit status)
+    ("unsafeCoerce#", values : _) -> pure (GrinConstant values)
+    ("raise#", (exception : _) : _) -> pure (GrinThrow exception)
+    ("catch#", (action : _) : (handler : _) : state) -> pure (GrinCatch resultRep action handler (concat state))
+    ("seq", (first : _) : second : _) -> do
+      evaluated <- freshVar "seq" liftedGrinRep
+      pure (GrinBind [evaluated] (GrinEval liftedGrinRep first) (GrinConstant second))
+    _ -> pure (GrinPrimitiveCall resultRep name (concat valueGroups))
+
+lowerForeignBody :: LowerEnv -> GrinForeignCall -> [Fc2.Type] -> [[GrinValue]] -> Fc2.Type -> LowerM GrinExpr
+lowerForeignBody env foreignCall argumentTypes valueGroups resultType = do
+  operands <- concat <$> zipWithM (sourceValues env) argumentTypes valueGroups
+  resultValues <- sourceValueTypes env resultType
+  let signature = grinForeignCallSignature foreignCall
+      expectedOperands = grinForeignOperandReps signature
+      resultReps = grinForeignCallResultReps signature
+  if length operands /= length expectedOperands
+    then throwLower ("GRIN foreign source arguments do not match the C ABI: " <> T.unpack (grinForeignCallName foreignCall))
+    else case (resultValues, resultReps) of
+      ([(resultValueType, resultValueRep)], [foreignResultRep]) ->
+        adaptForeignOperands env (zip operands expectedOperands) $ \values ->
+          adaptForeignResult env resultValueType resultValueRep foreignResultRep (GrinForeignCallExpr foreignCall values)
+      _ -> throwLower ("GRIN foreign result does not match the C ABI: " <> T.unpack (grinForeignCallName foreignCall))
+
+sourceValues :: LowerEnv -> Fc2.Type -> [GrinValue] -> LowerM [(Fc2.Type, GrinValue)]
+sourceValues env sourceType values = do
+  types <- sourceValueTypes env sourceType
+  if length types == length values
+    then pure (zip (map fst types) values)
+    else throwLower ("GRIN cannot match source values to type: " <> show sourceType)
+
+sourceValueTypes :: LowerEnv -> Fc2.Type -> LowerM [(Fc2.Type, GrinRep)]
+sourceValueTypes env sourceType = do
+  representation <- runtimeRep env sourceType
+  case representation of
+    TupleRep fields -> do
+      let (_, arguments) = collectTypeApplications (reduce env sourceType)
+          fieldTypes = drop (length arguments - length fields) arguments
+      if length fieldTypes /= length fields
+        then throwLower ("GRIN cannot find unboxed tuple fields for type: " <> show sourceType)
+        else fmap concat (zipWithM sourceFieldTypes fieldTypes fields)
+    _ -> pure [(sourceType, component) | component <- runtimeRepComponents representation]
+  where
+    sourceFieldTypes fieldType fieldRep =
+      case runtimeRepComponents fieldRep of
+        [] -> pure []
+        [component] -> pure [(fieldType, component)]
+        _ -> throwLower ("GRIN does not support a nested tuple foreign value: " <> show fieldType)
+
+adaptForeignOperands :: LowerEnv -> [((Fc2.Type, GrinValue), GrinRep)] -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
+adaptForeignOperands env operands continuation = go [] operands
+  where
+    go values [] = continuation (reverse values)
+    go values (((sourceType, value), expectedRep) : rest)
+      | grinValueRuntimeRep value == expectedRep = go (value : values) rest
+      | isLiftedRuntimeRep (grinValueRuntimeRep value) = do
+          (tag, fieldRep) <- findUnaryConstructor env sourceType expectedRep
+          evaluated <- freshVar "foreign_box" liftedGrinRep
+          caseBinder <- freshVar "foreign_box_case" liftedGrinRep
+          field <- freshVar "foreign_field" fieldRep
+          body <- go (GrinVarValue field : values) rest
+          pure
+            ( GrinBind
+                [evaluated]
+                (GrinEval liftedGrinRep value)
+                ( GrinCase
+                    (GrinVarValue evaluated)
+                    caseBinder
+                    [GrinAlt (GrinDataAlt tag) [field] body]
+                )
+            )
+      | otherwise = throwLower ("GRIN cannot adapt a foreign argument representation: " <> show sourceType)
+
+adaptForeignResult :: LowerEnv -> Fc2.Type -> GrinRep -> GrinRep -> GrinExpr -> LowerM GrinExpr
+adaptForeignResult env sourceType sourceRep foreignRep foreignExpression
+  | sourceRep == foreignRep = pure foreignExpression
+  | isLiftedRuntimeRep sourceRep = do
+      (tag, fieldRep) <- findUnaryConstructor env sourceType foreignRep
+      result <- freshVar "foreign_result" fieldRep
+      pure
+        ( GrinBind
+            [result]
+            foreignExpression
+            (GrinStore (GrinNode (GrinConstructor tag 0) [GrinVarValue result]))
+        )
+  | otherwise = throwLower ("GRIN cannot adapt a foreign result representation: " <> show sourceType)
+
+findUnaryConstructor :: LowerEnv -> Fc2.Type -> GrinRep -> LowerM (Text, GrinRep)
+findUnaryConstructor env resultType expectedRep =
+  case listToMaybe (mapMaybe matchConstructor (Map.toAscList (TypeOf.teHeaders (lowerTypes env)))) of
+    Just result -> pure result
+    Nothing -> throwLower ("GRIN cannot find a unary constructor adapter for type: " <> show resultType)
+  where
+    matchConstructor (name, constructorType)
+      | Fc2.nameSort name /= Fc2.SortDataConstructor = Nothing
+      | otherwise = do
+          fieldTypes <- instantiateConstructorFields env constructorType resultType
+          case fieldTypes of
+            [fieldType] ->
+              case runStateT (runtimeRep env fieldType) (LowerState 0 0 []) of
+                Right (fieldRep, _)
+                  | fieldRep == expectedRep -> Just (constructorTag name, fieldRep)
+                _ -> Nothing
+            _ -> Nothing
+
+instantiateConstructorFields :: LowerEnv -> Fc2.Type -> Fc2.Type -> Maybe [Fc2.Type]
+instantiateConstructorFields env constructorType targetType = do
+  let (binders, monotype) = splitForAlls constructorType
+  (fieldTypes, constructorResult) <- either (const Nothing) Just (splitFunctionType monotype)
+  substitution <- matchTypeBinders env (Map.fromList [(Fc2.binderName binder, Nothing) | binder <- binders]) constructorResult targetType
+  resolved <- sequenceA substitution
+  pure (map (TypeOf.substTypes resolved) fieldTypes)
+
+matchTypeBinders :: LowerEnv -> Map Fc2.Name (Maybe Fc2.Type) -> Fc2.Type -> Fc2.Type -> Maybe (Map Fc2.Name (Maybe Fc2.Type))
+matchTypeBinders env substitution patternType actualType =
+  case (reduce env patternType, reduce env actualType) of
+    (Fc2.TyVar name, actual)
+      | Just current <- Map.lookup name substitution ->
+          case current of
+            Nothing -> Just (Map.insert name (Just actual) substitution)
+            Just previous
+              | TypeOf.typesEqual (lowerTypes env) previous actual -> Just substitution
+              | otherwise -> Nothing
+    (Fc2.TyVar name, Fc2.TyVar actualName)
+      | name == actualName -> Just substitution
+    (Fc2.TyCon name, Fc2.TyCon actualName)
+      | name == actualName -> Just substitution
+    (Fc2.TyApp function argument, Fc2.TyApp actualFunction actualArgument) ->
+      matchTypeBinders env substitution function actualFunction
+        >>= \next -> matchTypeBinders env next argument actualArgument
+    (Fc2.TyFun r1 r2 argument result, Fc2.TyFun actualR1 actualR2 actualArgument actualResult) ->
+      matchTypeBinders env substitution r1 actualR1
+        >>= \s1 ->
+          matchTypeBinders env s1 r2 actualR2
+            >>= \s2 ->
+              matchTypeBinders env s2 argument actualArgument
+                >>= \s3 -> matchTypeBinders env s3 result actualResult
+    (Fc2.TyEq left right, Fc2.TyEq actualLeft actualRight) ->
+      matchTypeBinders env substitution left actualLeft
+        >>= \next -> matchTypeBinders env next right actualRight
+    _ -> Nothing
+
+collectTypeApplications :: Fc2.Type -> (Fc2.Type, [Fc2.Type])
+collectTypeApplications = go []
+  where
+    go arguments (Fc2.TyApp function argument) = go (argument : arguments) function
+    go arguments function = (function, arguments)
+
+lowerExpr :: LowerEnv -> Fc2.Expr -> LowerM GrinExpr
+lowerExpr env expression =
+  case expression of
+    Fc2.ExVar name -> lowerVariable env name
+    Fc2.ExLit literal -> GrinConstant . pure . GrinLitValue <$> lowerLiteral env literal
+    Fc2.ExApp function argument -> lowerApplication env function argument
+    Fc2.ExTyApp (Fc2.ExTyLam binder body) argument ->
+      lowerExpr env {lowerTypeSubstitution = Map.insert (Fc2.binderName binder) (applySubstitution env argument) (lowerTypeSubstitution env)} body
+    Fc2.ExTyApp function _ -> lowerExpr env function
+    Fc2.ExLam {} -> GrinStore <$> makeClosure env expression
+    Fc2.ExTyLam binder body -> lowerExpr (extendTypeBinder env binder) body
+    Fc2.ExLet binding body -> lowerLet env binding body
+    Fc2.ExRec bindings body -> lowerRec env bindings body
+    Fc2.ExCase scrutinee binder resultType alternatives -> lowerCase env scrutinee binder resultType alternatives
+    Fc2.ExCast inner _ -> lowerExpr env inner
+
+lowerVariable :: LowerEnv -> Fc2.Name -> LowerM GrinExpr
+lowerVariable env name = do
+  ty <- lookupNameType env name
+  representation <- runtimeRep env ty
+  let components = runtimeRepComponents representation
+  case Map.lookup name (lowerLocals env) of
+    Just variables ->
+      if isLiftedRuntimeRep representation
+        then case variables of
+          [variable] -> pure (GrinEval representation (GrinVarValue variable))
+          _ -> throwLower ("GRIN expected one lifted local value: " <> show name)
+        else pure (GrinConstant (map GrinVarValue variables))
+    Nothing
+      | null components -> pure (GrinConstant [])
+      | isLiftedRuntimeRep representation -> do
+          globalName <- lookupGlobalName env name
+          pure (GrinEval representation (GrinGlobalValue globalName))
+      | otherwise -> throwLower ("GRIN does not support an imported unlifted value: " <> show name)
+
+lowerApplication :: LowerEnv -> Fc2.Expr -> Fc2.Expr -> LowerM GrinExpr
+lowerApplication env function argument = do
+  let application = Fc2.ExApp function argument
+  resultType <- expressionType env application
+  resultRep <- runtimeRep env resultType
+  case (resultRep, collectApplications application) of
+    (_, (Fc2.ExVar name, arguments))
+      | Just arity <- Map.lookup (Fc2.nameText name) specialPrimitiveArities,
+        length arguments == arity ->
+          lowerSpecialApplication env resultRep (Fc2.nameText name) arguments
+    (TupleRep {}, (Fc2.ExVar name, arguments))
+      | "(#" `T.isPrefixOf` Fc2.nameText name -> lowerTupleArguments env arguments
+    _ ->
+      lowerLazySingle env "function" function $ \functionValue -> do
+        evaluated <- freshVar "function_whnf" liftedGrinRep
+        lowerArgument env argument $ \argumentValues ->
+          pure
+            ( GrinBind
+                [evaluated]
+                (GrinEval liftedGrinRep functionValue)
+                (GrinApply resultRep (GrinVarValue evaluated) argumentValues)
+            )
+
+collectApplications :: Fc2.Expr -> (Fc2.Expr, [Fc2.Expr])
+collectApplications expression = go expression []
+  where
+    go (Fc2.ExApp function argument) arguments = go function (argument : arguments)
+    go (Fc2.ExTyApp function _) arguments = go function arguments
+    go (Fc2.ExCast function _) arguments = go function arguments
+    go function arguments = (function, arguments)
+
+lowerTupleArguments :: LowerEnv -> [Fc2.Expr] -> LowerM GrinExpr
+lowerTupleArguments env = go []
+  where
+    go values [] = pure (GrinConstant values)
+    go values (argument : arguments) =
+      lowerArgument env argument (\newValues -> go (values <> newValues) arguments)
+
+specialPrimitiveArities :: Map Text Int
+specialPrimitiveArities = Map.fromList [("aihcExit#", 2), ("unsafeCoerce#", 1), ("raise#", 1), ("catch#", 3), ("seq", 2)]
+
+lowerSpecialApplication :: LowerEnv -> GrinRep -> Text -> [Fc2.Expr] -> LowerM GrinExpr
+lowerSpecialApplication env resultRep name arguments =
+  case (name, arguments) of
+    ("aihcExit#", status : state : _) ->
+      lowerArgument env status $ \case
+        value : _ -> lowerArgument env state (const (pure (GrinExit value)))
+        [] -> throwLower "GRIN process exit requires a status value"
+    ("unsafeCoerce#", value : _) -> lowerArgument env value (pure . GrinConstant)
+    ("raise#", exception : _) ->
+      lowerLazySingle env "exception" exception (pure . GrinThrow)
+    ("catch#", action : handler : state : _) ->
+      lowerLazySingle env "action" action $ \actionValue ->
+        lowerLazySingle env "handler" handler $ \handlerValue ->
+          lowerArgument env state (pure . GrinCatch resultRep actionValue handlerValue)
+    ("seq", first : second : _) ->
+      lowerLazySingle env "seq_argument" first $ \firstValue -> do
+        evaluated <- freshVar "seq" liftedGrinRep
+        rest <- lowerArgument env second (pure . GrinConstant)
+        pure (GrinBind [evaluated] (GrinEval liftedGrinRep firstValue) rest)
+    _ -> throwLower ("GRIN cannot lower compiler primitive application: " <> T.unpack name)
+
+lowerArgument :: LowerEnv -> Fc2.Expr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerArgument env expression continuation = do
+  representation <- expressionRuntimeRep env expression
+  if null (runtimeRepComponents representation)
+    then continuation []
+    else
+      if isLiftedRuntimeRep representation
+        then lowerLazySingle env "argument" expression (continuation . (: []))
+        else bindExpression env "argument" expression continuation
+
+lowerLazySingle :: LowerEnv -> Text -> Fc2.Expr -> (GrinValue -> LowerM GrinExpr) -> LowerM GrinExpr
+lowerLazySingle env hint expression continuation =
+  case expression of
+    Fc2.ExVar name ->
+      case Map.lookup name (lowerLocals env) of
+        Just [variable] -> continuation (GrinVarValue variable)
+        Just _ -> throwLower ("GRIN expected one lazy local value: " <> show name)
+        Nothing -> lookupGlobalName env name >>= continuation . GrinGlobalValue
+    Fc2.ExLit literal@Fc2.LitString {} -> lowerLiteral env literal >>= continuation . GrinLitValue
+    Fc2.ExTyApp inner _ -> lowerLazySingle env hint inner continuation
+    Fc2.ExCast inner _ -> lowerLazySingle env hint inner continuation
+    _ -> do
+      node <- makeThunk env hint expression
+      pointer <- freshVar hint liftedGrinRep
+      rest <- continuation (GrinVarValue pointer)
+      pure (GrinBind [pointer] (GrinStore node) rest)
+
+bindExpression :: LowerEnv -> Text -> Fc2.Expr -> ([GrinValue] -> LowerM GrinExpr) -> LowerM GrinExpr
+bindExpression env hint expression continuation = do
+  representation <- expressionRuntimeRep env expression
+  variables <- freshVars hint representation
+  valueExpression <- lowerExpr env expression
+  rest <- continuation (map GrinVarValue variables)
+  pure (bindIfNeeded variables valueExpression rest)
+
+lowerLet :: LowerEnv -> Fc2.Bind -> Fc2.Expr -> LowerM GrinExpr
+lowerLet env binding body = do
+  let binder = Fc2.bindBinder binding
+  representation <- runtimeRep env (applySubstitution env (Fc2.binderType binder))
+  variables <- freshVars (Fc2.nameText (Fc2.binderName binder)) representation
+  let bodyEnv = bindLocal env binder variables
+  loweredBody <- lowerExpr bodyEnv body
+  if isLiftedRuntimeRep representation
+    then do
+      node <- makeThunk env (Fc2.nameText (Fc2.binderName binder)) (Fc2.bindRhs binding)
+      pure (GrinBind variables (GrinStore node) loweredBody)
+    else do
+      loweredRhs <- lowerExpr env (Fc2.bindRhs binding)
+      pure (bindIfNeeded variables loweredRhs loweredBody)
+
+lowerRec :: LowerEnv -> [Fc2.Bind] -> Fc2.Expr -> LowerM GrinExpr
+lowerRec env bindings body = do
+  variables <- mapM makeVariables bindings
+  let recursiveEnv = foldl bindOne env (zip bindings variables)
+  nodes <- mapM (makeBindingNode recursiveEnv) bindings
+  loweredBody <- lowerExpr recursiveEnv body
+  pure (GrinStoreRec (zip (concat variables) nodes) loweredBody)
+  where
+    makeVariables binding = do
+      let binder = Fc2.bindBinder binding
+      representation <- runtimeRep env (applySubstitution env (Fc2.binderType binder))
+      if isLiftedRuntimeRep representation
+        then (: []) <$> freshVar (Fc2.nameText (Fc2.binderName binder)) representation
+        else throwLower ("GRIN does not support an unlifted recursive binding: " <> show (Fc2.binderName binder))
+    bindOne current (binding, vars) = bindLocal current (Fc2.bindBinder binding) vars
+    makeBindingNode recursiveEnv binding = makeThunk recursiveEnv (Fc2.nameText (Fc2.binderName (Fc2.bindBinder binding))) (Fc2.bindRhs binding)
+
+lowerCase :: LowerEnv -> Fc2.Expr -> Fc2.Binder -> Fc2.Type -> [Fc2.Alt] -> LowerM GrinExpr
+lowerCase env scrutinee binder _ alternatives = do
+  representation <- expressionRuntimeRep env scrutinee
+  case representation of
+    TupleRep fields -> lowerTupleCase env scrutinee binder fields alternatives
+    _ ->
+      bindExpression env "case_value" scrutinee $ \case
+        [value] -> do
+          caseBinder <- freshVar (Fc2.nameText (Fc2.binderName binder)) representation
+          loweredAlternatives <- mapM (lowerAlt (bindLocal env binder [caseBinder])) alternatives
+          pure (GrinCase value caseBinder loweredAlternatives)
+        _ -> throwLower "GRIN case expected one scrutinee value"
+
+lowerTupleCase :: LowerEnv -> Fc2.Expr -> Fc2.Binder -> [GrinRep] -> [Fc2.Alt] -> LowerM GrinExpr
+lowerTupleCase env scrutinee binder _fields alternatives = do
+  alternative <-
+    case alternatives of
+      first : _ -> pure first
+      [] -> throwLower "GRIN cannot lower an empty unboxed tuple case"
+  fieldVariables <- mapM (freshVarsForBinder env) (Fc2.altBinders alternative)
+  let values = concat fieldVariables
+      binderEnv = bindLocal env binder values
+      alternativeEnv = foldl bindPair binderEnv (zip (Fc2.altBinders alternative) fieldVariables)
+  loweredRhs <- lowerExpr alternativeEnv (Fc2.altRhs alternative)
+  loweredScrutinee <- lowerExpr env scrutinee
+  pure (bindIfNeeded values loweredScrutinee loweredRhs)
+  where
+    bindPair current (fieldBinder, vars) = bindLocal current fieldBinder vars
+
+lowerAlt :: LowerEnv -> Fc2.Alt -> LowerM GrinAlt
+lowerAlt env alternative = do
+  binderGroups <- mapM (freshVarsForBinder env) (Fc2.altBinders alternative)
+  let bodyEnv = foldl bindPair env (zip (Fc2.altBinders alternative) binderGroups)
+  body <- lowerExpr bodyEnv (Fc2.altRhs alternative)
+  alternativeConstructor <- lowerAltCon env (Fc2.altCon alternative)
+  pure
+    GrinAlt
+      { grinAltCon = alternativeConstructor,
+        grinAltBinders = concat binderGroups,
+        grinAltRhs = body
+      }
+  where
+    bindPair current (binder, vars) = bindLocal current binder vars
+
+lowerAltCon :: LowerEnv -> Fc2.AltCon -> LowerM GrinAltCon
+lowerAltCon env alternative =
+  case alternative of
+    Fc2.AltData name -> pure (GrinDataAlt (constructorTag name))
+    Fc2.AltLit literal -> GrinLitAlt <$> lowerLiteral env literal
+    Fc2.AltDefault -> pure GrinDefaultAlt
+
+makeThunk :: LowerEnv -> Text -> Fc2.Expr -> LowerM GrinNode
+makeThunk env hint expression = do
+  representation <- expressionRuntimeRep env expression
+  if not (isLiftedRuntimeRep representation)
+    then throwLower ("GRIN cannot suspend an unlifted expression with representation " <> show representation)
+    else do
+      captures <- capturedVariables env expression
+      functionName <- freshFunction (hint <> "_thunk")
+      body <- lowerExpr env expression
+      emitFunction
+        GrinFunction
+          { grinFunctionName = functionName,
+            grinFunctionParameters = captures,
+            grinFunctionResultRep = representation,
+            grinFunctionBody = body
+          }
+      pure (GrinNode (GrinThunk functionName) (map GrinVarValue captures))
+
+makeClosure :: LowerEnv -> Fc2.Expr -> LowerM GrinNode
+makeClosure env expression = do
+  let (bodyEnv0, binders, body) = collectLambdas env expression
+  captures <- capturedVariables env expression
+  parameterGroups <- mapM (freshVarsForBinder bodyEnv0) binders
+  let bodyEnv = foldl bindPair bodyEnv0 (zip binders parameterGroups)
+  bodyRep <- expressionRuntimeRep bodyEnv body
+  loweredBody <- lowerExpr bodyEnv body
+  functionName <- freshFunction "closure"
+  emitFunction
+    GrinFunction
+      { grinFunctionName = functionName,
+        grinFunctionParameters = captures <> concat parameterGroups,
+        grinFunctionResultRep = bodyRep,
+        grinFunctionBody = loweredBody
+      }
+  pure
+    ( GrinNode
+        (GrinClosure functionName (map (map grinVarRuntimeRep) parameterGroups))
+        (map GrinVarValue captures)
+    )
+  where
+    bindPair current (binder, vars) = bindLocal current binder vars
+
+collectLambdas :: LowerEnv -> Fc2.Expr -> (LowerEnv, [Fc2.Binder], Fc2.Expr)
+collectLambdas env expression =
+  case expression of
+    Fc2.ExLam binder body ->
+      let (bodyEnv, binders, result) = collectLambdas env body
+       in (bodyEnv, binder : binders, result)
+    Fc2.ExTyLam binder body -> collectLambdas (extendTypeBinder env binder) body
+    _ -> (env, [], expression)
+
+capturedVariables :: LowerEnv -> Fc2.Expr -> LowerM [GrinVar]
+capturedVariables env expression =
+  pure
+    ( concat
+        [ variables
+        | name <- Set.toAscList (freeVariables expression),
+          Just variables <- [Map.lookup name (lowerLocals env)]
+        ]
+    )
+
+freeVariables :: Fc2.Expr -> Set Fc2.Name
+freeVariables expression =
+  case expression of
+    Fc2.ExVar name -> Set.singleton name
+    Fc2.ExLit {} -> Set.empty
+    Fc2.ExApp function argument -> freeVariables function <> freeVariables argument
+    Fc2.ExTyApp function _ -> freeVariables function
+    Fc2.ExLam binder body -> Set.delete (Fc2.binderName binder) (freeVariables body)
+    Fc2.ExTyLam _ body -> freeVariables body
+    Fc2.ExLet binding body -> freeVariables (Fc2.bindRhs binding) <> Set.delete (Fc2.binderName (Fc2.bindBinder binding)) (freeVariables body)
+    Fc2.ExRec bindings body ->
+      let names = Set.fromList (map (Fc2.binderName . Fc2.bindBinder) bindings)
+       in (foldMap (freeVariables . Fc2.bindRhs) bindings <> freeVariables body) `Set.difference` names
+    Fc2.ExCase scrutinee binder _ alternatives ->
+      freeVariables scrutinee
+        <> Set.delete (Fc2.binderName binder) (foldMap freeAltVariables alternatives)
+    Fc2.ExCast inner _ -> freeVariables inner
+
+freeAltVariables :: Fc2.Alt -> Set Fc2.Name
+freeAltVariables alternative =
+  freeVariables (Fc2.altRhs alternative)
+    `Set.difference` Set.fromList (map Fc2.binderName (Fc2.altBinders alternative))
+
+expressionRuntimeRep :: LowerEnv -> Fc2.Expr -> LowerM GrinRep
+expressionRuntimeRep env expression =
+  case expression of
+    Fc2.ExLit literal -> literalRep env literal
+    _ -> expressionType env expression >>= runtimeRep env
+
+expressionType :: LowerEnv -> Fc2.Expr -> LowerM Fc2.Type
+expressionType env expression =
+  case expression of
+    Fc2.ExVar name -> lookupNameType env name
+    Fc2.ExLit {} -> throwLower "GRIN cannot infer a source type for this literal"
+    Fc2.ExApp function _ -> do
+      functionType <- expressionType env function
+      case reduce env functionType of
+        Fc2.TyFun _ _ _ result -> pure result
+        other -> throwLower ("GRIN application has a non-function type: " <> show other)
+    Fc2.ExTyApp function argument -> do
+      functionType <- expressionType env function
+      case reduce env functionType of
+        Fc2.TyForAll binder body -> pure (TypeOf.substType (Fc2.binderName binder) (applySubstitution env argument) body)
+        other -> throwLower ("GRIN type application has a non-forall type: " <> show other)
+    Fc2.ExLam binder body -> do
+      bodyType <- expressionType (extendTypeBinder env binder) body
+      argumentRep <- repType env (Fc2.binderType binder)
+      resultRep <- repType env bodyType
+      pure (Fc2.TyFun argumentRep resultRep (applySubstitution env (Fc2.binderType binder)) bodyType)
+    Fc2.ExTyLam binder body -> Fc2.TyForAll binder <$> expressionType (extendTypeBinder env binder) body
+    Fc2.ExLet binding body -> expressionType (extendTermBinder (Fc2.bindBinder binding) env) body
+    Fc2.ExRec bindings body -> expressionType (foldl (flip (extendTermBinder . Fc2.bindBinder)) env bindings) body
+    Fc2.ExCase _ _ resultType _ -> pure (applySubstitution env resultType)
+    Fc2.ExCast _ coercion ->
+      case TypeOf.coercionEndpoints (lowerTypes env) coercion of
+        Just (_, target) -> pure (applySubstitution env target)
+        Nothing -> throwLower ("GRIN cannot determine coercion endpoints: " <> show coercion)
+
+runtimeRep :: LowerEnv -> Fc2.Type -> LowerM GrinRep
+runtimeRep env sourceType =
+  case TypeOf.unwrapNewtype (lowerTypes env) appliedType of
+    Just unwrapped
+      | not (TypeOf.typesEqual (lowerTypes env) appliedType unwrapped) -> runtimeRep env unwrapped
+    _ -> directRuntimeRep env appliedType
+  where
+    appliedType = applySubstitution env sourceType
+
+directRuntimeRep :: LowerEnv -> Fc2.Type -> LowerM GrinRep
+directRuntimeRep env sourceType = do
+  representation <-
+    maybe
+      (throwLower ("GRIN cannot find a runtime representation for type: " <> show sourceType))
+      pure
+      (TypeOf.repOf (lowerTypes env) sourceType)
+  convertRep env representation
+
+repType :: LowerEnv -> Fc2.Type -> LowerM Fc2.Type
+repType env sourceType =
+  maybe
+    (throwLower ("GRIN cannot find a runtime representation type for: " <> show sourceType))
+    pure
+    (TypeOf.repOf (lowerTypes env) (applySubstitution env sourceType))
+
+runtimeComponents :: LowerEnv -> Fc2.Type -> LowerM [GrinRep]
+runtimeComponents env sourceType = runtimeRepComponents <$> runtimeRep env sourceType
+
+convertRep :: LowerEnv -> Fc2.Type -> LowerM GrinRep
+convertRep env sourceRep =
+  case reduce env sourceRep of
+    Fc2.TyVar name -> throwLower ("GRIN does not support a variable runtime representation: " <> show name)
+    Fc2.TyCon name -> simpleRep (Fc2.nameText name)
+    Fc2.TyApp (Fc2.TyCon name) levity
+      | Fc2.nameText name == "BoxedRep" -> BoxedRep <$> convertLevity levity
+    Fc2.TyApp (Fc2.TyCon name) fields
+      | Fc2.nameText name == "TupleRep" -> TupleRep <$> convertRepList env fields
+      | Fc2.nameText name == "SumRep" -> SumRep <$> convertRepList env fields
+    Fc2.TyApp (Fc2.TyApp (Fc2.TyCon name) count) element
+      | Fc2.nameText name == "VecRep" -> VecRep <$> readNamed "vector count" count <*> readNamed "vector element" element
+    other -> throwLower ("GRIN does not support runtime representation: " <> show other)
+
+simpleRep :: Text -> LowerM GrinRep
+simpleRep name =
+  case name of
+    "LiftedRep" -> pure liftedGrinRep
+    "UnliftedRep" -> pure (BoxedRep Unlifted)
+    "IntRep" -> pure IntRep
+    "Int8Rep" -> pure Int8Rep
+    "Int16Rep" -> pure Int16Rep
+    "Int32Rep" -> pure Int32Rep
+    "Int64Rep" -> pure Int64Rep
+    "WordRep" -> pure WordRep
+    "Word8Rep" -> pure Word8Rep
+    "Word16Rep" -> pure Word16Rep
+    "Word32Rep" -> pure Word32Rep
+    "Word64Rep" -> pure Word64Rep
+    "AddrRep" -> pure AddrRep
+    "FloatRep" -> pure FloatRep
+    "DoubleRep" -> pure DoubleRep
+    _ -> throwLower ("GRIN does not know runtime representation: " <> T.unpack name)
+
+convertLevity :: Fc2.Type -> LowerM GrinLevity
+convertLevity levity =
+  case levity of
+    Fc2.TyCon name
+      | Fc2.nameText name == "Lifted" -> pure Lifted
+      | Fc2.nameText name == "Unlifted" -> pure Unlifted
+    _ -> throwLower ("GRIN does not support levity: " <> show levity)
+
+convertRepList :: LowerEnv -> Fc2.Type -> LowerM [GrinRep]
+convertRepList env list =
+  case reduce env list of
+    Fc2.TyApp (Fc2.TyCon name) _
+      | Fc2.nameText name == "[]" -> pure []
+    Fc2.TyApp (Fc2.TyApp (Fc2.TyApp (Fc2.TyCon name) _) item) rest
+      | Fc2.nameText name == ":" -> (:) <$> convertRep env item <*> convertRepList env rest
+    other -> throwLower ("GRIN does not support this runtime representation list: " <> show other)
+
+readNamed :: (Read value) => String -> Fc2.Type -> LowerM value
+readNamed label ty =
+  case ty of
+    Fc2.TyCon name ->
+      maybe (throwLower ("GRIN does not know " <> label <> ": " <> T.unpack (Fc2.nameText name))) pure (readMaybe (T.unpack (Fc2.nameText name)))
+    _ -> throwLower ("GRIN does not support " <> label <> ": " <> show ty)
+
+literalRep :: LowerEnv -> Fc2.Literal -> LowerM GrinRep
+literalRep env literal =
+  case literal of
+    Fc2.LitInt representation _ -> convertRep env representation
+    Fc2.LitChar representation _ -> convertRep env representation
+    Fc2.LitString {} -> pure liftedGrinRep
+    Fc2.LitAddr {} -> pure AddrRep
+
+lowerLiteral :: LowerEnv -> Fc2.Literal -> LowerM GrinLiteral
+lowerLiteral env literal =
+  case literal of
+    Fc2.LitInt representation value -> GrinLitInt <$> convertRep env representation <*> pure value
+    Fc2.LitChar representation value -> GrinLitChar <$> convertRep env representation <*> pure value
+    Fc2.LitString value -> pure (GrinLitString value)
+    Fc2.LitAddr _ value -> pure (GrinLitAddr value)
+
+lowerForeignCall :: Fc2.Name -> Fc2.CCallSpec -> GrinForeignCall
+lowerForeignCall name specification =
+  GrinForeignCall
+    { grinForeignCallName = Fc2.nameText name,
+      grinForeignCallSymbol = Fc2.ccallSymbol specification,
+      grinForeignCallSignature =
+        GrinForeignSignature
+          { grinForeignArgumentTypes = map lowerForeignType (Fc2.ccallArgumentTypes specification),
+            grinForeignResultType = lowerForeignType (Fc2.ccallResultType specification),
+            grinForeignEffect =
+              case Fc2.ccallEffect specification of
+                Fc2.ForeignPure -> GrinForeignPure
+                Fc2.ForeignRealWorld -> GrinForeignRealWorld
+          }
+    }
+
+lowerForeignType :: Fc2.CAbiType -> GrinForeignType
+lowerForeignType foreignType =
+  case foreignType of
+    Fc2.CAbiInt -> GrinForeignInt
+    Fc2.CAbiInt32 -> GrinForeignInt32
+    Fc2.CAbiWord64 -> GrinForeignWord64
+    Fc2.CAbiAddr -> GrinForeignAddr
+
+splitFunctionType :: Fc2.Type -> Either String ([Fc2.Type], Fc2.Type)
+splitFunctionType sourceType =
+  case sourceType of
+    Fc2.TyForAll _ body -> splitFunctionType body
+    Fc2.TyFun _ _ argument result -> do
+      (arguments, finalResult) <- splitFunctionType result
+      pure (argument : arguments, finalResult)
+    _ -> pure ([], sourceType)
+
+splitOperationalFunctionType :: LowerEnv -> Fc2.Type -> LowerM ([Fc2.Type], Fc2.Type)
+splitOperationalFunctionType env sourceType =
+  case reduce env sourceType of
+    Fc2.TyForAll binder body -> splitOperationalFunctionType (extendTypeBinder env binder) body
+    Fc2.TyFun _ _ argument result -> do
+      (arguments, finalResult) <- splitOperationalFunctionType env result
+      pure (argument : arguments, finalResult)
+    other ->
+      case TypeOf.unwrapNewtype (lowerTypes env) other of
+        Just unwrapped
+          | not (TypeOf.typesEqual (lowerTypes env) other unwrapped) -> splitOperationalFunctionType env unwrapped
+        _ -> pure ([], other)
+
+splitForAlls :: Fc2.Type -> ([Fc2.Binder], Fc2.Type)
+splitForAlls sourceType =
+  case sourceType of
+    Fc2.TyForAll binder body ->
+      let (binders, result) = splitForAlls body
+       in (binder : binders, result)
+    _ -> ([], sourceType)
+
+constructorArgumentTypes :: Fc2.Type -> Either String [Fc2.Type]
+constructorArgumentTypes sourceType = fst <$> splitFunctionType sourceType
+
+constructorResultType :: Fc2.Type -> Either String Fc2.Type
+constructorResultType sourceType = snd <$> splitFunctionType sourceType
+
+globalNameTable :: TypeOf.TypeEnv -> Map Fc2.Name Text
+globalNameTable types =
+  Map.fromList
+    [ (name, stableGlobalName name)
+    | name <- Map.keys (TypeOf.teHeaders types),
+      Fc2.nameSort name `elem` [Fc2.SortValue, Fc2.SortDataConstructor]
+    ]
+
+stableGlobalName :: Fc2.Name -> Text
+stableGlobalName name =
+  case Fc2.nameOrigin name of
+    Fc2.OriginTop (PackageId packageName) moduleName ->
+      T.intercalate "\0" [packageName, moduleName, Fc2.nameText name]
+    Fc2.OriginLocal (Unique unique) -> Fc2.nameText name <> "\0" <> T.pack (show unique)
+
+constructorTag :: Fc2.Name -> Text
+constructorTag name =
+  case Fc2.nameOrigin name of
+    Fc2.OriginTop (PackageId packageName) moduleName ->
+      (if packageName == "" then "" else packageName <> ":") <> moduleName <> "." <> Fc2.nameText name
+    Fc2.OriginLocal {} -> Fc2.nameText name
+
+lookupGlobalName :: LowerEnv -> Fc2.Name -> LowerM Text
+lookupGlobalName env name =
+  maybe (throwLower ("GRIN has no global name for: " <> show name)) pure (Map.lookup name (lowerGlobalNames env))
+
+lookupNameType :: LowerEnv -> Fc2.Name -> LowerM Fc2.Type
+lookupNameType env name =
+  case Map.lookup name (TypeOf.teBinders (lowerTypes env)) <|> TypeOf.lookupHeaderType (lowerTypes env) name of
+    Just sourceType -> pure (applySubstitution env sourceType)
+    Nothing -> throwLower ("GRIN has no type for: " <> show name)
+
+applySubstitution :: LowerEnv -> Fc2.Type -> Fc2.Type
+applySubstitution env = TypeOf.substTypes (lowerTypeSubstitution env)
+
+reduce :: LowerEnv -> Fc2.Type -> Fc2.Type
+reduce env = TypeOf.reduceType (lowerTypes env) . applySubstitution env
+
+extendTypeBinder :: LowerEnv -> Fc2.Binder -> LowerEnv
+extendTypeBinder env binder = env {lowerTypes = TypeOf.extendBinder (lowerTypes env) binder}
+
+defaultRuntimeReps :: LowerEnv -> [Fc2.Binder] -> LowerEnv
+defaultRuntimeReps = foldl defaultOne
+  where
+    defaultOne env binder =
+      case reduce env (Fc2.binderType binder) of
+        Fc2.TyCon name
+          | Fc2.nameText name == "RuntimeRep",
+            Just lifted <- TypeOf.liftedRepType (lowerTypes env) ->
+              env {lowerTypeSubstitution = Map.insert (Fc2.binderName binder) lifted (lowerTypeSubstitution env)}
+        _ -> env
+
+extendTermBinder :: Fc2.Binder -> LowerEnv -> LowerEnv
+extendTermBinder binder env = env {lowerTypes = TypeOf.extendBinder (lowerTypes env) binder}
+
+bindLocal :: LowerEnv -> Fc2.Binder -> [GrinVar] -> LowerEnv
+bindLocal env binder variables =
+  (extendTermBinder binder env)
+    { lowerLocals = Map.insert (Fc2.binderName binder) variables (lowerLocals env)
+    }
+
+freshVarsForBinder :: LowerEnv -> Fc2.Binder -> LowerM [GrinVar]
+freshVarsForBinder env binder = freshVarsForType env (Fc2.nameText (Fc2.binderName binder), applySubstitution env (Fc2.binderType binder))
+
+freshVarsForType :: LowerEnv -> (Text, Fc2.Type) -> LowerM [GrinVar]
+freshVarsForType env (hint, sourceType) = runtimeRep env sourceType >>= freshVars hint
+
+freshVars :: Text -> GrinRep -> LowerM [GrinVar]
+freshVars hint representation = mapM (freshVar hint) (runtimeRepComponents representation)
+
+freshVar :: Text -> GrinRep -> LowerM GrinVar
+freshVar hint representation = do
+  state <- get
+  let unique = lowerNextUnique state
+  modify' (\current -> current {lowerNextUnique = unique - 1})
+  pure (GrinVar hint unique representation)
+
+freshFunction :: Text -> LowerM FunctionName
+freshFunction hint = do
+  state <- get
+  let unique = lowerNextFunction state
+  modify' (\current -> current {lowerNextFunction = unique + 1})
+  pure (FunctionName ("$grin_" <> hint <> "_" <> T.pack (show unique)))
+
+emitFunction :: GrinFunction -> LowerM ()
+emitFunction function = modify' (\state -> state {lowerFunctionsRev = function : lowerFunctionsRev state})
+
+bindIfNeeded :: [GrinVar] -> GrinExpr -> GrinExpr -> GrinExpr
+bindIfNeeded variables valueExpression body
+  | null variables = GrinBind [] valueExpression body
+  | otherwise = GrinBind variables valueExpression body
+
+liftEither :: Either String value -> LowerM value
+liftEither = either throwLower pure
+
+throwLower :: String -> LowerM value
+throwLower = lift . Left

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -9,6 +9,7 @@ where
 
 import Aihc.Fc2 qualified as Fc2
 import Aihc.Fc2.TypeOf qualified as TypeOf
+import Aihc.Fc2.Wired qualified as Wired
 import Aihc.Grin.Anf (normalizeGrinProgram)
 import Aihc.Grin.Syntax
 import Aihc.Resolve (PackageId (..))
@@ -871,8 +872,14 @@ defaultRuntimeReps = foldl defaultOne
       case reduce env (Fc2.binderType binder) of
         Fc2.TyCon name
           | Fc2.nameText name == "RuntimeRep",
-            Just lifted <- TypeOf.liftedRepType (lowerTypes env) ->
-              env {lowerTypeSubstitution = Map.insert (Fc2.binderName binder) lifted (lowerTypeSubstitution env)}
+            Just package <- TypeOf.tePrimPackage (lowerTypes env) ->
+              env
+                { lowerTypeSubstitution =
+                    Map.insert
+                      (Fc2.binderName binder)
+                      (Fc2.TyCon (Wired.liftedRepName package))
+                      (lowerTypeSubstitution env)
+                }
         _ -> env
 
 extendTermBinder :: Fc2.Binder -> LowerEnv -> LowerEnv

--- a/components/aihc-grin/src/Aihc/Grin/Lower.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Lower.hs
@@ -511,9 +511,10 @@ lowerTupleCase env scrutinee binder _fields alternatives = do
     case alternatives of
       first : _ -> pure first
       [] -> throwLower "GRIN cannot lower an empty unboxed tuple case"
-  fieldVariables <- mapM (freshVarsForBinder env) (Fc2.altBinders alternative)
+  let typeEnv = foldl extendTypeBinder env (Fc2.altTypeBinders alternative)
+  fieldVariables <- mapM (freshVarsForBinder typeEnv) (Fc2.altBinders alternative)
   let values = concat fieldVariables
-      binderEnv = bindLocal env binder values
+      binderEnv = bindLocal typeEnv binder values
       alternativeEnv = foldl bindPair binderEnv (zip (Fc2.altBinders alternative) fieldVariables)
   loweredRhs <- lowerExpr alternativeEnv (Fc2.altRhs alternative)
   loweredScrutinee <- lowerExpr env scrutinee
@@ -523,10 +524,11 @@ lowerTupleCase env scrutinee binder _fields alternatives = do
 
 lowerAlt :: LowerEnv -> Fc2.Alt -> LowerM GrinAlt
 lowerAlt env alternative = do
-  binderGroups <- mapM (freshVarsForBinder env) (Fc2.altBinders alternative)
-  let bodyEnv = foldl bindPair env (zip (Fc2.altBinders alternative) binderGroups)
+  let typeEnv = foldl extendTypeBinder env (Fc2.altTypeBinders alternative)
+  binderGroups <- mapM (freshVarsForBinder typeEnv) (Fc2.altBinders alternative)
+  let bodyEnv = foldl bindPair typeEnv (zip (Fc2.altBinders alternative) binderGroups)
   body <- lowerExpr bodyEnv (Fc2.altRhs alternative)
-  alternativeConstructor <- lowerAltCon env (Fc2.altCon alternative)
+  alternativeConstructor <- lowerAltCon typeEnv (Fc2.altCon alternative)
   pure
     GrinAlt
       { grinAltCon = alternativeConstructor,

--- a/components/aihc-grin/src/Aihc/Grin/Parser.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Parser.hs
@@ -41,10 +41,7 @@ data TopDeclaration
   = TopConstructor (Text, [[GrinRep]])
   | TopPrimitive (GrinVar, Int)
   | TopForeign GrinForeignCall
-  | TopExternalGlobal Text
-  | TopExternalFunction GrinCodeInfo
-  | TopWhnfGlobal (GrinVar, GrinNode)
-  | TopCaf (GrinVar, GrinNode)
+  | TopGlobal (Text, GrinNode)
   | TopFunction GrinFunction
 
 programParser :: Parser GrinProgram
@@ -60,10 +57,7 @@ emptyProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions = []
     }
 
@@ -73,10 +67,7 @@ addDeclaration program declaration =
     TopConstructor value -> program {grinConstructors = grinConstructors program <> [value]}
     TopPrimitive value -> program {grinPrimitives = grinPrimitives program <> [value]}
     TopForeign value -> program {grinForeignCalls = grinForeignCalls program <> [value]}
-    TopExternalGlobal value -> program {grinExternalGlobals = grinExternalGlobals program <> [value]}
-    TopExternalFunction value -> program {grinExternalFunctions = grinExternalFunctions program <> [value]}
-    TopWhnfGlobal value -> program {grinWhnfGlobals = grinWhnfGlobals program <> [value]}
-    TopCaf value -> program {grinCafs = grinCafs program <> [value]}
+    TopGlobal value -> program {grinGlobals = grinGlobals program <> [value]}
     TopFunction value -> program {grinFunctions = grinFunctions program <> [value]}
 
 topDeclaration :: Parser TopDeclaration
@@ -86,10 +77,7 @@ topDeclaration = do
     [ MP.try constructorDeclaration,
       MP.try primitiveDeclaration,
       MP.try foreignDeclaration,
-      MP.try externalGlobalDeclaration,
-      MP.try externalFunctionDeclaration,
-      MP.try (TopWhnfGlobal <$> staticDeclaration "global"),
-      MP.try (TopCaf <$> staticDeclaration "caf"),
+      MP.try (TopGlobal <$> globalDeclaration),
       TopFunction <$> functionDeclaration
     ]
 
@@ -123,53 +111,17 @@ foreignDeclaration = do
   lineEnd
   pure (TopForeign foreignCall)
 
-externalGlobalDeclaration :: Parser TopDeclaration
-externalGlobalDeclaration = do
-  keyword "external"
-  horizontal1
+globalDeclaration :: Parser (Text, GrinNode)
+globalDeclaration = do
   keyword "global"
   horizontal1
-  TopExternalGlobal <$> name <* lineEnd
-
-externalFunctionDeclaration :: Parser TopDeclaration
-externalFunctionDeclaration = do
-  keyword "external"
-  horizontal1
-  sourceName <- name
-  legacyArity <- optional (MPC.char '/' *> natural)
-  horizontal1
-  parameterLayouts <- layouts
-  horizontal1
-  _ <- MPC.string "->"
-  horizontal1
-  resultRep <- runtimeRep
-  horizontal1
-  _ <- MPC.char '='
-  horizontal1
-  functionName <- FunctionName <$> name
-  lineEnd
-  when (maybe False (/= length parameterLayouts) legacyArity) $ fail "external function arity does not match its layouts"
-  pure
-    ( TopExternalFunction
-        GrinCodeInfo
-          { grinCodeSourceName = sourceName,
-            grinCodeFunctionName = functionName,
-            grinCodeParameterLayouts = parameterLayouts,
-            grinCodeResultRep = resultRep
-          }
-    )
-
-staticDeclaration :: Text -> Parser (GrinVar, GrinNode)
-staticDeclaration declarationName = do
-  keyword declarationName
-  horizontal1
-  variable <- bareVar
+  globalName <- name
   horizontal1
   _ <- MPC.char '='
   horizontal1
   node <- grinNode
   lineEnd
-  pure (variable, node)
+  pure (globalName, node)
 
 functionDeclaration :: Parser GrinFunction
 functionDeclaration = do
@@ -179,7 +131,6 @@ functionDeclaration = do
   _ <- MPC.string "->"
   horizontal1
   resultRep <- runtimeRep
-  linkName <- optional (MP.try (horizontal1 *> keyword "link" *> horizontal1 *> name))
   horizontal1
   _ <- MPC.char '='
   lineEnd
@@ -187,7 +138,6 @@ functionDeclaration = do
   pure
     GrinFunction
       { grinFunctionName = functionName,
-        grinFunctionLinkName = linkName,
         grinFunctionParameters = parameters,
         grinFunctionResultRep = resultRep,
         grinFunctionBody = body
@@ -550,7 +500,8 @@ nodeTag =
 
 grinValue :: Parser GrinValue
 grinValue =
-  MP.try (GrinVarValue <$> varAtom)
+  MP.try (GrinGlobalValue <$> (keyword "global-ref" *> horizontal1 *> name))
+    <|> MP.try (GrinVarValue <$> varAtom)
     <|> GrinLitValue <$> grinLiteral
 
 grinLiteral :: Parser GrinLiteral

--- a/components/aihc-grin/src/Aihc/Grin/Pretty.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Pretty.hs
@@ -18,23 +18,9 @@ renderProgram program =
     ( map renderConstructor (grinConstructors program)
         <> map renderPrimitive (grinPrimitives program)
         <> map renderForeign (grinForeignCalls program)
-        <> map (("external global " <>) . renderName) (grinExternalGlobals program)
-        <> map renderExternalFunction (grinExternalFunctions program)
-        <> map renderGlobal (grinWhnfGlobals program)
-        <> map renderCaf (grinCafs program)
+        <> map renderGlobal (grinGlobals program)
         <> map renderFunction (grinFunctions program)
     )
-
-renderExternalFunction :: GrinCodeInfo -> String
-renderExternalFunction info =
-  "external "
-    <> renderName (grinCodeSourceName info)
-    <> " "
-    <> renderLayouts (grinCodeParameterLayouts info)
-    <> " -> "
-    <> show (grinCodeResultRep info)
-    <> " = "
-    <> renderFunctionName (grinCodeFunctionName info)
 
 renderConstructor :: (T.Text, [[GrinRep]]) -> String
 renderConstructor (name, fieldLayouts) =
@@ -57,13 +43,9 @@ renderForeign :: GrinForeignCall -> String
 renderForeign foreignCall =
   "foreign " <> renderForeignCall foreignCall
 
-renderGlobal :: (GrinVar, GrinNode) -> String
-renderGlobal (var, node) =
-  "global " <> renderVar var <> " = " <> renderNode node
-
-renderCaf :: (GrinVar, GrinNode) -> String
-renderCaf (var, node) =
-  "caf " <> renderVar var <> " = " <> renderNode node
+renderGlobal :: (T.Text, GrinNode) -> String
+renderGlobal (name, node) =
+  "global " <> renderName name <> " = " <> renderNode node
 
 renderFunction :: GrinFunction -> String
 renderFunction function =
@@ -71,7 +53,6 @@ renderFunction function =
     <> concatMap ((" " <>) . renderVarAtom) (grinFunctionParameters function)
     <> " -> "
     <> show (grinFunctionResultRep function)
-    <> maybe "" ((" link " <>) . renderName) (grinFunctionLinkName function)
     <> " =\n"
     <> renderExprIndented 2 (grinFunctionBody function)
 
@@ -237,6 +218,7 @@ renderValue :: GrinValue -> String
 renderValue value =
   case value of
     GrinVarValue var -> renderVarAtom var
+    GrinGlobalValue name -> "global-ref " <> renderName name
     GrinLitValue literal -> renderLiteral literal
 
 renderNode :: GrinNode -> String

--- a/components/aihc-grin/src/Aihc/Grin/Syntax.hs
+++ b/components/aihc-grin/src/Aihc/Grin/Syntax.hs
@@ -12,7 +12,6 @@ module Aihc.Grin.Syntax
     GrinVecElem (..),
     liftedGrinRep,
     GrinProgram (..),
-    GrinCodeInfo (..),
     GrinFunction (..),
     FunctionName (..),
     GrinVar (..),
@@ -31,6 +30,7 @@ module Aihc.Grin.Syntax
     grinForeignOperandReps,
     grinForeignCallResultReps,
     grinProgramLiterals,
+    grinProgramGlobalReferences,
     grinValueRuntimeRep,
     isLiftedRuntimeRep,
     isPointerRuntimeRep,
@@ -90,27 +90,8 @@ data GrinProgram = GrinProgram
   { grinConstructors :: ![(Text, [[GrinRep]])],
     grinPrimitives :: ![(GrinVar, Int)],
     grinForeignCalls :: ![GrinForeignCall],
-    -- | Global slots supplied by dependency units and referenced by this unit.
-    grinExternalGlobals :: ![Text],
-    -- | Code entries supplied by other compilation units. Unlike runtime
-    -- globals, these names never occupy global-table slots.
-    grinExternalFunctions :: ![GrinCodeInfo],
-    -- | Top-level values that are already in weak-head normal form. These are
-    -- initialized directly rather than represented by updateable CAF cells.
-    grinWhnfGlobals :: ![(GrinVar, GrinNode)],
-    grinCafs :: ![(GrinVar, GrinNode)],
+    grinGlobals :: ![(Text, GrinNode)],
     grinFunctions :: ![GrinFunction]
-  }
-  deriving (Eq, Show, Read)
-
--- | Runtime calling information exported for a top-level code binding.
--- Parameter layouts retain source-argument boundaries because a Core term
--- argument such as @State# RealWorld@ may contribute no runtime values.
-data GrinCodeInfo = GrinCodeInfo
-  { grinCodeSourceName :: !Text,
-    grinCodeFunctionName :: !FunctionName,
-    grinCodeParameterLayouts :: ![[GrinRep]],
-    grinCodeResultRep :: !GrinRep
   }
   deriving (Eq, Show, Read)
 
@@ -118,8 +99,6 @@ data GrinCodeInfo = GrinCodeInfo
 -- name and carry their environment as node fields.
 data GrinFunction = GrinFunction
   { grinFunctionName :: !FunctionName,
-    -- | Source-level name when this entry is link-visible to other units.
-    grinFunctionLinkName :: !(Maybe Text),
     grinFunctionParameters :: ![GrinVar],
     grinFunctionResultRep :: !GrinRep,
     grinFunctionBody :: !GrinExpr
@@ -224,6 +203,7 @@ data GrinExpr
 -- | Atomic operands in the strict language.
 data GrinValue
   = GrinVarValue !GrinVar
+  | GrinGlobalValue !Text
   | GrinLitValue !GrinLiteral
   deriving (Eq, Show, Read)
 
@@ -269,7 +249,7 @@ data GrinLiteral
 -- alternatives. Native backends use this to build static literal pools.
 grinProgramLiterals :: GrinProgram -> [GrinLiteral]
 grinProgramLiterals program =
-  concatMap (nodeLiterals . snd) (grinWhnfGlobals program <> grinCafs program)
+  concatMap (nodeLiterals . snd) (grinGlobals program)
     <> concatMap (exprLiterals . grinFunctionBody) (grinFunctions program)
   where
     exprLiterals expression =
@@ -313,11 +293,54 @@ grinProgramLiterals program =
       case value of
         GrinLitValue literal -> [literal]
         GrinVarValue {} -> []
+        GrinGlobalValue {} -> []
+
+-- | Every explicit global-table reference in one program.
+grinProgramGlobalReferences :: GrinProgram -> [Text]
+grinProgramGlobalReferences program =
+  concatMap (nodeReferences . snd) (grinGlobals program)
+    <> concatMap (exprReferences . grinFunctionBody) (grinFunctions program)
+  where
+    exprReferences expression =
+      case expression of
+        GrinConstant values -> valuesReferences values
+        GrinBind _ valueExpression body -> exprReferences valueExpression <> exprReferences body
+        GrinStore node -> nodeReferences node
+        GrinEnsureHeap requiredWords roots -> valueReferences requiredWords <> valuesReferences roots
+        GrinStoreUnchecked node -> nodeReferences node
+        GrinStoreRec bindings body -> concatMap (nodeReferences . snd) bindings <> exprReferences body
+        GrinStoreRecUnchecked bindings body -> concatMap (nodeReferences . snd) bindings <> exprReferences body
+        GrinFetch _ pointer -> valueReferences pointer
+        GrinUpdate pointer value -> valueReferences pointer <> valueReferences value
+        GrinEval _ value -> valueReferences value
+        GrinCpsEval _ value continuation updateContinuation -> valuesReferences [value, continuation, updateContinuation]
+        GrinCall _ _ arguments -> valuesReferences arguments
+        GrinPrimitiveCall _ _ arguments -> valuesReferences arguments
+        GrinCpsPrimitiveCall _ _ arguments continuation -> valuesReferences arguments <> valueReferences continuation
+        GrinApply _ function arguments -> valueReferences function <> valuesReferences arguments
+        GrinCpsApply _ function arguments continuation -> valueReferences function <> valuesReferences arguments <> valueReferences continuation
+        GrinContinue continuation values -> valueReferences continuation <> valuesReferences values
+        GrinCpsRaise exception continuation -> valueReferences exception <> valueReferences continuation
+        GrinUpdateBlackhole pointer value -> valueReferences pointer <> valueReferences value
+        GrinHalt values -> valuesReferences values
+        GrinExit status -> valueReferences status
+        GrinCase scrutinee _ alternatives -> valueReferences scrutinee <> concatMap (exprReferences . grinAltRhs) alternatives
+        GrinThrow exception -> valueReferences exception
+        GrinCatch _ action handler state -> valuesReferences (action : handler : state)
+        GrinForeignCallExpr _ arguments -> valuesReferences arguments
+    nodeReferences = valuesReferences . grinNodeFields
+    valuesReferences = concatMap valueReferences
+    valueReferences value =
+      case value of
+        GrinGlobalValue name -> [name]
+        GrinVarValue {} -> []
+        GrinLitValue {} -> []
 
 grinValueRuntimeRep :: GrinValue -> GrinRep
 grinValueRuntimeRep value =
   case value of
     GrinVarValue var -> grinVarRuntimeRep var
+    GrinGlobalValue {} -> liftedGrinRep
     GrinLitValue literal ->
       case literal of
         GrinLitInt runtimeRep _ -> runtimeRep

--- a/components/aihc-grin/test/GrinGolden.hs
+++ b/components/aihc-grin/test/GrinGolden.hs
@@ -9,19 +9,45 @@ module GrinGolden
   )
 where
 
+import Aihc.Fc2 (DesugarConfig (..), Fc2DesugarResult (..), Program, desugarModuleFc2, lintPrograms)
 import Aihc.Fc2.TypeOf (typeEnvFromPrograms)
 import Aihc.Grin (lintProgram, lowerProgram, renderProgram)
-import Aihc.Parser.Syntax (Extension, parseExtensionName)
+import Aihc.Parser (ParserConfig (..), defaultConfig, parseModule)
+import Aihc.Parser.Syntax
+  ( Extension (ImplicitPrelude),
+    LanguageEdition (Haskell98Edition),
+    Module,
+    effectiveExtensions,
+    headerExtensionSettings,
+    headerLanguageEdition,
+    moduleName,
+    parseExtensionName,
+    parseLanguageEdition,
+  )
+import Aihc.Parser.Token (readModuleHeaderPragmas)
+import Aihc.Resolve (ModuleExports, Package (..), PackageId (..), ResolveResult (..), extractInterface, modulesInPackage, resolveWithDeps)
+import Aihc.Tc
+  ( TcInterface,
+    emptyTcInterface,
+    tcConfig,
+    tcModuleBindings,
+    tcModuleDiagnostics,
+    tcModuleSuccess,
+    typecheckModuleSccWithInterface,
+    typecheckModulesWithInterface,
+  )
 import Data.Aeson ((.!=), (.:), (.:?))
 import Data.Aeson.Types (parseEither, withObject)
 import Data.Char (isSpace, toLower)
 import Data.List (dropWhileEnd, sort)
+import Data.Maybe (fromMaybe)
 import Data.Text (Text)
 import Data.Text qualified as T
+import Data.Text.IO qualified as TIO
 import Data.Yaml qualified as Y
-import Fc2Golden qualified
-import System.Directory (doesDirectoryExist, getCurrentDirectory, listDirectory)
+import System.Directory (doesDirectoryExist, doesFileExist, getCurrentDirectory, listDirectory)
 import System.FilePath (makeRelative, takeDirectory, takeExtension, (</>))
+import System.IO.Unsafe (unsafePerformIO)
 
 data ExpectedStatus = StatusPass | StatusFail | StatusXPass | StatusXFail
   deriving (Eq, Show)
@@ -38,6 +64,12 @@ data GrinCase = GrinCase
   }
   deriving (Eq, Show)
 
+data PrimitiveSupport = PrimitiveSupport
+  { supportScopes :: !ModuleExports,
+    supportTcInterface :: !TcInterface,
+    supportPrograms :: ![Program]
+  }
+
 loadGrinCases :: IO [GrinCase]
 loadGrinCases = do
   root <- fixtureRoot
@@ -52,22 +84,143 @@ evaluateGrinCase fixture =
 
 renderCase :: GrinCase -> Either String String
 renderCase fixture = do
-  let fc2Case =
-        Fc2Golden.Fc2Case
-          { Fc2Golden.caseId = caseId fixture,
-            Fc2Golden.casePath = caseId fixture,
-            Fc2Golden.caseExtensions = caseExtensions fixture,
-            Fc2Golden.caseModules = caseModules fixture,
-            Fc2Golden.caseExpected = "",
-            Fc2Golden.caseStatus = Fc2Golden.StatusPass,
-            Fc2Golden.caseReason = ""
-          }
-  (allPrograms, targetPrograms) <- Fc2Golden.buildFc2CasePrograms fc2Case
+  (allPrograms, targetPrograms) <- buildFc2Programs (caseExtensions fixture) (caseModules fixture)
   let types = typeEnvFromPrograms allPrograms
   lowered <- traverse (lowerProgram types) targetPrograms
   case concatMap lintProgram lowered of
     [] -> pure (trim (unlines (map renderProgram lowered)))
     errors -> Left ("GRIN lint error: " <> show errors)
+
+buildFc2Programs :: [Extension] -> [Text] -> Either String ([Program], [Program])
+buildFc2Programs extensions sources = do
+  modules <- traverse (parseFixtureModule extensions) sources
+  resolved <-
+    case resolveWithDeps (supportScopes primitiveSupport) (modulesInPackage fixturePackage modules) of
+      result@ResolveResult {resolveErrors = []} -> Right result
+      ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+  let fixtureAsts = map snd (resolvedModules resolved)
+      (fixtureTcResults, tcInterface) =
+        typecheckModulesWithInterface
+          (tcConfig (primPackageId desugarConfig))
+          (supportTcInterface primitiveSupport)
+          fixtureAsts
+  if not (all tcModuleSuccess fixtureTcResults)
+    then Left ("typecheck error: " <> unlines [show diagnostic | result <- fixtureTcResults, diagnostic <- tcModuleDiagnostics result])
+    else do
+      let fixtureBindings = concatMap tcModuleBindings fixtureTcResults
+          fixtureResults = map (desugarModuleFc2 desugarConfig fixtureBindings tcInterface) fixtureTcResults
+      if not (all ds2Success fixtureResults)
+        then Left (unlines (concatMap ds2Errors fixtureResults))
+        else do
+          let fixturePrograms = map ds2Program fixtureResults
+              allPrograms = supportPrograms primitiveSupport <> fixturePrograms
+          case lintPrograms allPrograms of
+            [] -> Right (allPrograms, fixturePrograms)
+            errors -> Left (unlines ["System FC 2 lint error: " <> show errorValue | errorValue <- errors])
+
+parseFixtureModule :: [Extension] -> Text -> Either String Module
+parseFixtureModule extensions input =
+  parseModuleText (T.unpack (T.takeWhile (/= '\n') input)) extensions input
+
+primitiveSupport :: PrimitiveSupport
+primitiveSupport = unsafePerformIO $ do
+  modules <- loadPrimitiveModules
+  case preparePrimitiveSupport modules of
+    Left problem -> fail problem
+    Right support -> pure support
+{-# NOINLINE primitiveSupport #-}
+
+loadPrimitiveModules :: IO [(FilePath, Text)]
+loadPrimitiveModules = do
+  sourceRoot <- findPrimitiveSourceRoot
+  traverse (loadOne sourceRoot) ["GHC/Types.hs", "GHC/Prim.hs", "GHC/Tuple.hs"]
+  where
+    loadOne sourceRoot relativePath = do
+      let path = sourceRoot </> relativePath
+      source <- TIO.readFile path
+      pure (path, source)
+
+findPrimitiveSourceRoot :: IO FilePath
+findPrimitiveSourceRoot = getCurrentDirectory >>= findUp
+  where
+    findUp directory = do
+      let candidate = directory </> "core-libs" </> "aihc-prim" </> "src"
+          files = [candidate </> "GHC/Types.hs", candidate </> "GHC/Prim.hs", candidate </> "GHC/Tuple.hs"]
+      exists <- and <$> traverse doesFileExist files
+      if exists
+        then pure candidate
+        else do
+          let parent = takeDirectory directory
+          if parent == directory
+            then fail "Cannot find the aihc-prim source modules."
+            else findUp parent
+
+preparePrimitiveSupport :: [(FilePath, Text)] -> Either String PrimitiveSupport
+preparePrimitiveSupport sources = do
+  modules <- traverse (uncurry parsePrimitiveModule) sources
+  resolved <-
+    case resolveWithDeps mempty (modulesInPackage primitivePackage modules) of
+      result@ResolveResult {resolveErrors = []} -> Right result
+      ResolveResult {resolveErrors} -> Left ("resolve error: " <> show resolveErrors)
+  let primitiveAsts = map snd (resolvedModules resolved)
+      (primitiveTcResults, tcInterface) =
+        typecheckModuleSccWithInterface
+          (tcConfig (primPackageId desugarConfig))
+          emptyTcInterface
+          primitiveAsts
+  if not (all tcModuleSuccess primitiveTcResults)
+    then
+      Left
+        ( "typecheck error: "
+            <> unlines
+              [ show (moduleName ast) <> ": " <> show diagnostic
+              | (ast, result) <- zip primitiveAsts primitiveTcResults,
+                diagnostic <- tcModuleDiagnostics result
+              ]
+        )
+    else do
+      let primitiveBindings = concatMap tcModuleBindings primitiveTcResults
+          primitiveResults = map (desugarModuleFc2 desugarConfig primitiveBindings tcInterface) primitiveTcResults
+      if all ds2Success primitiveResults
+        then
+          Right
+            PrimitiveSupport
+              { supportScopes = extractInterface resolved,
+                supportTcInterface = tcInterface,
+                supportPrograms = map ds2Program primitiveResults
+              }
+        else Left (unlines (concatMap ds2Errors primitiveResults))
+
+primitivePackage :: Package
+primitivePackage = Package "aihc-prim" (PackageId "aihc-prim")
+
+fixturePackage :: Package
+fixturePackage = Package "" (PackageId "")
+
+desugarConfig :: DesugarConfig
+desugarConfig = DesugarConfig {primPackageId = PackageId "aihc-prim"}
+
+parsePrimitiveModule :: FilePath -> Text -> Either String Module
+parsePrimitiveModule sourceName input =
+  parseModuleText sourceName (primitiveExtensions input) input
+
+parseModuleText :: FilePath -> [Extension] -> Text -> Either String Module
+parseModuleText sourceName extensions input =
+  let config =
+        defaultConfig
+          { parserSourceName = sourceName,
+            parserExtensions = extensions
+          }
+      (errors, ast) = parseModule config input
+   in if null errors then Right ast else Left (show errors)
+
+primitiveExtensions :: Text -> [Extension]
+primitiveExtensions source =
+  filter (/= ImplicitPrelude) (effectiveExtensions language (headerExtensionSettings header))
+  where
+    header = readModuleHeaderPragmas source
+    defaultLanguage = fromMaybe Haskell98Edition (parseLanguageEdition "GHC2021")
+    language = fromMaybe defaultLanguage (headerLanguageEdition header)
 
 loadCase :: FilePath -> FilePath -> IO GrinCase
 loadCase root path = do

--- a/components/aihc-grin/test/GrinGolden.hs
+++ b/components/aihc-grin/test/GrinGolden.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Source-to-GRIN fixture support.
+module GrinGolden
+  ( GrinCase (..),
+    Outcome (..),
+    evaluateGrinCase,
+    loadGrinCases,
+  )
+where
+
+import Aihc.Fc2.TypeOf (typeEnvFromPrograms)
+import Aihc.Grin (lintProgram, lowerProgram, renderProgram)
+import Aihc.Parser.Syntax (Extension, parseExtensionName)
+import Data.Aeson ((.!=), (.:), (.:?))
+import Data.Aeson.Types (parseEither, withObject)
+import Data.Char (isSpace, toLower)
+import Data.List (dropWhileEnd, sort)
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Yaml qualified as Y
+import Fc2Golden qualified
+import System.Directory (doesDirectoryExist, getCurrentDirectory, listDirectory)
+import System.FilePath (makeRelative, takeDirectory, takeExtension, (</>))
+
+data ExpectedStatus = StatusPass | StatusFail | StatusXPass | StatusXFail
+  deriving (Eq, Show)
+
+data Outcome = OutcomePass | OutcomeXFail | OutcomeXPass | OutcomeFail
+  deriving (Eq, Show)
+
+data GrinCase = GrinCase
+  { caseId :: !String,
+    caseExtensions :: ![Extension],
+    caseModules :: ![Text],
+    caseExpected :: !String,
+    caseStatus :: !ExpectedStatus
+  }
+  deriving (Eq, Show)
+
+loadGrinCases :: IO [GrinCase]
+loadGrinCases = do
+  root <- fixtureRoot
+  paths <- listFixtureFiles root
+  mapM (loadCase root) paths
+
+evaluateGrinCase :: GrinCase -> (Outcome, String)
+evaluateGrinCase fixture =
+  case renderCase fixture of
+    Left problem -> classifyFailure fixture problem
+    Right actual -> classifySuccess fixture actual
+
+renderCase :: GrinCase -> Either String String
+renderCase fixture = do
+  let fc2Case =
+        Fc2Golden.Fc2Case
+          { Fc2Golden.caseId = caseId fixture,
+            Fc2Golden.casePath = caseId fixture,
+            Fc2Golden.caseExtensions = caseExtensions fixture,
+            Fc2Golden.caseModules = caseModules fixture,
+            Fc2Golden.caseExpected = "",
+            Fc2Golden.caseStatus = Fc2Golden.StatusPass,
+            Fc2Golden.caseReason = ""
+          }
+  (allPrograms, targetPrograms) <- Fc2Golden.buildFc2CasePrograms fc2Case
+  let types = typeEnvFromPrograms allPrograms
+  lowered <- traverse (lowerProgram types) targetPrograms
+  case concatMap lintProgram lowered of
+    [] -> pure (trim (unlines (map renderProgram lowered)))
+    errors -> Left ("GRIN lint error: " <> show errors)
+
+loadCase :: FilePath -> FilePath -> IO GrinCase
+loadCase root path = do
+  decoded <- Y.decodeFileEither path
+  case decoded of
+    Left problem -> fail ("Invalid GRIN fixture " <> path <> ": " <> Y.prettyPrintParseException problem)
+    Right value -> either fail pure (parseFixture root path value)
+
+parseFixture :: FilePath -> FilePath -> Y.Value -> Either String GrinCase
+parseFixture root path value = do
+  (extensionNames, source, modules, expected, statusText) <-
+    parseEither
+      ( withObject "GRIN fixture" $ \object ->
+          (,,,,)
+            <$> object .:? "extensions" .!= []
+            <*> object .:? "source"
+            <*> object .:? "modules"
+            <*> object .:? "expected" .!= ""
+            <*> object .: "status"
+      )
+      value
+  extensions <- traverse parseExtension extensionNames
+  status <- parseStatus statusText
+  moduleTexts <-
+    case (source, modules) of
+      (Just one, Nothing) -> Right [one]
+      (Nothing, Just many) -> Right many
+      _ -> Left ("GRIN fixture must contain source or modules: " <> path)
+  pure
+    GrinCase
+      { caseId = makeRelative root path,
+        caseExtensions = extensions,
+        caseModules = moduleTexts,
+        caseExpected = trim (T.unpack expected),
+        caseStatus = status
+      }
+  where
+    parseExtension name = maybe (Left ("Unknown extension in " <> path <> ": " <> T.unpack name)) Right (parseExtensionName name)
+
+parseStatus :: Text -> Either String ExpectedStatus
+parseStatus value =
+  case T.toLower value of
+    "pass" -> Right StatusPass
+    "fail" -> Right StatusFail
+    "xpass" -> Right StatusXPass
+    "xfail" -> Right StatusXFail
+    _ -> Left ("Invalid GRIN fixture status: " <> T.unpack value)
+
+classifySuccess :: GrinCase -> String -> (Outcome, String)
+classifySuccess fixture actual =
+  case caseStatus fixture of
+    StatusPass
+      | actual == caseExpected fixture -> (OutcomePass, "")
+      | otherwise -> (OutcomeFail, "output mismatch\nexpected:\n" <> caseExpected fixture <> "\nactual:\n" <> actual)
+    StatusFail -> (OutcomeFail, "expected failure")
+    StatusXFail
+      | actual == caseExpected fixture -> (OutcomeXPass, "")
+      | otherwise -> (OutcomeXFail, "")
+    StatusXPass
+      | actual == caseExpected fixture -> (OutcomeXPass, "")
+      | otherwise -> (OutcomeFail, "expected xpass output")
+
+classifyFailure :: GrinCase -> String -> (Outcome, String)
+classifyFailure fixture problem =
+  case caseStatus fixture of
+    StatusPass -> (OutcomeFail, problem)
+    StatusFail -> (OutcomePass, "")
+    StatusXFail -> (OutcomeXFail, "")
+    StatusXPass -> (OutcomeFail, problem)
+
+fixtureRoot :: IO FilePath
+fixtureRoot = getCurrentDirectory >>= findUp
+  where
+    findUp directory = do
+      let candidate = directory </> "test" </> "Test" </> "Fixtures" </> "grin"
+      exists <- doesDirectoryExist candidate
+      if exists
+        then pure candidate
+        else
+          let parent = takeDirectory directory
+           in if parent == directory then fail "GRIN fixture root does not exist" else findUp parent
+
+listFixtureFiles :: FilePath -> IO [FilePath]
+listFixtureFiles directory = do
+  entries <- sort <$> listDirectory directory
+  concat <$> traverse select entries
+  where
+    select entry = do
+      let path = directory </> entry
+      isDirectory <- doesDirectoryExist path
+      if isDirectory
+        then listFixtureFiles path
+        else pure [path | map toLower (takeExtension path) `elem` [".yaml", ".yml"]]
+
+trim :: String -> String
+trim = dropWhile isSpace . dropWhileEnd isSpace

--- a/components/aihc-grin/test/Spec.hs
+++ b/components/aihc-grin/test/Spec.hs
@@ -1,13 +1,26 @@
 module Main (main) where
 
+import GrinGolden qualified
 import Test.Grin.Arbitrary (prop_grinPrettyRoundTrip)
-import Test.Tasty (defaultMain, testGroup)
+import Test.Tasty (TestTree, defaultMain, testGroup)
+import Test.Tasty.HUnit (assertFailure, testCase)
 import Test.Tasty.Hedgehog (testProperty)
 
 main :: IO ()
-main =
+main = do
+  fixtures <- GrinGolden.loadGrinCases
   defaultMain
     ( testGroup
         "aihc-grin"
-        [testProperty "generated GRIN pretty-printer round-trip" prop_grinPrettyRoundTrip]
+        ( testProperty "generated GRIN pretty-printer round-trip" prop_grinPrettyRoundTrip
+            : map fixtureTest fixtures
+        )
     )
+
+fixtureTest :: GrinGolden.GrinCase -> TestTree
+fixtureTest fixture = testCase (GrinGolden.caseId fixture) $
+  case GrinGolden.evaluateGrinCase fixture of
+    (GrinGolden.OutcomePass, _) -> pure ()
+    (GrinGolden.OutcomeXFail, _) -> pure ()
+    (GrinGolden.OutcomeXPass, details) -> assertFailure ("unexpected pass: " <> details)
+    (GrinGolden.OutcomeFail, details) -> assertFailure details

--- a/components/aihc-grin/test/Test/Grin/Arbitrary.hs
+++ b/components/aihc-grin/test/Test/Grin/Arbitrary.hs
@@ -35,25 +35,13 @@ genGrinProgram =
     <$> smallList ((,) <$> genText <*> smallList (smallList genRuntimeRep))
     <*> smallList ((,) <$> genVar <*> genInt)
     <*> smallList genForeignCall
-    <*> smallList genText
-    <*> smallList genCodeInfo
-    <*> smallList ((,) <$> genVar <*> genNode)
-    <*> smallList ((,) <$> genVar <*> genNode)
+    <*> smallList ((,) <$> genText <*> genNode)
     <*> smallList genFunction
-
-genCodeInfo :: Gen GrinCodeInfo
-genCodeInfo =
-  GrinCodeInfo
-    <$> genText
-    <*> genFunctionName
-    <*> smallList (smallList genRuntimeRep)
-    <*> genRuntimeRep
 
 genFunction :: Gen GrinFunction
 genFunction =
   GrinFunction
     <$> genFunctionName
-    <*> Gen.maybe genText
     <*> smallList genVar
     <*> genRuntimeRep
     <*> genExpr
@@ -102,7 +90,7 @@ genAltCon =
     ]
 
 genValue :: Gen GrinValue
-genValue = Gen.choice [GrinVarValue <$> genVar, GrinLitValue <$> genLiteral]
+genValue = Gen.choice [GrinVarValue <$> genVar, GrinGlobalValue <$> genText, GrinLitValue <$> genLiteral]
 
 genNode :: Gen GrinNode
 genNode = GrinNode <$> genNodeTag <*> smallList genValue

--- a/components/aihc-llvm/src/Aihc/Llvm/Codegen.hs
+++ b/components/aihc-llvm/src/Aihc/Llvm/Codegen.hs
@@ -26,7 +26,6 @@ import Aihc.Native
     buildAddrLiteralPool,
     buildLinkLayout,
     nativeRuntimePrimitiveCall,
-    renderLinkedFunctionSymbol,
     supportedNativePrimitiveNames,
   )
 import Control.Monad (forM, zipWithM)
@@ -209,13 +208,9 @@ compileEnvironment unitKind continuationFunctions continuationFrames layout prog
     constructorIds = zip (map fst constructors) [1 ..]
     functionLabels =
       Map.fromList
-        ( [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
-          | info <- grinExternalFunctions program
-          ]
-            <> [ (grinFunctionName function, localFunctionLabel index function)
-               | (index, function) <- zip [0 :: Int ..] (grinFunctions program)
-               ]
-        )
+        [ (grinFunctionName function, localFunctionLabel index function)
+        | (index, function) <- zip [0 :: Int ..] (grinFunctions program)
+        ]
     constructorEntries =
       [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next Nothing Nothing (runtimeInfoKeyObjectKind key))
       | ((name, layouts), (_, identifier)) <- zip (linkConstructors layout) constructorIds,
@@ -1105,6 +1100,9 @@ materializeValue env value =
         Nothing -> do
           slot <- liftEither (globalSlot (valueCompileEnv env) (grinVarName var))
           loadGlobal slot
+    GrinGlobalValue name -> do
+      slot <- liftEither (globalSlot (valueCompileEnv env) name)
+      loadGlobal slot
     GrinLitValue literal -> materializeLiteral (valueCompileEnv env) literal
 
 materializeLiteral :: CompileEnv -> GrinLiteral -> FunctionM ([Text], Text)
@@ -1180,8 +1178,8 @@ compileConstructorInitializers env = fmap concat . forM nullary $ \(name, _) -> 
 
 compileInitializers :: CompileEnv -> GrinProgram -> FunctionM [Text]
 compileInitializers env program = do
-  cafAllocations <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
-    slot <- liftEither (globalSlot env (grinVarName var))
+  thunkAllocations <- fmap concat . forM thunkGlobals $ \(name, node) -> do
+    slot <- liftEither (globalSlot env name)
     info <- liftEither (nodeHeader env node)
     object <- freshValue
     objectInteger <- freshValue
@@ -1192,17 +1190,21 @@ compileInitializers env program = do
         ]
           <> globalStore
       )
-  whnfs <- fmap concat . forM (grinWhnfGlobals program) $ \(var, node) -> do
-    slot <- liftEither (globalSlot env (grinVarName var))
+  values <- fmap concat . forM valueGlobals $ \(name, node) -> do
+    slot <- liftEither (globalSlot env name)
     (lines', operand) <- materializeNode (ValueEnv env Map.empty) False node
     globalStore <- storeGlobal slot operand
     pure (lines' <> globalStore)
-  cafFields <- fmap concat . forM (grinCafs program) $ \(var, node) -> do
-    slot <- liftEither (globalSlot env (grinVarName var))
+  thunkFields <- fmap concat . forM thunkGlobals $ \(name, node) -> do
+    slot <- liftEither (globalSlot env name)
     (objectLines, object) <- loadGlobal slot
     fields <- initializeLocalFields (ValueEnv env Map.empty) object node
     pure (objectLines <> fields)
-  pure (cafAllocations <> whnfs <> cafFields)
+  pure (thunkAllocations <> values <> thunkFields)
+  where
+    (thunkGlobals, valueGlobals) = foldr partitionOne ([], []) (grinGlobals program)
+    partitionOne binding@(_, GrinNode GrinThunk {} _) (thunks, values) = (binding : thunks, values)
+    partitionOne binding (thunks, values) = (thunks, binding : values)
 
 runInitializer :: FunctionM value -> Either LlvmError value
 runInitializer action = fst <$> runStateT action (FunctionState 0 0 0 [])
@@ -1685,16 +1687,7 @@ renderForeignDeclarations program =
       ]
 
 renderExternalFunctionDeclarations :: CompileEnv -> GrinProgram -> [Text]
-renderExternalFunctionDeclarations env program =
-  [ "declare tailcc void @"
-      <> label
-      <> "("
-      <> T.intercalate ", " ("ptr" : replicate (length (concat (grinCodeParameterLayouts info))) "i64")
-      <> ")"
-  | info <- grinExternalFunctions program,
-    Just label <- [Map.lookup (grinCodeFunctionName info) (compileFunctionLabels env)]
-  ]
-    <> ["" | not (null (grinExternalFunctions program))]
+renderExternalFunctionDeclarations _env _program = []
 
 renderAddrLiterals :: CompileEnv -> [Text]
 renderAddrLiterals env =
@@ -1844,7 +1837,7 @@ boundVarGroups expression = case expression of
   _ -> []
 
 programNodes :: GrinProgram -> [GrinNode]
-programNodes program = map snd (grinWhnfGlobals program <> grinCafs program) <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
+programNodes program = map snd (grinGlobals program) <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
 
 exprNodes :: GrinExpr -> [GrinNode]
 exprNodes expression = case expression of
@@ -1917,16 +1910,13 @@ renderI64 :: Integer -> Text
 renderI64 integer = tshow (integer `mod` (2 ^ (64 :: Int)))
 
 localFunctionLabel :: Int -> GrinFunction -> Text
-localFunctionLabel index function = maybe ("aihc_llvm_function_" <> tshow index) linkedFunctionLabel (grinFunctionLinkName function)
-
-linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel = renderLinkedFunctionSymbol
+localFunctionLabel index _function = "aihc_llvm_function_" <> tshow index
 
 llvmLabel :: Text -> Text
 llvmLabel = T.map (\character -> if character `elem` ['a' .. 'z'] <> ['A' .. 'Z'] <> ['0' .. '9'] <> ['_'] then character else '_')
 
 functionLinkage :: GrinFunction -> Text
-functionLinkage function = maybe "internal " (const "") (grinFunctionLinkName function)
+functionLinkage _function = "internal "
 
 boolInteger :: Bool -> Text
 boolInteger True = "1"

--- a/components/aihc-llvm/test/Test/Llvm/Suite.hs
+++ b/components/aihc-llvm/test/Test/Llvm/Suite.hs
@@ -156,14 +156,10 @@ primitiveProgram primitiveCase =
     { grinConstructors = [],
       grinPrimitives = [(GrinVar name 80 resultRep, length arguments)],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName ("$primitive_" <> name),
-              grinFunctionLinkName = Just ("primitive." <> name),
               grinFunctionParameters = [],
               grinFunctionResultRep = resultRep,
               grinFunctionBody =
@@ -211,14 +207,10 @@ intAddProgram =
     { grinConstructors = [("()", [])],
       grinPrimitives = [(GrinVar "+#" 30 IntRep, 2)],
       grinForeignCalls = [putcharCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
-      grinCafs = [],
+      grinGlobals = [(grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -248,7 +240,7 @@ intAddProgram =
           grinAltBinders = [],
           grinAltRhs =
             GrinBind [output] (GrinForeignCallExpr putcharCall [GrinLitValue (GrinLitInt Int32Rep (toInteger (fromEnum character)))]) $
-              GrinConstant [GrinVarValue unitValue]
+              GrinConstant [GrinGlobalValue (grinVarName unitValue)]
         }
 
 firstMatchCaseProgram :: GrinProgram
@@ -257,14 +249,10 @@ firstMatchCaseProgram =
     { grinConstructors = [("()", [])],
       grinPrimitives = [],
       grinForeignCalls = [putcharCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
-      grinCafs = [],
+      grinGlobals = [(grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -294,7 +282,7 @@ firstMatchCaseProgram =
           grinAltBinders = [],
           grinAltRhs =
             GrinBind [output] (GrinForeignCallExpr putcharCall [GrinLitValue (GrinLitInt Int32Rep (toInteger (fromEnum character)))]) $
-              GrinConstant [GrinVarValue unitValue]
+              GrinConstant [GrinGlobalValue (grinVarName unitValue)]
         }
 
 thunkEntryProgram :: GrinProgram
@@ -303,28 +291,23 @@ thunkEntryProgram =
     { grinConstructors = [("()", [])],
       grinPrimitives = [],
       grinForeignCalls = [putcharCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [(mainThunk, GrinNode (GrinThunk mainThunkFunction) [])],
+      grinGlobals = [(grinVarName mainThunk, GrinNode (GrinThunk mainThunkFunction) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainThunkFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody = GrinStore (GrinNode (GrinClosure mainActionFunction [[]]) [])
             },
           GrinFunction
             { grinFunctionName = mainActionFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
                 GrinBind
                   [output]
                   (GrinForeignCallExpr putcharCall [GrinLitValue (GrinLitInt Int32Rep (toInteger (fromEnum 'T')))])
-                  (GrinConstant [GrinVarValue unitValue])
+                  (GrinConstant [GrinGlobalValue (grinVarName unitValue)])
             }
         ]
     }
@@ -355,14 +338,10 @@ foreignIntProgram =
     { grinConstructors = [("()", [])],
       grinPrimitives = [],
       grinForeignCalls = [labsCall, putcharCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
-      grinCafs = [],
+      grinGlobals = [(grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -392,7 +371,7 @@ foreignIntProgram =
           grinAltBinders = [],
           grinAltRhs =
             GrinBind [output] (GrinForeignCallExpr putcharCall [GrinLitValue (GrinLitInt Int32Rep (toInteger (fromEnum character)))]) $
-              GrinConstant [GrinVarValue unitValue]
+              GrinConstant [GrinGlobalValue (grinVarName unitValue)]
         }
 
 labsCall :: GrinForeignCall
@@ -442,14 +421,10 @@ processExitProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
-      grinCafs = [],
+      grinGlobals = [(grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = IntRep,
               grinFunctionBody = GrinExit (intValue 7)

--- a/components/aihc-native/src/Aihc/Native.hs
+++ b/components/aihc-native/src/Aihc/Native.hs
@@ -374,8 +374,8 @@ emptyLinkLayout =
 programGlobalNames :: GrinProgram -> [Text]
 programGlobalNames program =
   [name | (name, arity) <- programConstructorArities program, arity == 0]
-    <> map (grinVarName . fst) (grinWhnfGlobals program)
-    <> map (grinVarName . fst) (grinCafs program)
+    <> map fst (grinGlobals program)
+    <> grinProgramGlobalReferences program
 
 programConstructorArities :: GrinProgram -> [(Text, Int)]
 programConstructorArities program =

--- a/components/aihc-native/src/Aihc/Native/RegisterAllocate.hs
+++ b/components/aihc-native/src/Aihc/Native/RegisterAllocate.hs
@@ -257,6 +257,7 @@ valueUses :: GrinValue -> Set GrinVar
 valueUses value =
   case value of
     GrinVarValue var -> Set.singleton var
+    GrinGlobalValue {} -> Set.empty
     GrinLitValue {} -> Set.empty
 
 -- | A call whose result is bound by an enclosing 'GrinBind'. Variables live

--- a/components/aihc-native/test/Test/Native/RegisterAllocate.hs
+++ b/components/aihc-native/test/Test/Native/RegisterAllocate.hs
@@ -115,7 +115,6 @@ grinFunction :: [GrinVar] -> GrinExpr -> GrinFunction
 grinFunction parameters body =
   GrinFunction
     { grinFunctionName = FunctionName "loop",
-      grinFunctionLinkName = Nothing,
       grinFunctionParameters = parameters,
       grinFunctionResultRep = IntRep,
       grinFunctionBody = body

--- a/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
+++ b/components/aihc-wasm/src/Aihc/Wasm/Codegen.hs
@@ -17,7 +17,7 @@ where
 import Aihc.Grin.Cps (ContinuationFrameKind (..), continuationFrameKindCode)
 import Aihc.Grin.Gc (GcGrinProgram, gcContinuationFrames, gcContinuationFunctions, gcGrinProgram, gcUpdateFunction)
 import Aihc.Grin.Syntax
-import Aihc.Native (LinkLayout (..), NativeRuntimeCall (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, renderLinkedFunctionSymbol, supportedNativePrimitiveNames)
+import Aihc.Native (LinkLayout (..), NativeRuntimeCall (..), buildAddrLiteralPool, buildLinkLayout, nativeRuntimePrimitiveCall, supportedNativePrimitiveNames)
 import Control.Monad (forM)
 import Data.ByteString qualified as BS
 import Data.Char (ord)
@@ -212,22 +212,14 @@ compileEnvironment unitKind layout gcProgram =
     constructorIds = zip (map fst constructors) [1 ..]
     functionLabels =
       Map.fromList
-        ( [ (grinCodeFunctionName info, linkedFunctionLabel (grinCodeSourceName info))
-          | info <- grinExternalFunctions program
-          ]
-            <> [ (grinFunctionName function, localFunctionLabel index function)
-               | (index, function) <- zip [0 :: Int ..] (grinFunctions program)
-               ]
-        )
+        [ (grinFunctionName function, localFunctionLabel index function)
+        | (index, function) <- zip [0 :: Int ..] (grinFunctions program)
+        ]
     functionArities =
       Map.fromList
-        ( [ (grinCodeFunctionName info, length (concat (grinCodeParameterLayouts info)))
-          | info <- grinExternalFunctions program
-          ]
-            <> [ (grinFunctionName function, length (grinFunctionParameters function))
-               | function <- grinFunctions program
-               ]
-        )
+        [ (grinFunctionName function, length (grinFunctionParameters function))
+        | function <- grinFunctions program
+        ]
     constructorEntries =
       [ (key, label, RuntimeInfo label (Just identifier) Nothing fields remaining next Nothing Nothing (runtimeInfoKeyObjectKind key))
       | ((name, layouts), (_, identifier)) <- zip (linkConstructors layout) constructorIds,
@@ -757,6 +749,10 @@ materializeValue env value = case value of
       Nothing -> case Map.lookup (grinVarName var) (compileGlobalSlots (valueCompileEnv env)) of
         Just slot -> machine <> i64Const (tshow slot) <> call "aihc_wasm_global_get"
         Nothing -> call "aihc_no_match" <> ["unreachable", "i64.const\t0"]
+  GrinGlobalValue name ->
+    case Map.lookup name (compileGlobalSlots (valueCompileEnv env)) of
+      Just slot -> machine <> i64Const (tshow slot) <> call "aihc_wasm_global_get"
+      Nothing -> call "aihc_no_match" <> ["unreachable", "i64.const\t0"]
   GrinLitValue literal -> case literal of
     GrinLitAddr bytes -> case Map.lookup bytes (compileAddrLiteralLabels (valueCompileEnv env)) of
       Just label -> i32Data label <> ["i64.extend_i32_u"]
@@ -878,15 +874,16 @@ compileConstructorInitializers env = forM nullary $ \(name, _identifier) -> do
       ]
 
 compileInitializers :: CompileEnv -> GrinProgram -> Either WasmError [InitialNode]
-compileInitializers env program = mapM withSlot (grinCafs program <> grinWhnfGlobals program)
+compileInitializers env program = mapM withSlot (grinGlobals program)
   where
-    withSlot (var, node) = do
-      slot <- globalSlot env (grinVarName var)
+    withSlot (name, node) = do
+      slot <- globalSlot env name
       info <- nodeHeader env node
       fields <- mapM initialValue (grinNodeFields node)
       pure (InitialNode slot info fields)
     initialValue value = case value of
       GrinVarValue var -> InitialGlobal <$> globalSlot env (grinVarName var)
+      GrinGlobalValue name -> InitialGlobal <$> globalSlot env name
       GrinLitValue literal -> case literal of
         GrinLitAddr bytes -> maybe (Left (WasmUnsupportedValue "unregistered initializer address")) (Right . InitialAddress) (Map.lookup bytes (compileAddrLiteralLabels env))
         _ -> maybe (Left (WasmUnsupportedValue "unsupported initializer literal")) (Right . InitialInteger) (normalizedLiteralInteger literal)
@@ -1209,7 +1206,7 @@ boundVarGroups expression = case expression of
   _ -> []
 
 programNodes :: GrinProgram -> [GrinNode]
-programNodes program = map snd (grinWhnfGlobals program <> grinCafs program) <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
+programNodes program = map snd (grinGlobals program) <> concatMap (exprNodes . grinFunctionBody) (grinFunctions program)
 
 exprNodes :: GrinExpr -> [GrinNode]
 exprNodes expression = case expression of
@@ -1280,10 +1277,7 @@ renderInteger :: Integer -> Text
 renderInteger = tshow
 
 localFunctionLabel :: Int -> GrinFunction -> Text
-localFunctionLabel index function = maybe (".Laihc_wasm_function_" <> tshow index) linkedFunctionLabel (grinFunctionLinkName function)
-
-linkedFunctionLabel :: Text -> Text
-linkedFunctionLabel = renderLinkedFunctionSymbol
+localFunctionLabel index _function = ".Laihc_wasm_function_" <> tshow index
 
 boolInteger :: Bool -> Text
 boolInteger True = "1"

--- a/components/aihc-wasm/test/Test/Wasm/Suite.hs
+++ b/components/aihc-wasm/test/Test/Wasm/Suite.hs
@@ -4,7 +4,7 @@ module Test.Wasm.Suite (tests) where
 
 import Aihc.Grin (lowerGc, toCpsGrin)
 import Aihc.Grin.Syntax
-import Aihc.Native (LinkLayout (..), buildLinkLayout, renderLinkedFunctionSymbol, supportedNativePrimitiveNames)
+import Aihc.Native (LinkLayout (..), buildLinkLayout, supportedNativePrimitiveNames)
 import Aihc.Wasm (WasmError (..), compileModule, compileProgram, compileProgramWithDependencies, validatePrimitiveNames, validateProgramPrimitives)
 import Control.Monad (forM_)
 import Data.Text qualified as T
@@ -67,7 +67,7 @@ testWasmLocals =
       case compileModule (buildLinkLayout [directCallProgram]) "_aihc_init_wasm_locals" (lowerGc cps) of
         Left err -> assertFailure (show err)
         Right source -> do
-          let (_, fromFastEntry) = T.breakOn "aihc_entry_caller:" source
+          let (_, fromFastEntry) = T.breakOn ".Laihc_wasm_function_0:" source
               fastEntry = fst (T.breakOn "\tend_function" fromFastEntry)
           assertBool "reads the incoming parameter directly" ("local.get\t1" `T.isInfixOf` fastEntry)
           assertBool "does not copy fast-entry parameters from memory" (not ("i64.load" `T.isInfixOf` fastEntry))
@@ -82,7 +82,7 @@ testRepeatedParameterLocals =
       case compileModule (buildLinkLayout [repeatedParameterProgram]) "_aihc_init_repeated_parameters" (lowerGc cps) of
         Left err -> assertFailure (show err)
         Right source -> do
-          let label = "\n" <> renderLinkedFunctionSymbol "repeated_parameters" <> ":\n"
+          let label = "\n.Laihc_wasm_function_0:\n"
               (_, fromFunction) = T.breakOn label source
               function = fst (T.breakOn "\tend_function" fromFunction)
           assertBool "uses the bound result local" ("local.set\t" `T.isInfixOf` function)
@@ -124,8 +124,8 @@ testDirectCallArguments =
       case compileModule (buildLinkLayout [directCallProgram]) "_aihc_init_direct_call" (lowerGc cps) of
         Left err -> assertFailure (show err)
         Right source -> do
-          assertBool "declares the exact external fast-entry signature" ("\t.functype\taihc_entry_identity (i32, i64, i64) -> ()" `T.isInfixOf` source)
-          assertBool "tail-calls the known entry" ("return_call\taihc_entry_identity" `T.isInfixOf` source)
+          assertBool "declares the exact local fast-entry signature" ("\t.functype\t.Laihc_wasm_function_1 (i32, i64, i64) -> ()" `T.isInfixOf` source)
+          assertBool "tail-calls the known entry" ("return_call\t.Laihc_wasm_function_1" `T.isInfixOf` source)
           assertBool "does not route known calls through C" (not ("call\taihc_wasm_transfer_direct" `T.isInfixOf` source))
 
 testObjectEntryAdapters :: IO ()
@@ -284,14 +284,10 @@ primitiveProgram primitiveCase =
     { grinConstructors = [],
       grinPrimitives = [(GrinVar name 80 resultRep, length arguments)],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName ("$primitive_" <> name),
-              grinFunctionLinkName = Just ("primitive." <> name),
               grinFunctionParameters = [],
               grinFunctionResultRep = resultRep,
               grinFunctionBody =
@@ -362,18 +358,14 @@ program =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals =
-        [ ( GrinVar "main" 1 (BoxedRep Lifted),
+      grinGlobals =
+        [ ( "main",
             GrinNode (GrinClosure mainFunction [[]]) []
           )
         ],
-      grinCafs = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = IntRep,
               grinFunctionBody = GrinConstant [GrinLitValue (GrinLitInt IntRep 42)]
@@ -390,18 +382,14 @@ exceptionProgram =
     { grinConstructors = [("Exception", [])],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals =
-        [ (exceptionMainClosure, GrinNode (GrinClosure exceptionMainFunction [[]]) []),
-          (exceptionActionClosure, GrinNode (GrinClosure exceptionActionFunction [[]]) []),
-          (exceptionHandlerClosure, GrinNode (GrinClosure exceptionHandlerFunction [[lifted]]) [])
+      grinGlobals =
+        [ (grinVarName exceptionMainClosure, GrinNode (GrinClosure exceptionMainFunction [[]]) []),
+          (grinVarName exceptionActionClosure, GrinNode (GrinClosure exceptionActionFunction [[]]) []),
+          (grinVarName exceptionHandlerClosure, GrinNode (GrinClosure exceptionHandlerFunction [[lifted]]) [])
         ],
-      grinCafs = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = exceptionMainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -413,7 +401,6 @@ exceptionProgram =
             },
           GrinFunction
             { grinFunctionName = exceptionActionFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -424,7 +411,6 @@ exceptionProgram =
             },
           GrinFunction
             { grinFunctionName = exceptionHandlerFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [caughtException],
               grinFunctionResultRep = lifted,
               grinFunctionBody = GrinConstant [GrinVarValue caughtException]
@@ -445,15 +431,14 @@ exceptionProgram =
 dependencyProgram :: GrinProgram
 dependencyProgram =
   program
-    { grinWhnfGlobals =
-        [ ( GrinVar "dependency" 2 (BoxedRep Lifted),
+    { grinGlobals =
+        [ ( "dependency",
             GrinNode (GrinClosure dependencyFunction [[]]) []
           )
         ],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = dependencyFunction,
-              grinFunctionLinkName = Just "Demo.dependency",
               grinFunctionParameters = [],
               grinFunctionResultRep = IntRep,
               grinFunctionBody = GrinConstant [GrinLitValue (GrinLitInt IntRep 7)]
@@ -470,18 +455,14 @@ capturedThunkProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs =
-        [ ( GrinVar "thunk" 3 (BoxedRep Lifted),
+      grinGlobals =
+        [ ( "thunk",
             GrinNode (GrinThunk thunkFunction) [GrinLitValue (GrinLitInt IntRep 41)]
           )
         ],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = thunkFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [captured],
               grinFunctionResultRep = IntRep,
               grinFunctionBody = GrinConstant [GrinVarValue captured]
@@ -498,29 +479,25 @@ directCallProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions =
-        [ GrinCodeInfo
-            { grinCodeSourceName = "identity",
-              grinCodeFunctionName = identityFunction,
-              grinCodeParameterLayouts = [[BoxedRep Lifted]],
-              grinCodeResultRep = BoxedRep Lifted
-            }
-        ],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$caller",
-              grinFunctionLinkName = Just "caller",
               grinFunctionParameters = [argument],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody = GrinCall (BoxedRep Lifted) identityFunction [GrinVarValue argument]
+            },
+          GrinFunction
+            { grinFunctionName = identityFunction,
+              grinFunctionParameters = [identityArgument],
+              grinFunctionResultRep = BoxedRep Lifted,
+              grinFunctionBody = GrinConstant [GrinVarValue identityArgument]
             }
         ]
     }
   where
     argument = GrinVar "argument" 50 (BoxedRep Lifted)
+    identityArgument = GrinVar "identity_argument" 51 (BoxedRep Lifted)
     identityFunction = FunctionName "$identity"
 
 repeatedParameterProgram :: GrinProgram
@@ -529,14 +506,10 @@ repeatedParameterProgram =
     { grinConstructors = [],
       grinPrimitives = [(GrinVar "+#" 51 IntRep, 2)],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$repeated_parameters",
-              grinFunctionLinkName = Just "repeated_parameters",
               grinFunctionParameters = [argument, argument],
               grinFunctionResultRep = IntRep,
               grinFunctionBody =
@@ -557,14 +530,10 @@ gcRootProgram =
     { grinConstructors = [("Box", [[BoxedRep Lifted]])],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$allocate_box",
-              grinFunctionLinkName = Just "allocate_box",
               grinFunctionParameters = [root],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody = GrinStore (GrinNode (GrinConstructor "Box" 0) [GrinVarValue root])
@@ -580,14 +549,10 @@ literalCaseProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$literal_case",
-              grinFunctionLinkName = Just "literal_case",
               grinFunctionParameters = [input],
               grinFunctionResultRep = IntRep,
               grinFunctionBody =
@@ -614,14 +579,10 @@ byteArrayProgram =
           (GrinVar "mutableByteArrayContents#" 62 AddrRep, 1)
         ],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$byte_array",
-              grinFunctionLinkName = Just "byte_array",
               grinFunctionParameters = [],
               grinFunctionResultRep = AddrRep,
               grinFunctionBody =
@@ -643,14 +604,10 @@ foreignIntProgram =
     { grinConstructors = [],
       grinPrimitives = [],
       grinForeignCalls = [takeResultCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$foreign_int",
-              grinFunctionLinkName = Just "foreign_int",
               grinFunctionParameters = [request],
               grinFunctionResultRep = IntRep,
               grinFunctionBody = GrinForeignCallExpr takeResultCall [GrinVarValue request]
@@ -677,14 +634,10 @@ mvarProgram =
           (GrinVar "takeMVar#" 73 (BoxedRep Lifted), 2)
         ],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$mvars",
-              grinFunctionLinkName = Just "mvars",
               grinFunctionParameters = [],
               grinFunctionResultRep = BoxedRep Lifted,
               grinFunctionBody =
@@ -708,10 +661,7 @@ intPrimitiveProgram =
     { grinConstructors = [],
       grinPrimitives = [(GrinVar name unique IntRep, 2) | (name, unique) <- zip primitiveNames [90 ..]],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions = zipWith primitiveFunction primitiveNames [100 ..]
     }
   where
@@ -719,7 +669,6 @@ intPrimitiveProgram =
     primitiveFunction name unique =
       GrinFunction
         { grinFunctionName = FunctionName ("$" <> name),
-          grinFunctionLinkName = Just ("primitive_" <> name),
           grinFunctionParameters = [left unique, right unique],
           grinFunctionResultRep = IntRep,
           grinFunctionBody = GrinPrimitiveCall IntRep name [GrinVarValue (left unique), GrinVarValue (right unique)]
@@ -733,14 +682,10 @@ dormantPrimitiveProgram =
     { grinConstructors = [],
       grinPrimitives = [(GrinVar "unsupported#" 40 IntRep, 1)],
       grinForeignCalls = [],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [],
-      grinCafs = [],
+      grinGlobals = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = FunctionName "$dormant_unsupported",
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = IntRep,
               grinFunctionBody =

--- a/test/Test/Fixtures/grin-snapshot/fork.yaml
+++ b/test/Test/Fixtures/grin-snapshot/fork.yaml
@@ -2,10 +2,10 @@ entry: $fork_snapshot_main
 program: |
   constructor ChildResult/0 []
   primitive fork#%1 :: BoxedRep Lifted/2
-  global child%2 :: BoxedRep Lifted = (P$fork_snapshot_child/[[]])
+  global child = (P$fork_snapshot_child/[[]])
 
   $fork_snapshot_main -> BoxedRep Unlifted =
-    (thread_id%3 :: BoxedRep Unlifted) <- primitive-call @(TupleRep [TupleRep [], BoxedRep Unlifted]) fork# (child%2 :: BoxedRep Lifted)
+    (thread_id%3 :: BoxedRep Unlifted) <- primitive-call @(TupleRep [TupleRep [], BoxedRep Unlifted]) fork# global-ref child
     constant (thread_id%3 :: BoxedRep Unlifted)
 
   $fork_snapshot_child -> BoxedRep Lifted =

--- a/test/Test/Fixtures/grin-snapshot/yield.yaml
+++ b/test/Test/Fixtures/grin-snapshot/yield.yaml
@@ -4,16 +4,16 @@ program: |
   constructor ChildResult/0 []
   primitive fork#%1 :: BoxedRep Lifted/2
   primitive yield#%2 :: BoxedRep Lifted/1
-  global child%3 :: BoxedRep Lifted = (P$yield_snapshot_child/[[]])
-  caf shared%4 :: BoxedRep Lifted = (F$yield_snapshot_shared)
+  global child = (P$yield_snapshot_child/[[]])
+  global shared = (F$yield_snapshot_shared)
 
   $yield_snapshot_main -> BoxedRep Lifted =
-    (thread_id%5 :: BoxedRep Unlifted) <- primitive-call @(TupleRep [TupleRep [], BoxedRep Unlifted]) fork# (child%3 :: BoxedRep Lifted)
+    (thread_id%5 :: BoxedRep Unlifted) <- primitive-call @(TupleRep [TupleRep [], BoxedRep Unlifted]) fork# global-ref child
     () <- primitive-call @(TupleRep []) yield#
-    store (CSchedulerSnapshot (thread_id%5 :: BoxedRep Unlifted) (shared%4 :: BoxedRep Lifted))
+    store (CSchedulerSnapshot (thread_id%5 :: BoxedRep Unlifted) global-ref shared)
 
   $yield_snapshot_child -> BoxedRep Lifted =
-    eval @(BoxedRep Lifted) (shared%4 :: BoxedRep Lifted)
+    eval @(BoxedRep Lifted) global-ref shared
 
   $yield_snapshot_shared -> BoxedRep Lifted =
     store (CChildResult)

--- a/test/Test/Fixtures/grin/boxed-int-field.yaml
+++ b/test/Test/Fixtures/grin/boxed-int-field.yaml
@@ -1,13 +1,23 @@
 expected: |-
-  constructor main:Test.Box [IntRep]
+  constructor Test.Box [IntRep]
 
-  global value%1002 :: BoxedRep Lifted = (Cmain:Test.Box (42 :: IntRep))
+  global "\NULTest\NULBox" = (CTest.Box/1)
+
+  global "\NULTest\NULvalue" = (F$grin_value_thunk_0)
+
+  $grin_value_thunk_0 -> BoxedRep Lifted =
+    argument%-1000000001 :: IntRep <-
+      constant (42 :: IntRep)
+    function_whnf%-1000000000 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULTest\NULBox"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) (argument%-1000000001 :: IntRep)
 extensions:
 - MagicHash
 reason: initializes a static lifted constructor directly and preserves its IntRep
   field representation
 source: |
   module Test where
+  import GHC.Prim
   data Box = Box Int#
   value :: Box
   value = Box 42#

--- a/test/Test/Fixtures/grin/existential-constructor-pattern.yaml
+++ b/test/Test/Fixtures/grin/existential-constructor-pattern.yaml
@@ -7,6 +7,23 @@ source: |
   copyBox :: Box -> Box
   copyBox box = case box of
     Box value -> Box value
-expected: ""
-status: xfail
-reason: the lowerer does not add alternative type binders to the local type environment
+expected: |-
+  constructor Test.Box [BoxedRep Lifted]
+
+  global "\NULTest\NULBox" = (CTest.Box/1)
+
+  global "\NULTest\NULcopyBox" = (F$grin_copyBox_thunk_0)
+
+  $grin_closure_1 (x%-1000000000 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    case_value%-1000000001 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) (x%-1000000000 :: BoxedRep Lifted)
+    case (case_value%-1000000001 :: BoxedRep Lifted) as _scrut%-1000000002 :: BoxedRep Lifted of
+      data Test.Box (value%-1000000003 :: BoxedRep Lifted) ->
+        function_whnf%-1000000004 :: BoxedRep Lifted <-
+          eval @(BoxedRep Lifted) global-ref "\NULTest\NULBox"
+        apply @(BoxedRep Lifted) (function_whnf%-1000000004 :: BoxedRep Lifted) (value%-1000000003 :: BoxedRep Lifted)
+
+  $grin_copyBox_thunk_0 -> BoxedRep Lifted =
+    store (P$grin_closure_1/1)
+status: pass
+reason: preserves the lifted representation of an existential constructor field

--- a/test/Test/Fixtures/grin/existential-constructor-pattern.yaml
+++ b/test/Test/Fixtures/grin/existential-constructor-pattern.yaml
@@ -1,0 +1,12 @@
+extensions:
+- ExistentialQuantification
+source: |
+  module Test where
+  import GHC.Prim
+  data Box = forall a. Box a
+  copyBox :: Box -> Box
+  copyBox box = case box of
+    Box value -> Box value
+expected: ""
+status: xfail
+reason: the lowerer does not add alternative type binders to the local type environment

--- a/test/Test/Fixtures/grin/foreign-ccall.yaml
+++ b/test/Test/Fixtures/grin/foreign-ccall.yaml
@@ -1,0 +1,16 @@
+expected: |-
+  foreign labs = "labs" :: (int) -> int ! pure
+
+  global "\NULTest\NULlabs" = (P$grin_labs_foreign_0/[[IntRep]])
+
+  $grin_labs_foreign_0 (foreign_argument_0%-1000000000 :: IntRep) -> IntRep =
+    foreign-call labs = "labs" :: (int) -> int ! pure with (foreign_argument_0%-1000000000 :: IntRep)
+extensions:
+- ForeignFunctionInterface
+- MagicHash
+source: |
+  module Test where
+  import GHC.Prim
+  foreign import ccall unsafe "labs" labs :: Int# -> Int#
+reason: creates a local heap closure around a C foreign call
+status: pass

--- a/test/Test/Fixtures/grin/imported-function-and-caf.yaml
+++ b/test/Test/Fixtures/grin/imported-function-and-caf.yaml
@@ -1,0 +1,53 @@
+expected: |-
+  constructor Dependency.Box [IntRep]
+
+  global "\NULDependency\NULBox" = (CDependency.Box/1)
+
+  global "\NULDependency\NULidentity" = (F$grin_identity_thunk_0)
+
+  global "\NULDependency\NULcaf" = (F$grin_caf_thunk_2)
+
+  $grin_closure_1 (x%-1000000000 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    eval @(BoxedRep Lifted) (x%-1000000000 :: BoxedRep Lifted)
+
+  $grin_identity_thunk_0 -> BoxedRep Lifted =
+    store (P$grin_closure_1/1)
+
+  $grin_caf_thunk_2 -> BoxedRep Lifted =
+    argument%-1000000002 :: IntRep <-
+      constant (7 :: IntRep)
+    function_whnf%-1000000001 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULDependency\NULBox"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000001 :: BoxedRep Lifted) (argument%-1000000002 :: IntRep)
+  global "\NULTarget\NULuseFunction" = (F$grin_useFunction_thunk_0)
+
+  global "\NULTarget\NULuseCaf" = (F$grin_useCaf_thunk_1)
+
+  $grin_useFunction_thunk_0 -> BoxedRep Lifted =
+    function_whnf%-1000000000 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULDependency\NULidentity"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) global-ref "\NULDependency\NULcaf"
+
+  $grin_useCaf_thunk_1 -> BoxedRep Lifted =
+    eval @(BoxedRep Lifted) global-ref "\NULDependency\NULcaf"
+extensions:
+- MagicHash
+modules:
+- |
+  module Dependency where
+  import GHC.Prim
+  data Box = Box Int#
+  identity :: Box -> Box
+  identity value = value
+  caf :: Box
+  caf = Box 7#
+- |
+  module Target where
+  import GHC.Prim
+  import Dependency
+  useFunction :: Box
+  useFunction = identity caf
+  useCaf :: Box
+  useCaf = caf
+reason: uses the shared FC2 type environment without dependency program access
+status: pass

--- a/test/Test/Fixtures/grin/narrow-integer-fields.yaml
+++ b/test/Test/Fixtures/grin/narrow-integer-fields.yaml
@@ -1,7 +1,25 @@
 expected: |-
-  constructor main:Test.Narrow [Int8Rep, Word16Rep]
+  constructor Test.Narrow [Int8Rep, Word16Rep]
 
-  global value%1002 :: BoxedRep Lifted = (Cmain:Test.Narrow (123 :: Int8Rep) (456 :: Word16Rep))
+  global "\NULTest\NULNarrow" = (CTest.Narrow/2)
+
+  global "\NULTest\NULvalue" = (F$grin_value_thunk_0)
+
+  $grin_function_thunk_1 -> BoxedRep Lifted =
+    argument%-1000000001 :: Int8Rep <-
+      constant (123 :: Int8Rep)
+    function_whnf%-1000000000 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULTest\NULNarrow"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) (argument%-1000000001 :: Int8Rep)
+
+  $grin_value_thunk_0 -> BoxedRep Lifted =
+    function%-1000000002 :: BoxedRep Lifted <-
+      store (F$grin_function_thunk_1)
+    argument%-1000000004 :: Word16Rep <-
+      constant (456 :: Word16Rep)
+    function_whnf%-1000000003 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) (function%-1000000002 :: BoxedRep Lifted)
+    apply @(BoxedRep Lifted) (function_whnf%-1000000003 :: BoxedRep Lifted) (argument%-1000000004 :: Word16Rep)
 extensions:
 - MagicHash
 - ExtendedLiterals
@@ -9,6 +27,7 @@ reason: initializes a static constructor directly while preserving distinct narr
   signed and unsigned runtime representations
 source: |
   module Test where
+  import GHC.Prim
   data Narrow = Narrow Int8# Word16#
   value :: Narrow
   value = Narrow 123#Int8 456#Word16

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -1,15 +1,22 @@
 expected: |-
-  constructor main:Test.IS [IntRep]
+  constructor Test.IS [IntRep]
 
-  caf value%1003 :: BoxedRep Lifted = (Fvalue_thunk)
+  global "\NULTest\NULIS" = (CTest.IS/1)
 
-  value_thunk -> BoxedRep Lifted =
-    store (Cmain:Test.IS (42 :: IntRep))
+  global "\NULTest\NULvalue" = (F$grin_value_thunk_0)
+
+  $grin_value_thunk_0 -> BoxedRep Lifted =
+    argument%-1000000001 :: IntRep <-
+      constant (42 :: IntRep)
+    function_whnf%-1000000000 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULTest\NULIS"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) (argument%-1000000001 :: IntRep)
 extensions:
 - MagicHash
 reason: erases newtype constructors and casts before producing runtime GRIN
 source: |
   module Test where
+  import GHC.Prim
   data Int = IS Int#
   newtype Identity a = Identity a
   value :: Identity Int

--- a/test/Test/Fixtures/grin/newtype-erasure.yaml
+++ b/test/Test/Fixtures/grin/newtype-erasure.yaml
@@ -5,15 +5,30 @@ expected: |-
 
   global "\NULTest\NULvalue" = (F$grin_value_thunk_0)
 
-  $grin_value_thunk_0 -> BoxedRep Lifted =
-    argument%-1000000001 :: IntRep <-
+  $grin_closure_2 (_newtype%-1000000000 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    eval @(BoxedRep Lifted) (_newtype%-1000000000 :: BoxedRep Lifted)
+
+  $grin_function_thunk_1 -> BoxedRep Lifted =
+    store (P$grin_closure_2/1)
+
+  $grin_argument_thunk_3 -> BoxedRep Lifted =
+    argument%-1000000004 :: IntRep <-
       constant (42 :: IntRep)
-    function_whnf%-1000000000 :: BoxedRep Lifted <-
+    function_whnf%-1000000003 :: BoxedRep Lifted <-
       eval @(BoxedRep Lifted) global-ref "\NULTest\NULIS"
-    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) (argument%-1000000001 :: IntRep)
+    apply @(BoxedRep Lifted) (function_whnf%-1000000003 :: BoxedRep Lifted) (argument%-1000000004 :: IntRep)
+
+  $grin_value_thunk_0 -> BoxedRep Lifted =
+    function%-1000000001 :: BoxedRep Lifted <-
+      store (F$grin_function_thunk_1)
+    argument%-1000000005 :: BoxedRep Lifted <-
+      store (F$grin_argument_thunk_3)
+    function_whnf%-1000000002 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) (function%-1000000001 :: BoxedRep Lifted)
+    apply @(BoxedRep Lifted) (function_whnf%-1000000002 :: BoxedRep Lifted) (argument%-1000000005 :: BoxedRep Lifted)
 extensions:
 - MagicHash
-reason: erases newtype constructors and casts before producing runtime GRIN
+reason: does not allocate a newtype node and preserves its lifted coercion
 source: |
   module Test where
   import GHC.Prim

--- a/test/Test/Fixtures/grin/primitive-seq.yaml
+++ b/test/Test/Fixtures/grin/primitive-seq.yaml
@@ -1,0 +1,32 @@
+expected: |-
+  constructor Test.First []
+
+  constructor Test.Second []
+
+  global "\NULTest\NULFirst" = (CTest.First)
+
+  global "\NULTest\NULSecond" = (CTest.Second)
+
+  global "\NULTest\NULseq" = (P$grin_seq_foreign_0/2)
+
+  global "\NULTest\NULvalue" = (F$grin_value_thunk_1)
+
+  $grin_seq_foreign_0 (foreign_argument_0%-1000000000 :: BoxedRep Lifted) (foreign_argument_1%-1000000001 :: BoxedRep Lifted) -> BoxedRep Lifted =
+    seq%-1000000002 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) (foreign_argument_0%-1000000000 :: BoxedRep Lifted)
+    constant (foreign_argument_1%-1000000001 :: BoxedRep Lifted)
+
+  $grin_value_thunk_1 -> BoxedRep Lifted =
+    seq%-1000000003 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULTest\NULFirst"
+    constant global-ref "\NULTest\NULSecond"
+extensions: []
+source: |
+  module Test where
+  data First = First
+  data Second = Second
+  foreign import prim seq :: a -> b -> b
+  value :: Second
+  value = seq First Second
+reason: lowers the compiler primitive to explicit evaluation
+status: pass

--- a/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-case.yaml
@@ -1,16 +1,24 @@
 expected: |-
-  constructor main:Test.Box [IntRep]
+  constructor Test.Box [IntRep]
 
-  caf value%1008 :: BoxedRep Lifted = (Fvalue_thunk)
+  global "\NULTest\NULBox" = (CTest.Box/1)
 
-  value_thunk -> BoxedRep Lifted =
-    $grin__case_value_0_1010%1010 :: IntRep, $grin__case_value_1_1011%1011 :: WordRep <-
-      constant (1 :: IntRep) (2 :: WordRep)
-    $grin_tuple_1012%1012 :: IntRep, $grin_tuple_1013%1013 :: WordRep <-
-      constant ($grin__case_value_0_1010%1010 :: IntRep) ($grin__case_value_1_1011%1011 :: WordRep)
-    $grin_argument_1009%1009 :: IntRep <-
-      constant ($grin_tuple_1012%1012 :: IntRep)
-    store (Cmain:Test.Box ($grin_argument_1009%1009 :: IntRep))
+  global "\NULTest\NULvalue" = (F$grin_value_thunk_0)
+
+  $grin_value_thunk_0 -> BoxedRep Lifted =
+    argument%-1000000006 :: IntRep <-
+      constant (1 :: IntRep)
+    argument%-1000000007 :: WordRep <-
+      constant (2 :: WordRep)
+    _case%-1000000002 :: IntRep, _case%-1000000003 :: WordRep <-
+      constant (argument%-1000000006 :: IntRep) (argument%-1000000007 :: WordRep)
+    first%-1000000004 :: IntRep, _pat%-1000000005 :: WordRep <-
+      constant (_case%-1000000002 :: IntRep) (_case%-1000000003 :: WordRep)
+    argument%-1000000001 :: IntRep <-
+      constant (first%-1000000004 :: IntRep)
+    function_whnf%-1000000000 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULTest\NULBox"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) (argument%-1000000001 :: IntRep)
 extensions:
 - MagicHash
 - UnboxedTuples
@@ -18,6 +26,7 @@ reason: returns heterogeneous unboxed-tuple components directly without allocati
   or matching a node
 source: |
   module Test where
+  import GHC.Prim
   data Box = Box Int#
   value :: Box
   value = Box (case (# 1#, 2## #) of (# first, _ #) -> first)

--- a/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
+++ b/test/Test/Fixtures/grin/unboxed-tuple-zero-width.yaml
@@ -1,14 +1,29 @@
 expected: |-
-  constructor main:Test.Box [IntRep]
+  constructor Test.Box [IntRep]
 
-  primitive realWorld#%1000 :: BoxedRep Lifted/0
+  primitive realWorld#%-2000000000 :: TupleRep []/0
 
-  caf value%1010 :: BoxedRep Lifted = (Fvalue_thunk)
+  global "\NULTest\NULBox" = (CTest.Box/1)
 
-  value_thunk -> BoxedRep Lifted =
-    $grin_argument_1011%1011 :: IntRep <-
+  global "\NULTest\NULrealWorld#" = (P$grin_realWorld#_foreign_0/0)
+
+  global "\NULTest\NULvalue" = (F$grin_value_thunk_1)
+
+  $grin_realWorld#_foreign_0 -> TupleRep [] =
+    primitive-call @(TupleRep []) realWorld#
+
+  $grin_value_thunk_1 -> BoxedRep Lifted =
+    argument%-1000000004 :: IntRep <-
       constant (42 :: IntRep)
-    store (Cmain:Test.Box ($grin_argument_1011%1011 :: IntRep))
+    _case%-1000000002 :: IntRep <-
+      constant (argument%-1000000004 :: IntRep)
+    answer%-1000000003 :: IntRep <-
+      constant (_case%-1000000002 :: IntRep)
+    argument%-1000000001 :: IntRep <-
+      constant (answer%-1000000003 :: IntRep)
+    function_whnf%-1000000000 :: BoxedRep Lifted <-
+      eval @(BoxedRep Lifted) global-ref "\NULTest\NULBox"
+    apply @(BoxedRep Lifted) (function_whnf%-1000000000 :: BoxedRep Lifted) (argument%-1000000001 :: IntRep)
 extensions:
 - EmptyDataDecls
 - MagicHash
@@ -16,8 +31,7 @@ extensions:
 reason: omits zero-width State# components from unboxed-tuple returns and binds
 source: |
   module Test where
-  data State# s
-  data RealWorld
+  import GHC.Prim
   data Box = Box Int#
   foreign import prim realWorld# :: State# RealWorld
   value :: Box

--- a/test/support/Aihc/Testing/ExceptionProgram.hs
+++ b/test/support/Aihc/Testing/ExceptionProgram.hs
@@ -16,41 +16,35 @@ synchronousExceptionProgram =
     { grinConstructors = [("Exception", [])],
       grinPrimitives = [],
       grinForeignCalls = [putcharCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals =
-        [ (mainClosure, GrinNode (GrinClosure mainFunction [[]]) []),
-          (outerActionClosure, GrinNode (GrinClosure outerActionFunction [[]]) []),
-          (failingActionClosure, GrinNode (GrinClosure failingActionFunction [[]]) []),
-          (rethrowHandlerClosure, GrinNode (GrinClosure rethrowHandlerFunction [[lifted]]) []),
-          (outerHandlerClosure, GrinNode (GrinClosure outerHandlerFunction [[lifted]]) [])
+      grinGlobals =
+        [ (grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) []),
+          (grinVarName outerActionClosure, GrinNode (GrinClosure outerActionFunction [[]]) []),
+          (grinVarName failingActionClosure, GrinNode (GrinClosure failingActionFunction [[]]) []),
+          (grinVarName rethrowHandlerClosure, GrinNode (GrinClosure rethrowHandlerFunction [[lifted]]) []),
+          (grinVarName outerHandlerClosure, GrinNode (GrinClosure outerHandlerFunction [[lifted]]) []),
+          (grinVarName failingThunk, GrinNode (GrinThunk failingThunkFunction) [])
         ],
-      grinCafs = [(failingThunk, GrinNode (GrinThunk failingThunkFunction) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
-              grinFunctionBody = GrinCatch lifted (GrinVarValue outerActionClosure) (GrinVarValue outerHandlerClosure) []
+              grinFunctionBody = GrinCatch lifted (global outerActionClosure) (global outerHandlerClosure) []
             },
           GrinFunction
             { grinFunctionName = outerActionFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
-              grinFunctionBody = GrinCatch lifted (GrinVarValue failingActionClosure) (GrinVarValue rethrowHandlerClosure) []
+              grinFunctionBody = GrinCatch lifted (global failingActionClosure) (global rethrowHandlerClosure) []
             },
           GrinFunction
             { grinFunctionName = failingActionFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
-              grinFunctionBody = GrinEval lifted (GrinVarValue failingThunk)
+              grinFunctionBody = GrinEval lifted (global failingThunk)
             },
           GrinFunction
             { grinFunctionName = failingThunkFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -61,14 +55,12 @@ synchronousExceptionProgram =
             },
           GrinFunction
             { grinFunctionName = rethrowHandlerFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [innerException],
               grinFunctionResultRep = lifted,
               grinFunctionBody = GrinThrow (GrinVarValue innerException)
             },
           GrinFunction
             { grinFunctionName = outerHandlerFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [outerException],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -100,6 +92,7 @@ synchronousExceptionProgram =
     innerException = GrinVar "inner_exception" 8 lifted
     outerException = GrinVar "outer_exception" 9 lifted
     output = GrinVar "output" 10 Int32Rep
+    global = GrinGlobalValue . grinVarName
 
 putcharCall :: GrinForeignCall
 putcharCall =

--- a/test/support/Aihc/Testing/SchedulerProgram.hs
+++ b/test/support/Aihc/Testing/SchedulerProgram.hs
@@ -18,36 +18,31 @@ schedulerProgram =
           (GrinVar "yield#" 2 lifted, 1)
         ],
       grinForeignCalls = [putcharCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals =
-        [ (mainClosure, GrinNode (GrinClosure mainFunction [[]]) []),
-          (childClosure, GrinNode (GrinClosure childFunction [[]]) [])
+      grinGlobals =
+        [ (grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) []),
+          (grinVarName childClosure, GrinNode (GrinClosure childFunction [[]]) [])
         ],
-      grinCafs = [],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
-                GrinBind [threadId] (GrinPrimitiveCall forkResultRep "fork#" [GrinVarValue childClosure]) $
+                GrinBind [threadId] (GrinPrimitiveCall forkResultRep "fork#" [global childClosure]) $
                   GrinBind [parentBeforeYield] (putchar 'P') $
                     GrinBind [] (GrinPrimitiveCall (TupleRep []) "yield#" []) $
                       GrinBind [parentAfterYield] (putchar 'A') $
                         GrinBind [] (GrinPrimitiveCall (TupleRep []) "yield#" []) $
                           GrinBind [parentAfterSoloYield] (putchar 'B') $
-                            GrinConstant [GrinVarValue unitValue]
+                            GrinConstant [global unitValue]
             },
           GrinFunction
             { grinFunctionName = childFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
                 GrinBind [childOutput] (putchar 'C') $
-                  GrinConstant [GrinVarValue unitValue]
+                  GrinConstant [global unitValue]
             }
         ]
     }
@@ -64,6 +59,7 @@ schedulerProgram =
     childOutput = GrinVar "child_output" 8 Int32Rep
     unitValue = GrinVar "()" 9 lifted
     parentAfterSoloYield = GrinVar "parent_after_solo_yield" 10 Int32Rep
+    global = GrinGlobalValue . grinVarName
     putchar char =
       GrinForeignCallExpr
         putcharCall
@@ -79,14 +75,10 @@ stdioSchedulerProgram =
           (GrinVar "mutableByteArrayContents#" 32 AddrRep, 1)
         ],
       grinForeignCalls = [stdinCall, stdoutCall, submitReadCall, submitWriteCall, takeResultCall],
-      grinExternalGlobals = [],
-      grinExternalFunctions = [],
-      grinWhnfGlobals = [(mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
-      grinCafs = [],
+      grinGlobals = [(grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
@@ -100,7 +92,7 @@ stdioSchedulerProgram =
                               GrinBind [writeRequest] (GrinForeignCallExpr submitWriteCall [GrinVarValue stdoutIOHandle, GrinVarValue bufferContents, int32 0, GrinVarValue readCount]) $
                                 GrinBind [] (GrinPrimitiveCall (TupleRep []) "awaitIO#" [GrinVarValue writeRequest]) $
                                   GrinBind [writeResult] (GrinForeignCallExpr takeResultCall [GrinVarValue writeRequest]) $
-                                    GrinConstant [GrinVarValue unitValue]
+                                    GrinConstant [GrinGlobalValue (grinVarName unitValue)]
             }
         ]
     }
@@ -152,40 +144,37 @@ putcharCall =
 blackholeSchedulerProgram :: GrinProgram
 blackholeSchedulerProgram =
   schedulerProgram
-    { grinWhnfGlobals =
-        [ (mainClosure, GrinNode (GrinClosure mainFunction [[]]) []),
-          (childClosure, GrinNode (GrinClosure childFunction [[]]) [])
+    { grinGlobals =
+        [ (grinVarName mainClosure, GrinNode (GrinClosure mainFunction [[]]) []),
+          (grinVarName childClosure, GrinNode (GrinClosure childFunction [[]]) []),
+          (grinVarName sharedThunk, GrinNode (GrinThunk sharedFunction) [])
         ],
-      grinCafs = [(sharedThunk, GrinNode (GrinThunk sharedFunction) [])],
       grinFunctions =
         [ GrinFunction
             { grinFunctionName = mainFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
-                GrinBind [threadId] (GrinPrimitiveCall forkResultRep "fork#" [GrinVarValue childClosure]) $
+                GrinBind [threadId] (GrinPrimitiveCall forkResultRep "fork#" [global childClosure]) $
                   GrinBind [] (GrinPrimitiveCall (TupleRep []) "yield#" []) $
-                    GrinBind [mainShared] (GrinEval lifted (GrinVarValue sharedThunk)) $
+                    GrinBind [mainShared] (GrinEval lifted (global sharedThunk)) $
                       GrinBind [parentOutput] (putchar 'A') $
-                        GrinConstant [GrinVarValue unitValue]
+                        GrinConstant [global unitValue]
             },
           GrinFunction
             { grinFunctionName = childFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
-              grinFunctionBody = GrinEval lifted (GrinVarValue sharedThunk)
+              grinFunctionBody = GrinEval lifted (global sharedThunk)
             },
           GrinFunction
             { grinFunctionName = sharedFunction,
-              grinFunctionLinkName = Nothing,
               grinFunctionParameters = [],
               grinFunctionResultRep = lifted,
               grinFunctionBody =
                 GrinBind [] (GrinPrimitiveCall (TupleRep []) "yield#" []) $
                   GrinBind [thunkOutput] (putchar 'T') $
-                    GrinConstant [GrinVarValue unitValue]
+                    GrinConstant [global unitValue]
             }
         ]
     }
@@ -203,6 +192,7 @@ blackholeSchedulerProgram =
     parentOutput = GrinVar "parent_output" 25 Int32Rep
     thunkOutput = GrinVar "thunk_output" 26 Int32Rep
     unitValue = GrinVar "()" 27 lifted
+    global = GrinGlobalValue . grinVarName
     putchar char =
       GrinForeignCallExpr
         putcharCall


### PR DESCRIPTION
## Summary

- Add a direct and conservative FC2-to-GRIN pass.
- Use only one FC2 program and one shared FC2 type environment.
- Replace separate CAF and external fields with one global table.
- Add explicit global references to GRIN syntax.
- Update GRIN passes, interpreters, and backends for the new interface.
- Restore source-to-GRIN fixture execution with current compiler stages.
- Add `install-v2 --keep-grin` and missing-file repair.

## Progress

- Increase source GRIN fixtures from 5 to 9.
- Increase `aihc` command tests from 11 to 12.

## Validation

- Run `just fmt` successfully.
- Run `just check` successfully.
