### PR TITLE
perf(nix): keep test fixtures out of library source

### DIFF
--- a/scripts/nix/checks.nix
+++ b/scripts/nix/checks.nix
@@ -34,11 +34,33 @@
   addCheckSettings = drv: old:
     addHiddenSuccesses old
     // pkgs.lib.optionalAttrs (drv ? intermediates) {
-      # Reuse the optimized build, including its already-compiled test components.
+      # Reuse the package build, including its already-compiled test components.
       doInstallIntermediates = false;
       enableSeparateIntermediatesOutput = false;
       previousIntermediates = drv.intermediates;
     };
+
+  # Copy runtime test data into the package tree for Cabal relative paths.
+  copyInto = dest: src: ''
+    mkdir -p ${pkgs.lib.escapeShellArg dest}
+    cp -R -- ${src}/. ${pkgs.lib.escapeShellArg dest}/
+  '';
+
+  # Tests walk up from the package directory to find core-libs/aihc-prim/src.
+  installPrimModules = ''
+    if [[ -z "$sourceRoot" ]]; then
+      echo "sourceRoot is not set; cannot install aihc-prim test modules." >&2
+      exit 1
+    fi
+    unpackDir="$NIX_BUILD_TOP/''${sourceRoot%%/*}"
+    mkdir -p "$unpackDir/core-libs"
+    ln -sfn ${sources.primSrc pkgs} "$unpackDir/core-libs/aihc-prim"
+  '';
+
+  appendPreCheck = extra: drv:
+    pkgs.haskell.lib.overrideCabal drv (old: {
+      preCheck = (old.preCheck or "") + extra;
+    });
 
   mkPackageTest = drv:
     pkgs.haskell.lib.doCheck (
@@ -309,9 +331,16 @@
   amd64Tests = mkEvalPackageTest (
     pkgs.haskell.lib.overrideCabal hsPkgs.aihc-amd64 (old: {
       testToolDepends = (old.testToolDepends or []) ++ [pkgs.llvmPackages.clang];
+      preCheck =
+        (old.preCheck or "")
+        + copyInto "test/Test/Fixtures/grin-snapshot" (sources.grinSnapshotFixturesSrc pkgs);
     })
   );
-  arm64Tests = mkEvalPackageTest hsPkgs.aihc-arm64;
+  arm64Tests = mkEvalPackageTest (
+    appendPreCheck
+    (copyInto "test/Test/Fixtures/grin-snapshot" (sources.grinSnapshotFixturesSrc pkgs))
+    hsPkgs.aihc-arm64
+  );
   llvmTests = mkEvalPackageTest (
     pkgs.haskell.lib.overrideCabal hsPkgs.aihc-llvm (old: {
       testToolDepends = (old.testToolDepends or []) ++ [pkgs.llvmPackages.clang];
@@ -319,14 +348,36 @@
   );
   nativeTests = mkPackageTest hsPkgs.aihc-native;
   wasmTests = mkPackageTest hsPkgs.aihc-wasm;
-  fcTests = mkEvalPackageTest hsPkgs.aihc-fc;
+  fcTests = mkEvalPackageTest (
+    appendPreCheck
+    (
+      copyInto "test/Test/Fixtures" (sources.fcFixturesSrc pkgs)
+      + installPrimModules
+    )
+    hsPkgs.aihc-fc
+  );
   grinTests = mkEvalPackageTest hsPkgs.aihc-grin;
-  resolveTests = mkPackageTest hsPkgs.aihc-resolve;
-  tcTests = mkPackageTest hsPkgs.aihc-tc;
+  resolveTests = mkPackageTest (
+    appendPreCheck
+    (copyInto "test/Test/Fixtures" (sources.resolveFixturesSrc pkgs))
+    hsPkgs.aihc-resolve
+  );
+  tcTests = mkPackageTest (
+    appendPreCheck
+    (
+      copyInto "test/Test/Fixtures" (sources.tcFixturesSrc pkgs)
+      + installPrimModules
+    )
+    hsPkgs.aihc-tc
+  );
   testingTests = mkPackageTest hsPkgs.aihc-testing;
   devTests = mkPackageTest hsPkgs.aihc-dev;
   aihcTests = mkAihcPackageTest hsPkgs.aihc;
-  fmtTests = mkPackageTest hsPkgs.aihc-fmt;
+  fmtTests = mkPackageTest (
+    appendPreCheck
+    (copyInto "test/Test/Fixtures" (sources.fmtFixturesSrc pkgs))
+    hsPkgs.aihc-fmt
+  );
   unicode = import ./unicode.nix {inherit pkgs;};
   unicodeGenerated =
     pkgs.runCommand "aihc-unicode-generated" {

--- a/scripts/nix/haskell-packages.nix
+++ b/scripts/nix/haskell-packages.nix
@@ -23,7 +23,6 @@
       src = sources.amd64Src;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath components/aihc-amd64";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -34,7 +33,6 @@
       src = sources.arm64Src;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath components/aihc-arm64";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -45,7 +43,6 @@
       src = sources.llvmSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath components/aihc-llvm";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -70,7 +67,6 @@
       src = sources.fcSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath components/aihc-fc";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -81,7 +77,6 @@
       src = sources.grinSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--flag fuzz --subpath components/aihc-grin";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -99,7 +94,6 @@
       src = sources.tcSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--flag fuzz --subpath components/aihc-tc";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -124,7 +118,6 @@
       src = sources.devSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath tooling/aihc-dev";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -135,7 +128,6 @@
       src = sources.testingSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath tooling/aihc-testing";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -146,7 +138,6 @@
       src = sources.resolveToolingCommonSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath tooling/aihc-resolve-tooling-common";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -157,7 +148,6 @@
       src = sources.aihcSrc;
       cabal2nixOptions = {
         extraCabal2nixOptions = "--subpath bin/aihc";
-        srcModifier = src: src;
       };
       disableProfiling = true;
       optimizeForChecks = true;
@@ -258,13 +248,35 @@ in rec {
         })
       else drv;
 
+    # Keep directory nodes so --subpath still finds the Cabal file.
+    # Keep only Cabal files so YAML fixture edits do not re-run cabal2nix.
+    keepCabalFilesForIfd = src:
+      pkgs.lib.cleanSourceWith {
+        inherit src;
+        filter = path: type:
+          type
+          == "directory"
+          || pkgs.lib.hasSuffix ".cabal" (baseNameOf path)
+          || baseNameOf path == "package.yaml";
+      };
+
+    cabal2nixCallOptions = spec: let
+      extra =
+        if builtins.isString (spec.cabal2nixOptions or "")
+        then spec.cabal2nixOptions or ""
+        else (spec.cabal2nixOptions or {}).extraCabal2nixOptions or "";
+    in {
+      extraCabal2nixOptions = extra;
+      srcModifier = keepCabalFilesForIfd;
+    };
+
     mkComponent = final: name: spec: let
       prepareChecks = enableSeparateIntermediates && builtins.elem name checkedPackageNames;
       baseDrv =
         final.callCabal2nixWithOptions
         name
         (spec.src pkgs)
-        (spec.cabal2nixOptions or "")
+        (cabal2nixCallOptions spec)
         {};
       profilingAdjusted =
         if spec.disableProfiling
@@ -337,6 +349,7 @@ in rec {
 
   mkHsPkgsForChecks = pkgs:
     mkHsPkgsVariant pkgs {
+      disableOptimization = true;
       enableSeparateIntermediates = true;
       warningsAsErrors = true;
     };

--- a/scripts/nix/sources.nix
+++ b/scripts/nix/sources.nix
@@ -4,6 +4,10 @@
   in
     builtins.any (suffix: pkgs.lib.hasSuffix suffix baseName) suffixes;
 
+  # Runtime fixture trees are copied in check preCheck. Keep them out of compile src.
+  isFixtureRoot = pkgs: path: type:
+    type == "directory" && pkgs.lib.hasSuffix "/test/Test/Fixtures" (toString path);
+
   mkComponentSrc = subpath: suffixes: pkgs:
     pkgs.lib.cleanSourceWith {
       src = root + subpath;
@@ -11,7 +15,8 @@
         baseName = baseNameOf path;
         matchesSourceSuffix = matchesSuffix pkgs suffixes path;
       in
-        type == "directory" || matchesSourceSuffix || baseName == "LICENSE" || baseName == "CHANGELOG.md";
+        !(isFixtureRoot pkgs path type)
+        && (type == "directory" || matchesSourceSuffix || baseName == "LICENSE" || baseName == "CHANGELOG.md");
     };
 
   mkRootSubsetSrc = prefixes: suffixes: pkgs:
@@ -21,9 +26,28 @@
         baseName = baseNameOf path;
         relPath = pkgs.lib.removePrefix ((toString root) + "/") (toString path);
         inSubset = builtins.any (prefix: pkgs.lib.hasPrefix prefix relPath) prefixes;
+        # Keep only the subset tree and its parent directories.
+        inSubsetTree =
+          type
+          == "directory"
+          && builtins.any (
+            prefix: let
+              p = pkgs.lib.removeSuffix "/" prefix;
+            in
+              relPath
+              == ""
+              || relPath == p
+              || pkgs.lib.hasPrefix (p + "/") relPath
+              || pkgs.lib.hasPrefix (relPath + "/") p
+          )
+          prefixes;
         matchesSourceSuffix = matchesSuffix pkgs suffixes path;
       in
-        type == "directory" || (inSubset && (matchesSourceSuffix || baseName == "LICENSE" || baseName == "CHANGELOG.md"));
+        !(isFixtureRoot pkgs path type)
+        && (
+          inSubsetTree
+          || (inSubset && (matchesSourceSuffix || baseName == "LICENSE" || baseName == "CHANGELOG.md"))
+        );
     };
 
   exampleSourceSuffixes = [
@@ -38,39 +62,29 @@
     "stdout"
   ];
 in rec {
-  # Source filtering: only include relevant files for each component.
-  # This prevents rebuilds when unrelated files change.
+  # Source filtering: only include files that the package compile uses.
+  # Runtime test data is a separate input for check derivations.
   fcSrc =
     mkRootSubsetSrc [
       "components/aihc-fc/"
-      "core-libs/aihc-prim/src/GHC/Prim.hs"
-      "core-libs/aihc-prim/src/GHC/Tuple.hs"
-      "core-libs/aihc-prim/src/GHC/Types.hs"
       "test/support/"
     ] [
       ".hs"
       ".cabal"
-      ".yaml"
-      ".yml"
-      ".fc2"
     ];
 
-  arm64Src = mkRootSubsetSrc ["components/aihc-arm64/" "test/support/" "test/Test/Fixtures/grin-snapshot/"] [
+  arm64Src = mkRootSubsetSrc ["components/aihc-arm64/" "test/support/"] [
     ".hs"
     ".cabal"
     ".c"
     ".h"
-    ".yaml"
-    ".yml"
   ];
 
-  amd64Src = mkRootSubsetSrc ["components/aihc-amd64/" "test/support/" "test/Test/Fixtures/grin-snapshot/"] [
+  amd64Src = mkRootSubsetSrc ["components/aihc-amd64/" "test/support/"] [
     ".hs"
     ".cabal"
     ".c"
     ".h"
-    ".yaml"
-    ".yml"
   ];
 
   llvmSrc = mkRootSubsetSrc ["components/aihc-llvm/" "test/support/"] [
@@ -106,23 +120,38 @@ in rec {
   resolveSrc = mkComponentSrc "/components/aihc-resolve" [
     ".hs"
     ".cabal"
+  ];
+
+  tcSrc = mkRootSubsetSrc ["components/aihc-tc/"] [
+    ".hs"
+    ".cabal"
+  ];
+
+  tcFixturesSrc = mkComponentSrc "/components/aihc-tc/test/Test/Fixtures" [
     ".yaml"
     ".yml"
   ];
 
-  tcSrc =
-    mkRootSubsetSrc [
-      "components/aihc-tc/"
-      "core-libs/aihc-prim/src/GHC/Classes.hs"
-      "core-libs/aihc-prim/src/GHC/Prim.hs"
-      "core-libs/aihc-prim/src/GHC/Tuple.hs"
-      "core-libs/aihc-prim/src/GHC/Types.hs"
-    ] [
-      ".hs"
-      ".cabal"
-      ".yaml"
-      ".yml"
-    ];
+  resolveFixturesSrc = mkComponentSrc "/components/aihc-resolve/test/Test/Fixtures" [
+    ".yaml"
+    ".yml"
+  ];
+
+  fcFixturesSrc = mkComponentSrc "/components/aihc-fc/test/Test/Fixtures" [
+    ".yaml"
+    ".yml"
+    ".fc2"
+  ];
+
+  fmtFixturesSrc = mkComponentSrc "/bin/aihc-fmt/test/Test/Fixtures" [
+    ".yaml"
+    ".yml"
+  ];
+
+  grinSnapshotFixturesSrc = mkComponentSrc "/test/Test/Fixtures/grin-snapshot" [
+    ".yaml"
+    ".yml"
+  ];
 
   baseSrc = mkComponentSrc "/core-libs/aihc-base" [
     ".hs"
@@ -165,7 +194,7 @@ in rec {
         inDev = pkgs.lib.hasPrefix "tooling/aihc-dev/" relPath;
         inTcCommon = pkgs.lib.hasPrefix "components/aihc-tc/common/" relPath;
         inResolveCommon = pkgs.lib.hasPrefix "components/aihc-resolve/common/" relPath;
-        matchesSourceSuffix = matchesSuffix pkgs [".hs" ".cabal" ".yaml" ".yml"] path;
+        matchesSourceSuffix = matchesSuffix pkgs [".hs" ".cabal"] path;
       in
         type == "directory" || ((inDev || inTcCommon || inResolveCommon) && (matchesSourceSuffix || baseName == "LICENSE" || baseName == "CHANGELOG.md"));
     };
@@ -198,8 +227,6 @@ in rec {
   fmtSrc = mkComponentSrc "/bin/aihc-fmt" [
     ".hs"
     ".cabal"
-    ".yaml"
-    ".yml"
   ];
 
   # Filtered source for nix linting - only nix files.


### PR DESCRIPTION
Nix hashed YAML fixtures into each library source tree.
A fixture change rebuilt that library and all dependent packages.

This PR:

- Removes YAML, System FC 2 text, and `aihc-prim` test modules from library Nix source.
- Copies those files in check `preCheck` only.
- Builds Nix checks with `--disable-optimization`.
- Restricts cabal2nix import-from-derivation source to Cabal files.

Local `cabal test` still reads fixtures from the Git tree.

Progress counts do not change.