### PR TITLE
refactor(tc): remove unboxed tuple type rendering

### DIFF
--- a/components/aihc-tc/src/Aihc/Tc/Annotations.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Annotations.hs
@@ -57,7 +57,7 @@ import Aihc.Parser.Syntax
 import Aihc.Resolve (ResolutionNamespace (..))
 import Aihc.Tc.Env (DataTypeInfo)
 import Aihc.Tc.Evidence (EvTerm, EvVar)
-import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, isUnboxedTupleType, tyConModuleName, tyConNamespace, pattern KType)
+import Aihc.Tc.Types (Pred (..), TcType (..), TyCon (..), TyVarId (..), Unique (..), boxedTupleTyConName, tyConModuleName, tyConNamespace, pattern KType)
 import Data.Text (Text)
 import Data.Text qualified as T
 
@@ -307,9 +307,6 @@ renderTcTypeInModule currentModule = go 0
         isBoxedTupleCon name arity,
         arity == length args =
           "(" ++ commaSep (map (go 0) args) ++ ")"
-    go _ tupleType@(TcTyCon _ args)
-      | isUnboxedTupleType tupleType =
-          "(# " ++ commaSep (map (go 0) args) ++ " #)"
     go _ (TcTyCon tc []) = T.unpack (renderTyConName tc)
     go p (TcTyCon tc args) =
       parenIf (p >= 2) $

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -21,7 +21,6 @@ module Aihc.Tc.Types
     TypeScheme (..),
     boxedTupleTyConName,
     unboxedTupleTyConName,
-    isUnboxedTupleType,
     typeTyCon,
     constraintTyCon,
     runtimeRepTyCon,
@@ -59,7 +58,6 @@ module Aihc.Tc.Types
     runtimeRepOfTypeInEnv,
     isLiftedTypeInEnv,
     isUnliftedTypeInEnv,
-    isUnboxedTupleTypeWithKind,
     pattern KTYPE,
     pattern KConstraint,
     pattern KRuntimeRep,
@@ -550,21 +548,6 @@ runtimeRepFromKind kind =
     TcTyCon tyCon [representation]
       | tyConName tyCon == "TYPE" -> Right representation
     _ -> Left ("type does not have a runtime representation: " <> show kind)
-
-isUnboxedTupleTypeWithKind :: TcType -> TcType -> Bool
-isUnboxedTupleTypeWithKind ty kind =
-  case (ty, runtimeRepFromKind kind) of
-    (TcTyCon tyCon arguments, Right (TupleRep fields)) ->
-      tyConName tyCon == unboxedTupleTyConName (length arguments)
-        && tyConArity tyCon == length arguments
-        && length fields == length arguments
-    _ -> False
-
-isUnboxedTupleType :: TcType -> Bool
-isUnboxedTupleType (TcTyCon tyCon arguments) =
-  tyConName tyCon == unboxedTupleTyConName (length arguments)
-    && tyConArity tyCon == length arguments
-isUnboxedTupleType _ = False
 
 newtype TcLevel = TcLevel Int
   deriving (Eq, Ord, Show, Read)

--- a/components/aihc-tc/test/Test/Fixtures/annotated/foreign-import-prim-unboxed-tuple.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/foreign-import-prim-unboxed-tuple.yaml
@@ -3,9 +3,9 @@ annotated:
   module Test where
   import GHC.Prim (Int#)
   foreign import prim "tup" tuple :: () -> (# Int#, Int# #)
-  └─ type: () → (# Int#, Int# #)
+  └─ type: () → Tuple2# Int# Int#
   test = tuple
-  └─ type: () → (# Int#, Int# #)
+  └─ type: () → Tuple2# Int# Int#
 extensions:
 - GHCForeignImportPrim
 - MagicHash

--- a/components/aihc-tc/test/Test/Fixtures/annotated/standalone-kind-signature.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/standalone-kind-signature.yaml
@@ -4,7 +4,7 @@ annotated:
   import GHC.Types (RuntimeRep(..), TYPE)
   type Tuple2# :: TYPE r1 -> TYPE r2 -> TYPE ('TupleRep '[r2, r1])
   data Tuple2# (a1 :: TYPE r1) (a2 :: TYPE r2) = (# a1, a2 #)
-       │                                         └─ type: ∀ r1 r2 a1 a2. a1 → a2 → (# a1, a2 #)
+       │                                         └─ type: ∀ r1 r2 a1 a2. a1 → a2 → Tuple2# a1 a2
        └─ type: TYPE r1 → TYPE r2 → TYPE ('TupleRep (': r2 (': r1 '[])))
 extensions:
 - DataKinds

--- a/components/aihc-tc/test/Test/Fixtures/annotated/top-level-unlifted-bindings.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/top-level-unlifted-bindings.yaml
@@ -24,9 +24,9 @@ annotated:
   tupleValue = (# 1#, 2# #)
   ││            │  │   └─ type: Int#
   ││            │  └─ type: Int#
-  ││            └─ type: (# Int#, Int# #); type-args: Int#, Int#
-  └─ type: (# Int#, Int# #)
-  └─ error: top-level binding tupleValue has unlifted type (# Int#, Int# #)
+  ││            └─ type: Tuple2# Int# Int#; type-args: Int#, Int#
+  └─ type: Tuple2# Int# Int#
+  └─ error: top-level binding tupleValue has unlifted type Tuple2# Int# Int#
 
   returnsInt _ = 10#
   │          │   └─ type: Int#


### PR DESCRIPTION
## Summary

- Remove special annotation output for unboxed tuple types.
- Remove two unused unboxed tuple type checks.
- Update three type checker fixtures for type constructor output.

## Progress counts

- Type checker annotated fixtures: 0 added, 0 removed, and 3 updated.
- Total fixture count: no change.

## Tests

- `cabal test -v0 aihc-tc:spec --test-options="--pattern tc-annotated-golden --hide-successes"`
- `just fmt`
- `just check`