### PR TITLE
fix(fc): retain checked pattern types

### DIFF
--- a/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
+++ b/components/aihc-fc/src/Aihc/Fc2/Desugar/Value.hs
@@ -1055,11 +1055,19 @@ patternType pattern' =
   case pattern' of
     Syn.PVar name -> nameTcType name
     Syn.PAnn annotation inner -> (tcAnnType <$> Syn.fromAnnotation annotation) <|> patternType inner
+    Syn.PLit literal -> literalType literal
+    Syn.PNegLit literal -> literalType literal
     Syn.PParen inner -> patternType inner
     Syn.PStrict inner -> patternType inner
     Syn.PIrrefutable inner -> patternType inner
     Syn.PAs name inner -> nameTcType name <|> patternType inner
     Syn.PTypeSig inner _ -> patternType inner
+    _ -> Nothing
+
+literalType :: Syn.Literal -> Maybe TcType
+literalType literal =
+  case literal of
+    Syn.LitAnn annotation inner -> (tcAnnType <$> Syn.fromAnnotation annotation) <|> literalType inner
     _ -> Nothing
 
 fromBinderType :: Syn.Pattern -> TcType

--- a/components/aihc-fc/test/Test/Fixtures/golden-v2/character-literal-list-pattern.yaml
+++ b/components/aihc-fc/test/Test/Fixtures/golden-v2/character-literal-list-pattern.yaml
@@ -1,0 +1,61 @@
+---
+extensions:
+- MagicHash
+modules:
+- |
+  module Test where
+
+  import GHC.Prim (Char#)
+
+  data Char = C# Char#
+
+  firstSpace :: [Char] -> Char
+  firstSpace (' ' : _) = 'y'
+  firstSpace _ = 'n'
+
+  emptyTail :: [Char] -> Char
+  emptyTail (_ : []) = 'y'
+  emptyTail _ = 'n'
+expected: |-
+  scope 1 = "" Test
+  scope 2 = "aihc-prim" GHC.Prim
+  scope 3 = "aihc-prim" GHC.Types
+
+  pub type 1.tChar :: 3.tType {
+      pub 1.vC# :: FUN @3.vWordRep @3.tLiftedRep 2.tChar# 1.tChar
+  }
+
+  pub val 1.vfirstSpace :: 3.t[] 1.tChar 3.→ 1.tChar
+   = λ(x : 3.t[] 1.tChar).
+    case x as (_scrut : 3.t[] 1.tChar) return (1.tChar) of {
+        3.v: (_pat : 1.tChar) (_pat{1} : 3.t[] 1.tChar) →
+            case _pat as (_scrut{1} : 1.tChar) return (1.tChar) of {
+                1.vC# (_pat{2} : 2.tChar#) →
+                    case _pat{2} as (_scrut{2} : 2.tChar#) return (1.tChar) of {
+                        ' '#3.vWordRep →
+                            1.vC# 'y'#3.vWordRep;
+                        _ →
+                            1.vC# 'n'#3.vWordRep
+                    };
+                _ →
+                    1.vC# 'n'#3.vWordRep
+            };
+        _ →
+            1.vC# 'n'#3.vWordRep
+    }
+
+  pub val 1.vemptyTail :: 3.t[] 1.tChar 3.→ 1.tChar
+   = λ(x : 3.t[] 1.tChar).
+    case x as (_scrut : 3.t[] 1.tChar) return (1.tChar) of {
+        3.v: (_pat : 1.tChar) (_pat{1} : 3.t[] 1.tChar) →
+            case _pat{1} as (_scrut{1} : 3.t[] 1.tChar) return (1.tChar) of {
+                3.v[] →
+                    1.vC# 'y'#3.vWordRep;
+                _ →
+                    1.vC# 'n'#3.vWordRep
+            };
+        _ →
+            1.vC# 'n'#3.vWordRep
+    }
+status: pass
+reason: Character literals in constructor patterns retain their checked types.

--- a/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
+++ b/components/aihc-tc/src/Aihc/Tc/Generate/Pattern.hs
@@ -142,7 +142,6 @@ patternNeedsCheckedType pat =
     PParen inner -> patternNeedsCheckedType inner
     PLit {} -> False
     PNegLit {} -> False
-    PList [] -> False
     PStrict inner -> patternNeedsCheckedType inner
     PIrrefutable inner -> patternNeedsCheckedType inner
     PTypeSig inner _ -> patternNeedsCheckedType inner

--- a/components/aihc-tc/test/Test/Fixtures/annotated/list-signature-polymorphic.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/list-signature-polymorphic.yaml
@@ -3,8 +3,9 @@ annotated:
   module Test where
   (++) :: [a] -> [a] -> [a]
   [] ++ bs = bs
-  │     └─ type: [a]
+  ││     └─ type: [a]
   └─ type: ∀ a. [a] → [a] → [a]
+  └─ type: [a]
   (a:as) ++ bs = a : (as ++ bs)
   ││││      │      │     └─ type: [a] → [a] → [a]; type-args: a
   ││││      │      └─ type: a → [a] → [a]; type-args: a

--- a/components/aihc-tc/test/Test/Fixtures/annotated/prelude-list-core-lib.yaml
+++ b/components/aihc-tc/test/Test/Fixtures/annotated/prelude-list-core-lib.yaml
@@ -8,7 +8,8 @@ annotated:
   infixr 5 :
   (++) :: [a] -> [a] -> [a]
   (++) [] ys = ys
-  │       └─ type: [a]
+  │    │  └─ type: [a]
+  │    └─ type: [a]
   └─ type: ∀ a. [a] → [a] → [a]
   (++) (x : xs) ys = x : (xs ++ ys)
   │     │ │ │   │      │     └─ type: [a] → [a] → [a]; type-args: a

--- a/core-libs/aihc-base/src/System/Environment.hs
+++ b/core-libs/aihc-base/src/System/Environment.hs
@@ -74,5 +74,6 @@ baseName = go []
 reverseString :: String -> String
 reverseString = go []
   where
+    go :: String -> String -> String
     go reversed [] = reversed
     go reversed (character : rest) = go (character : reversed) rest

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -399,6 +399,8 @@
       nativeBuildInputs = [pkgs.findutils];
     } ''
       cd "$src"
+      export LANG=C.UTF-8
+      export LC_ALL=C.UTF-8
       store="$TMPDIR/store"
       mkdir -p "$store"
 

--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -393,6 +393,24 @@
     test "$failed" -eq 0
   '';
 
+  coreLibrariesInstallV2 =
+    pkgs.runCommand "aihc-core-libraries-install-v2" {
+      src = sources.coreLibrariesSrc pkgs;
+      nativeBuildInputs = [pkgs.findutils];
+    } ''
+      cd "$src"
+      store="$TMPDIR/store"
+      mkdir -p "$store"
+
+      ${aihcExe} install-v2 core-libs/aihc-prim --store "$store"
+      ${aihcExe} install-v2 core-libs/aihc-base --store "$store"
+
+      test -n "$(find "$store" -path '*/GHC/Prim/core-v2' -print -quit)"
+      test -n "$(find "$store" -path '*/Prelude/core-v2' -print -quit)"
+      test -z "$(find "$store" -type f -name 'core-v2.bad' -print -quit)"
+      touch "$out"
+    '';
+
   # The compiler owns preparation of the installed toolchain. Runtime archives
   # are built once per backend/GC pair, and ordinary package installation emits
   # the reusable library interfaces and target-specific archives.
@@ -647,4 +665,5 @@ in {
   c-lint = cLint;
   c-format = cFormat;
   cabal-format = cabalFormat;
+  core-libraries-install-v2 = coreLibrariesInstallV2;
 }


### PR DESCRIPTION
## Summary

- Read checked types from literal annotations during FC2 generation.
- Retain checked types on empty list patterns.
- Add regression fixtures for nested character and empty list patterns.
- Add a Nix check that installs `aihc-prim` and `aihc-base` with `install-v2`.

## Validation

- Run `just fmt`.
- Run `just check`.
- Build `checks.aarch64-darwin.core-libraries-install-v2`.

## Progress counts

No progress count changes are applicable.