### PR TITLE
refactor(tc): resolve runtime representation synonyms

### DIFF
--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -542,9 +542,6 @@ matchesNullary _ _ _ = False
 runtimeRepFromKind :: TcType -> Either String TcType
 runtimeRepFromKind kind =
   case kind of
-    TcTyCon tyCon []
-      | tyConName tyCon `elem` ["Type", "LiftedType", "Constraint"] -> Right liftedRep
-      | tyConName tyCon == "UnliftedType" -> Right unliftedRep
     TcTyCon tyCon [representation]
       | tyConName tyCon == "TYPE" -> Right representation
     _ -> Left ("type does not have a runtime representation: " <> show kind)

--- a/components/aihc-tc/src/Aihc/Tc/Types.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Types.hs
@@ -420,9 +420,6 @@ pattern KMeta unique = TcMetaTv unique
 matchTYPEKind :: TcType -> Maybe TcType
 matchTYPEKind kind =
   case kind of
-    TcTyCon tyCon []
-      | tyConName tyCon `elem` ["Type", "LiftedType"] -> Just liftedRep
-      | tyConName tyCon == "UnliftedType" -> Just unliftedRep
     TcTyCon tyCon [representation]
       | tyConName tyCon == "TYPE" -> Just representation
     _ -> Nothing

--- a/components/aihc-tc/src/Aihc/Tc/Zonk.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Zonk.hs
@@ -68,7 +68,7 @@ defaultTyConKindScheme :: TypeScheme -> TcM TypeScheme
 defaultTyConKindScheme scheme@(ForAll tyVars predicates _) = do
   tyVars' <- mapM defaultTyVarKinds tyVars
   predicates' <- mapM defaultPredKinds predicates
-  kind <- defaultKindMetas (typeSchemeBody scheme)
+  kind <- defaultKindMetas (typeSchemeBody scheme) >>= zonkKind
   pure (ForAll tyVars' predicates' kind)
 
 defaultPredKinds :: Pred -> TcM Pred


### PR DESCRIPTION
## Summary

- Resolve type synonyms in type-constructor kind schemes.
- Extract runtime representations only from `TYPE rep`.
- Remove special cases for named kind synonyms.

## Validation

- `just fmt`
- `just check`

## Progress counts

This change does not change progress counts.