### PR TITLE
fix(fc): unify newtype constructor desugaring

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -1082,7 +1082,7 @@ desugarExpr expression =
     Syn.EAnn annotation inner
       | Just tcAnnotation <- Syn.fromAnnotation annotation -> desugarAnnotatedExpr tcAnnotation inner
       | otherwise -> desugarExpr inner
-    Syn.EVar name -> ExVar <$> occurrenceName name
+    Syn.EVar name -> desugarVariable Nothing name
     Syn.EApp function argument -> desugarApplication function argument
     Syn.EInfix left operator right -> do
       operator' <- desugarInfixOperator operator
@@ -1106,15 +1106,7 @@ desugarAnnotatedExpr annotation inner = do
         | not (null (tcAnnTypeBinders annotation)) -> desugarExpr inner
       expression
         | Just name <- annotatedVariable expression -> do
-            maybeNewtype <- newtypeConstructorData name
-            case maybeNewtype of
-              Just dataType -> desugarNewtypeConstructor annotation dataType
-              Nothing -> do
-                variable <- occurrenceName name
-                inferredTypes <- localOccurrenceTypeArguments name annotation
-                types <- mapM convertCheckedType inferredTypes
-                evidence <- mapM desugarEvidence (tcAnnEvidenceTerms annotation)
-                pure (foldl ExApp (foldl ExTyApp (ExVar variable) types) evidence)
+            desugarVariable (Just annotation) name
       Syn.EAnn resolutionAnnotation (Syn.EInt value Syn.TInteger _)
         | Just resolution <- Syn.fromAnnotation resolutionAnnotation,
           resolutionNamespace resolution == ResolutionNamespaceTerm,
@@ -1198,24 +1190,32 @@ desugarInfixOperator operator =
 
 desugarApplication :: Syn.Expr -> Syn.Expr -> ValueM Expr
 desugarApplication function argument = do
-  maybeNewtype <- newtypeApplication function
   argument' <- desugarExpr argument
-  case maybeNewtype of
-    Just (dataType, typeArguments) -> do
-      convertedArguments <- mapM convertCheckedType typeArguments
-      let tyCon = dtiTyCon dataType
-          axiom = Name ("$ax$" <> dtiName dataType) SortAxiom (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
-      pure (ExCast argument' (CoSym (CoAxiom axiom convertedArguments)))
-    Nothing -> ExApp <$> desugarExpr function <*> pure argument'
+  ExApp <$> desugarExpr function <*> pure argument'
 
-newtypeApplication :: Syn.Expr -> ValueM (Maybe (DataTypeInfo, [TcType]))
-newtypeApplication expression = do
-  newtypes <- gets vsNewtypeConstructors
-  pure $ do
-    (name, annotation) <- annotatedHead expression
-    key <- resolvedTermKey name
-    dataType <- Map.lookup key newtypes
-    pure (dataType, tcAnnTypeArgs annotation)
+desugarVariable :: Maybe TcAnnotation -> Syn.Name -> ValueM Expr
+desugarVariable maybeAnnotation name = do
+  maybeNewtype <- newtypeConstructorData name
+  case maybeNewtype of
+    Just dataType -> do
+      annotation <-
+        case maybeAnnotation of
+          Just value -> pure value
+          Nothing -> do
+            types <- gets vsTypes
+            case Map.lookup (Syn.nameText name) types of
+              Just constructorType -> pure (TcAnnotation constructorType [] [] [] [])
+              Nothing -> failValue ("missing checked newtype constructor type " <> T.unpack (Syn.nameText name))
+      desugarNewtypeConstructor annotation dataType
+    Nothing -> do
+      variable <- occurrenceName name
+      case maybeAnnotation of
+        Nothing -> pure (ExVar variable)
+        Just annotation -> do
+          inferredTypes <- localOccurrenceTypeArguments name annotation
+          types <- mapM convertCheckedType inferredTypes
+          evidence <- mapM desugarEvidence (tcAnnEvidenceTerms annotation)
+          pure (foldl ExApp (foldl ExTyApp (ExVar variable) types) evidence)
 
 newtypeConstructorData :: Syn.Name -> ValueM (Maybe DataTypeInfo)
 newtypeConstructorData name = do
@@ -1243,18 +1243,6 @@ desugarNewtypeConstructor annotation dataType = do
       axiom = Name ("$ax$" <> dtiName dataType) SortAxiom (OriginTop (tyConPackageId tyCon) (tyConModuleName tyCon))
   convertedArguments <- mapM convertCheckedType typeArguments
   pure (ExLam argument (ExCast (ExVar (binderName argument)) (CoSym (CoAxiom axiom convertedArguments))))
-
-annotatedHead :: Syn.Expr -> Maybe (Syn.Name, TcAnnotation)
-annotatedHead = go Nothing
-  where
-    go maybeAnnotation expression =
-      case expression of
-        Syn.EAnn annotation inner -> go ((Syn.fromAnnotation annotation :: Maybe TcAnnotation) <|> maybeAnnotation) inner
-        Syn.EParen inner -> go maybeAnnotation inner
-        Syn.ETypeApp inner _ -> go maybeAnnotation inner
-        Syn.EVar name -> (,fromMaybe emptyTcAnnotation maybeAnnotation) <$> Just name
-        _ -> Nothing
-    emptyTcAnnotation = TcAnnotation typeKindType [] [] [] []
 
 desugarLambda :: [Syn.Pattern] -> Syn.Expr -> ValueM Expr
 desugarLambda patterns body = do

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/imported-newtype-axiom-type-variable.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/imported-newtype-axiom-type-variable.yaml
@@ -22,6 +22,7 @@ expected: |-
   pub val 2.vwrap :: ∀(a : 3.tType). a 3.→ 1.tIdentity a
    = Λ(a : 3.tType).
     λ(x : a).
-      x ▷ sym (axiom-co 1.$ax$Identity @a)
+      (λ(_newtype : a).
+        _newtype ▷ sym (axiom-co 1.$ax$Identity @a)) x
 status: pass
 reason: ''

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-age.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-age.yaml
@@ -18,6 +18,7 @@ expected: |-
   axiom 1.$ax$Age : 1.tAge ~R 1.tInt
 
   pub val 1.vone :: 1.tAge
-   = 1.vI ▷ sym (axiom-co 1.$ax$Age)
+   = (λ(_newtype : 1.tInt).
+    _newtype ▷ sym (axiom-co 1.$ax$Age)) 1.vI
 status: pass
 reason: A newtype becomes an empty type, a representational axiom, and a cast.

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-constructor-type-synonym-application.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-constructor-type-synonym-application.yaml
@@ -1,0 +1,32 @@
+extensions: []
+modules:
+  - |
+    module Test where
+
+    data Field = Field
+    newtype IOException = IOError Field
+    type IOError = IOException
+
+    makeError :: Field -> IOException
+    makeError value = IOError value
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  pub type 1.tField :: 2.tType {
+      pub 1.vField :: 1.tField
+  }
+
+  pub type 1.tIOException :: 2.tType {}
+
+  axiom 1.$ax$IOException : 1.tIOException ~R 1.tField
+
+  pub type 1.tIOError :: 2.tType =
+   1.tIOException
+
+  pub val 1.vmakeError :: 1.tField 2.→ 1.tIOException
+   = λ(x : 1.tField).
+    (λ(_newtype : 1.tField).
+      _newtype ▷ sym (axiom-co 1.$ax$IOException)) x
+status: pass
+reason: ""

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-constructor-type-synonym-partial.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/newtype-constructor-type-synonym-partial.yaml
@@ -1,0 +1,31 @@
+extensions: []
+modules:
+  - |
+    module Test where
+
+    data Field = Field
+    newtype IOException = IOError Field
+    type IOError = IOException
+
+    makeError :: Field -> IOException
+    makeError = IOError
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Types
+
+  pub type 1.tField :: 2.tType {
+      pub 1.vField :: 1.tField
+  }
+
+  pub type 1.tIOException :: 2.tType {}
+
+  axiom 1.$ax$IOException : 1.tIOException ~R 1.tField
+
+  pub type 1.tIOError :: 2.tType =
+   1.tIOException
+
+  pub val 1.vmakeError :: 1.tField 2.→ 1.tIOException
+   = λ(_newtype : 1.tField).
+    _newtype ▷ sym (axiom-co 1.$ax$IOException)
+status: pass
+reason: ""


### PR DESCRIPTION
## Summary

- Desugar all newtype constructor occurrences through one variable conversion path.
- Use normal FC application for applied newtype constructors.
- Preserve the checked constructor type during newtype conversion.
- Add partial and applied constructor regression fixtures for a same-name type synonym.

## Progress counts

- Add two passing System FC 2 golden fixtures.
- Increase the System FC 2 golden fixture count by two.

## Validation

- `just fmt`
- `just check`
- `cabal run -v0 aihc -- install-v2 core-libs/aihc-base`

The install command passes the original `IOError` Core-v2 lint failure.
It stops later at a separate missing checked pattern type error.
